### PR TITLE
Register Lexicon

### DIFF
--- a/Lexicon/url
+++ b/Lexicon/url
@@ -1,0 +1,1 @@
+git://github.com/MichaelHatherly/Lexicon.jl.git


### PR DESCRIPTION
Package URL: https://github.com/MichaelHatherly/Lexicon.jl

This package separates the querying and rendering code from the core
functionality of https://github.com/MichaelHatherly/Docile.jl, namely
the `@doc` macro.
