### PR TITLE
Register JLDArchives: v0.0.1

### DIFF
--- a/JLDArchives/url
+++ b/JLDArchives/url
@@ -1,0 +1,1 @@
+git://github.com/timholy/JLDArchives.jl.git

--- a/JLDArchives/versions/0.0.1/sha1
+++ b/JLDArchives/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+dffc78de519d3a7fd8273fa4d252cb54f0cf4a4f


### PR DESCRIPTION
A new package for archiving examples of JLD files. Over time, these become useful for making sure we haven't broken backwards-compatibility. I didn't want to add large-ish .jld files to the HDF5/JLD package, so this is the solution I came up with.

My plan would be to add this as a test on Travis for HDF5's tests, so these backwards-compatibility tests will be run frequently.

I won't hit "merge" myself right away, to give people a chance to bikeshed the name and strategy.
