### PR TITLE
Update DataArrays v0.1.0 requires

### DIFF
--- a/DataArrays/versions/0.1.0/requires
+++ b/DataArrays/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.2-
-StatsBase 0.2.5 0.3-
+StatsBase 0.3-
 SortingAlgorithms


### PR DESCRIPTION
DataArrays master (now 0.1.0) has required Stats(Base) 0.3 for some time -- this is just here because it was copied from the last DataArrays release.
