### PR TITLE
Update BioSeq

### DIFF
--- a/BioSeq/versions/0.0.0/sha1
+++ b/BioSeq/versions/0.0.0/sha1
@@ -1,1 +1,1 @@
-aa03098fc635ea0cd9bc3a83a1d8bea3de8ffeda
+60293cdee3bd6f965db037440d772a3f4aceaef6


### PR DESCRIPTION
Using @b_str in @nt_str, @aa_str and @dna2_str
This works fine for Julia 0.1 and 0.2, but without interpolation on Julia 0.2. This is updated on docs.
Faster percentGC using chunks and bit-wise operations on DNA2Seq.
