### PR TITLE
Specify Stats versions in DataArrays requirements

### DIFF
--- a/DataArrays/versions/0.0.0/requires
+++ b/DataArrays/versions/0.0.0/requires
@@ -1,3 +1,3 @@
 julia 0.2-
-Stats
+Stats 0.2.5 0.3-
 SortingAlgorithms

--- a/DataArrays/versions/0.0.1/requires
+++ b/DataArrays/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
-Stats
+Stats 0.2.5 0.3-
 SortingAlgorithms


### PR DESCRIPTION
DataFrames/DataArrays masters work with Stats 0.3, but the tagged Data\* releases don't.
