### PR TITLE
Less strict DataArrays requirement for RDatasets.

### DIFF
--- a/RDatasets/versions/0.1.1/requires
+++ b/RDatasets/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
-DataArrays 0.1-
+DataArrays
 DataFrames


### PR DESCRIPTION
@johnmyleswhite @garborg Would it be ok to do this?

The `data` function changed to `dataset`, which is fine except that versions of RDatasets since that change are not installable in julia 0.2, which is causing me problems with testing in gadfly.
