### PR TITLE
Register LatexPrint

### DIFF
--- a/LatexPrint/url
+++ b/LatexPrint/url
@@ -1,0 +1,1 @@
+git://github.com/scheinerman/LatexPrint.jl.git


### PR DESCRIPTION
`LatexPrint` is a module that provides functions to convert standard Julia objects (such as numbers and matrices) into text that is suitable for pasting into LaTeX's math mode. For example, the rational number `3//5` is rendered as `\frac{3}{5}`.