### PR TITLE
Tests for METADATA

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -1,0 +1,25 @@
+const url_reg = r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?"
+const gh_path_reg_git=r"^/(.*)?/(.*)?.git$"
+ 
+for (pkg, versions) in Pkg2.Read.available()
+	url = (Pkg2.Read.url(pkg))
+	maxv = sort([keys(versions)...])[end]
+	m=match(url_reg, url)
+	assert (m != null, "Invalid url $url for package $(pkg). Should satisfy $url_reg")
+	host=m.captures[4]
+	assert (host!=nothing , "Invalid url $url for package $(pkg). Cannot extract host")
+    path=m.captures[5]
+    assert (path!=nothing , "Invalid url $url for package $(pkg). Cannot extract path")
+   	scheme=m.captures[2]
+   	assert ( ismatch (r"git", scheme) || ismatch (r"http", scheme), "Invalid url scheme $scheme for package $(pkg). Should be 'git' or 'http[s]'")
+   	if ismatch(r"github\.com", host)
+        m2 = match(gh_path_reg_git, path)
+        assert (m2 != nothing , "Invalid github url pattern $url for package $(pkg). Should satisfy $gh_path_reg_git")
+        user=m2.captures[1]
+        repo=m2.captures[2]
+        sha1_file = "METADATA/$pkg/versions/$(maxv)/sha1"
+        @assert isfile(sha1_file)
+    end
+ end
+
+@assert Pkg2.check_metadata()

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: cpp
+compiler: 
+    - clang
+notifications:
+    email: false
+before_install:
+    - sudo add-apt-repository ppa:staticfloat/julia-deps -y
+    - sudo add-apt-repository ppa:staticfloat/julianightlies -y
+    - sudo apt-get update -qq -y
+    - sudo apt-get install libpcre3-dev julia -y
+    - git config --global user.name "Travis User"
+    - git config --global user.email "travis@example.net"
+script:
+    - cd ..
+    - ln -s METADATA.jl METADATA
+    - julia METADATA/.test/METADATA.jl


### PR DESCRIPTION
Given the occasional errors that creep into the METADATA repository, I've always wanted tests for it. However, that was difficult given that `Pkg.resolve` had so many side effects. Hence the eager wait for `Pkg2`. 

It turns out that `Pkg2` already has a `check_metadata` method that tests the consistency of the the repository. So the only thing I need to do is to add a travis configuration. 

The one thing to consider is where to keep these tests, given that the METADATA repository currently contains only configuration, one directory for each package. I've currently placed it in a _tests directory, but maybe thats not ideal. 

I've also added some tests to check the validity of the url's for each package. 

I can do a rebased version once there is some consensus on merging this. 
