### PR TITLE
Bump Nettle

### DIFF
--- a/Nettle/versions/0.1.0/requires
+++ b/Nettle/versions/0.1.0/requires
@@ -1,0 +1,2 @@
+julia 0.2-
+BinDeps

--- a/Nettle/versions/0.1.0/sha1
+++ b/Nettle/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+d06cc37b8a9e1af2936ff83af7bef4c3321e9e86


### PR DESCRIPTION
Bumps Nettle to a version that [does not have](https://github.com/staticfloat/Nettle.jl/commit/d06cc37b8a9e1af2936ff83af7bef4c3321e9e86) the error on Homebrew not being installed, etc...
