### PR TITLE
RFC: Checks most recent version's requirements

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -1,6 +1,12 @@
 const url_reg = r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?"
 const gh_path_reg_git=r"^/(.*)?/(.*)?.git$"
 
+#We don't have a mechanism for installing packages required for testing
+#purposes only when the repo being tested is METADATA
+Pkg.installed("Requests")==nothing && Pkg.add("Requests")
+
+using Requests
+
 for (pkg, versions) in Pkg.Read.available()
     url = (Pkg.Read.url(pkg))
     @assert length(versions) > 0 "Package $pkg has no tagged versions."
@@ -29,15 +35,41 @@ for (pkg, versions) in Pkg.Read.available()
             @assert sha1fromfile == avail.sha1
         end
 
-        #TODO Replace warnings with assertions below once packages in Issue #2057 have been addressed.
-        if !(pkg in ["PEGParser", "CompressedSensing"]) #Legacy package
-            @assert !endswith(pkg, ".jl") "Package name $pkg should not end in .jl"
-            @assert endswith(repo, ".jl") "Repository name $repo does not end in .jl"
-        end
+        #Check naming conventions. Issue #2057
+        @assert !endswith(pkg, ".jl") "Package name $pkg should not end in .jl"
+        @assert endswith(repo, ".jl") "Repository name $repo does not end in .jl"
 
+        #Check that SHA1 hash exists
         sha1_file = joinpath("METADATA", pkg, "versions", string(maxv), "sha1")
         @assert isfile(sha1_file) "File not found: $sha1_file"
 
+        #Check that requires and REQUIRE are consistent in the most recent tagged
+        #version
+        maxverreqs = versions[maxv].requires
+        sha1 = versions[maxv].sha1
+        pathwogit = path[1:end-4]
+        require_url = "https://raw.githubusercontent.com$pathwogit/$sha1/REQUIRE"
+        packet = get(require_url)
+        @assert packet.finished "HTTP request from $require_url did not complete"
+        data = if packet.status == 200
+                packet.data
+            elseif packet.status == 404
+                warn("404 Not found: $require_url")
+                ""
+            end
+        currentreqs = Pkg.Reqs.parse(IOBuffer(data))
+        #Check explicitly for Julia version tags
+        "julia" in keys(currentreqs) || warn("No Julia version tagged in $pkg REQUIRE")
+        "julia" in keys(maxverreqs)  || warn("No Julia version tagged in $pkg $maxv requires")
+        if maxverreqs != currentreqs
+            println("-"^78)
+            warn("Inconsistent requirements for $pkg v$maxv:\n")
+            println("$pkg $sha1 REQUIRE:\n")
+            display(currentreqs)
+            println("\n\n\n$pkg $maxv requires:\n")
+            display(maxverreqs)
+            println("\n", "-"^78)
+        end
     end
 end
 
@@ -72,6 +104,7 @@ for pkg in readdir("METADATA")
             error("Version v$verdir of $pkg is not configured correctly. Check that $relpath exists.")
         end
     end
+
 end
 
 Pkg.Entry.check_metadata()


### PR DESCRIPTION
For tagged version ver with hash sha1:

- Checks that version/$ver/requires has a tagged Julia version
- Checks that package repo's REQUIRE at hash sha1 has a tagged Julia version
- Checks that requires and REQUIRE agree

Note: the test now uses Requests to download the necessary REQUIRE files and
will install the Requests package automatically to do so.

Note 2: The test script does NOT error out when requirements are inconsistent;
there are way too many inconsistent packages!

Closes #1012