### PR TITLE
Tag IJulia v0.2.1

### DIFF
--- a/IJulia/versions/0.2.1/requires
+++ b/IJulia/versions/0.2.1/requires
@@ -1,0 +1,6 @@
+julia 0.2-
+Nettle
+JSON 0.2-
+ZMQ 0.1-
+REPLCompletions
+Compat 0.2

--- a/IJulia/versions/0.2.1/sha1
+++ b/IJulia/versions/0.2.1/sha1
@@ -1,0 +1,1 @@
+9b677b1e12e2d9ad17ab9e02589eccc2c3cd5c9d


### PR DESCRIPTION
Provides support for multiple Julia kernels on Jupyter/IPython 3.0

Ref: JuliaLang/IJulia.jl#280