### PR TITLE
Bump HttpParser to version 0.0.4

### DIFF
--- a/HttpParser/versions/0.0.4/requires
+++ b/HttpParser/versions/0.0.4/requires
@@ -1,0 +1,3 @@
+julia 0.2-
+BinDeps 0.2.5-
+HttpCommon

--- a/HttpParser/versions/0.0.4/sha1
+++ b/HttpParser/versions/0.0.4/sha1
@@ -1,0 +1,1 @@
+0dedebd57d07b5e0e70ce1ef874ea58da372b38f


### PR DESCRIPTION
This changes the BinDeps dependency to version 0.2.5, which is required to successfully compile the http-parser library for the first time.
