### PR TITLE
Force package repo names to end in .jl

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -14,9 +14,12 @@ for (pkg, versions) in Pkg.Read.available()
     @assert ismatch(r"git", scheme) "Invalid url scheme $scheme for package $(pkg). Should be 'git' "
     if ismatch(r"github\.com", host)
         m2 = match(gh_path_reg_git, path)
-        @assert m2 != nothing "Invalid github url pattern $url for package $(pkg). Should satisfy $gh_path_reg_git"
+        @assert m2 != nothing "Invalid GitHub url pattern $url for package $(pkg). Should satisfy $gh_path_reg_git"
         user=m2.captures[1]
         repo=m2.captures[2]
+        
+        @assert endswith(repo, ".jl") "Repository name $repo does not end in .jl"
+        
         sha1_file = "METADATA/$pkg/versions/$(maxv)/sha1"
         @assert isfile(sha1_file)
     end


### PR DESCRIPTION
We have enforced this policy manually up to now. Perhaps adding a test for this naming policy to the METADATA tests will help cut down on the need to check URLs of newly registered packages.

I have tested the logic locally and it seems to work. In fact, it picked up several packages whose repository names do not have a `.jl` extension, thus causing Travis to fail:

- [ ] NamedArrays git://github.com/davidavdav/NamedArrays.git
- [ ] PEGParser git://github.com/abeschneider/PEGParser.git
- [ ] JFVM git://github.com/simulkade/JFVM.git
- [ ] CompressedSensing git://github.com/dahlend/CompressedSensing.git

Perhaps we can ping the authors to get the repos renamed.