### PR TITLE
Better error if package has no tagged versions

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -3,7 +3,9 @@ const gh_path_reg_git=r"^/(.*)?/(.*)?.git$"
 
 for (pkg, versions) in Pkg.Read.available()
     url = (Pkg.Read.url(pkg))
-    maxv = sort([keys(versions)...])[end]
+    versions = sort([keys(versions)...])
+    @assert length(versions) > 0 "Package $pkg has no tagged versions."
+    maxv = versions[end]
     m=match(url_reg, url)
     @assert  m != null  "Invalid url $url for package $(pkg). Should satisfy $url_reg"
     host=m.captures[4]
@@ -19,6 +21,7 @@ for (pkg, versions) in Pkg.Read.available()
         repo=m2.captures[2]
         sha1_file = "METADATA/$pkg/versions/$(maxv)/sha1"
         @assert isfile(sha1_file)
+        
     end
 end
 


### PR DESCRIPTION
Currently if there are no tagged versions one would just get a `BoundsError`.