### PR TITLE
Register AV

### DIFF
--- a/AV/url
+++ b/AV/url
@@ -1,0 +1,1 @@
+git://github.com/kmsquire/AV.jl.git


### PR DESCRIPTION
Yes, another 2-letter package requesting to be registered... ;-)

This is the initial wrapping of libav/ffmpeg libraries, which handle almost all aspects of audio/video file/stream decoding/encoding.  

It is based off of work started by @ihnorton and (I believe) @timholy a while back.  

I've been working slowly but steadily on this for a couple of months, getting feedback as available from Isaiah, Tim, and @lucasb-eyer

libav was forked from ffmpeg sometime around 2010-2011.  The libraries are mostly compatible with each other, although there isn't much love between the two projects.

AV.jl was chosen as boring and relatively neutral name after a brief discussion [here](https://github.com/ihnorton/libAV.jl/pull/2), since the general plan is to support both libav and ffmpeg as long as that is feasible.  

That said, if anyone has a less boring suggestion for a name...

I actually want to go through a brief test period before tagging a version, to see how well this installs on different platforms.  I'll make an announcement on the mailing lists as soon as things are settled here.
