### PR TITLE
Tag BinDeps v0.2.11

### DIFF
--- a/BinDeps/versions/0.2.11/requires
+++ b/BinDeps/versions/0.2.11/requires
@@ -1,0 +1,2 @@
+julia 0.2-
+URIParser

--- a/BinDeps/versions/0.2.11/sha1
+++ b/BinDeps/versions/0.2.11/sha1
@@ -1,0 +1,1 @@
+0cea5a34994ddfb75c343cf8f1dfb4fde30801dc


### PR DESCRIPTION
Bump version so that this fix https://github.com/loladiro/BinDeps.jl/pull/62 is in the current version.
