### PR TITLE
Tag Lint v0.0.3

### DIFF
--- a/Lint/versions/0.0.3/sha1
+++ b/Lint/versions/0.0.3/sha1
@@ -1,0 +1,1 @@
+6904cd5dc715b712dac5d7e0e4b746af5bff956b


### PR DESCRIPTION
Lint does not follow into include() when lintfile() starts with absolute path. Fixed.

Global conflicts fix and better warning messages.
