### PR TITLE
Tag Iterators v0.1.6

### DIFF
--- a/Iterators/versions/0.1.6/sha1
+++ b/Iterators/versions/0.1.6/sha1
@@ -1,0 +1,1 @@
+4a8f4a33bd43a46d22f2dcfb0074b3fa82aea033


### PR DESCRIPTION
Update `groupby`
New `@itr` macro
Remove deprecations for `repeat`
