### PR TITLE
New packages must have at least one tagged version

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -1,4 +1,4 @@
-if VERSION < v"0.4"
+if VERSION < v"0.4-"
     startswith = beginswith
 end
 
@@ -7,9 +7,45 @@ const gh_path_reg_git=r"^/(.*)?/(.*)?.git$"
 
 const minjuliaver = v"0.3.0" #Oldest Julia version allowed to be registered
 const minpkgver = v"0.0.1"   #Oldest package version allowed to be registered
+
 print_list_3582 = false # set this to true to generate the list of grandfathered
                         # packages permitted under Issue #3582
 list_3582 = Any[]
+
+#Issue 2064 - check that all listed packages at at least one tagged version
+#2064## Uncomment the #2064# code blocks to generate the list of grandfathered
+#2064## packages permitted
+for pkg in readdir("METADATA")
+    startswith(pkg, ".") && continue
+    isfile(joinpath("METADATA", pkg)) && continue
+    pkg in [
+        "AuditoryFilters",
+        "CorpusTools",
+        "Elemental",
+        "ErrorFreeTransforms",
+        "Evapotranspiration",
+        "GtkSourceWidget",
+        "HiRedis",
+        "KrylovMethods",
+        "KyotoCabinet",
+        "LatexPrint",
+        "MachO",
+        "MathLink",
+        "Mimi",
+        "ObjectiveC",
+        "OffsetArrays",
+        "Processing",
+        "RaggedArrays",
+        "RationalExtensions",
+        "SignedDistanceFields",
+        "SolveBio",
+        "SortPerf",
+    ] && continue
+    if !("versions" in readdir(joinpath("METADATA", pkg)))
+        #2064#println("        \"", pkg, "\","); continue
+        error("Package $pkg has no tagged versions")
+    end
+end
 
 for (pkg, versions) in Pkg.Read.available()
     url = (Pkg.Read.url(pkg))


### PR DESCRIPTION
A package with no tagged versions cannot be installed by `Pkg.add()`, so including them on the official package list seems to have limited value. I believe the question of registering a package with no tagged version has come up several times.

This PR ~~adds warnings to Travis for packages with no tagged versions.~~ enforces a new policy that new PRs to METADATA that register a new package must also tag at least one version of the package.

21 currently registered packages have no tagged versions and are made exempt from this new policy. They are:

- [ ] AuditoryFilters
- [ ] CorpusTools
- [ ] Elemental
- [ ] ErrorFreeTransforms
- [ ] Evapotranspiration
- [ ] GtkSourceWidget
- [ ] HiRedis
- [ ] KrylovMethods
- [ ] KyotoCabinet
- [ ] LatexPrint
- [ ] MachO
- [ ] MathLink
- [ ] Mimi
- [ ] ObjectiveC
- [ ] OffsetArrays
- [ ] Processing
- [ ] RaggedArrays
- [ ] RationalExtensions
- [ ] SignedDistanceFields
- [ ] SolveBio
- [ ] SortPerf

[@jiahao: updated 2015/09/30]