### PR TITLE
Update URLs for ApproxFun, CLBLAS, ModernGL, Smile

### DIFF
--- a/ApproxFun/url
+++ b/ApproxFun/url
@@ -1,1 +1,1 @@
-git://github.com/dlfivefifty/ApproxFun.git
+git://github.com/dlfivefifty/ApproxFun.jl.git

--- a/CLBLAS/url
+++ b/CLBLAS/url
@@ -1,1 +1,1 @@
-git://github.com/ekobir/CLBLAS.jl.git
+git://github.com/JuliaGPU/CLBLAS.jl.git

--- a/ModernGL/url
+++ b/ModernGL/url
@@ -1,1 +1,1 @@
-git://github.com/SimonDanisch/ModernGL.jl.git
+git://github.com/JuliaGL/ModernGL.jl.git

--- a/Smile/url
+++ b/Smile/url
@@ -1,1 +1,1 @@
-git://github.com/tawheeler/Smile.jl.git
+git://github.com/sisl/Smile.jl.git


### PR DESCRIPTION
This PR updates the git URLs for four packages whose repositories have relocated: ApproxFun, CLBLAS, ModernGL, Smile.

React has also moved, but it has also been renamed to Reactive. I'm not sure if it makes sense to update its URL.
