### PR TITLE
Bokeh url update

### DIFF
--- a/Bokeh/url
+++ b/Bokeh/url
@@ -1,1 +1,1 @@
-git://github.com/samuelcolvin/Bokeh.jl.git
+git://github.com/bokeh/Bokeh.jl.git


### PR DESCRIPTION
Updated url to reflect transfer of the project to [bokeh/Bokeh.jl](https://github.com/bokeh/Bokeh.jl), see ContinuumIO/bokeh#999 for discussion.
