### PR TITLE
Change git url for FunctionalCollections

### DIFF
--- a/FunctionalCollections/url
+++ b/FunctionalCollections/url
@@ -1,1 +1,1 @@
-git://github.com/zachallaun/FunctionalCollections.jl.git
+git://github.com/JuliaLang/FunctionalCollections.jl.git


### PR DESCRIPTION
Pkg.update() throws a warning saying the new release cannot be found. But I thought github redirects meant this wouldn't be an issue. This seems like the way it should be anyway...
