### PR TITLE
Register CasaCore: v0.0.1

### DIFF
--- a/CasaCore/url
+++ b/CasaCore/url
@@ -1,0 +1,1 @@
+git://github.com/mweastwood/CasaCore.jl.git

--- a/CasaCore/versions/0.0.1/requires
+++ b/CasaCore/versions/0.0.1/requires
@@ -1,0 +1,2 @@
+julia 0.4-
+BinDeps

--- a/CasaCore/versions/0.0.1/sha1
+++ b/CasaCore/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+6fcb5ad9efd2a64b2fae29cfb862e11d5b8a7b4e


### PR DESCRIPTION
This is a wrapper for CasaCore, an important library for radio astronomers.

CasaCore currently wraps the necessary functionality for interacting with CasaCore tables and measurement sets (the data format produced by many modern radio telescopes -- eg. the [VLA](http://www.vla.nrao.edu/), [ALMA](http://www.almaobservatory.org/)). In addition, it deals with conversions between various astronomical coordinate systems.

https://github.com/mweastwood/CasaCore.jl
For more information on Casacore: https://code.google.com/p/casacore/
The more feature complete python wrapper (developed at Astron): https://code.google.com/p/pyrap/