### PR TITLE
Tag GraphViz v0.0.3

### DIFF
--- a/GraphViz/versions/0.0.3/requires
+++ b/GraphViz/versions/0.0.3/requires
@@ -1,0 +1,1 @@
+BinDeps

--- a/GraphViz/versions/0.0.3/sha1
+++ b/GraphViz/versions/0.0.3/sha1
@@ -1,0 +1,1 @@
+e5da541b5fac5ba50eeb36aea5a1122394b576da


### PR DESCRIPTION
GraphViz has been broken on linux since August (Keno/GraphViz.jl#6).
Bumping unless there are objections from @Keno.
