### PR TITLE
Run version check on all subdirectories of METADATA

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -21,7 +21,7 @@ for (pkg, versions) in Pkg.Read.available()
 
         for (ver, avail) in versions
             #Check that all sha1 files have the correct version hashes
-            sha1_file = "METADATA/$pkg/versions/$ver/sha1"
+            sha1_file = joinpath("METADATA", pkg, "versions", string(ver), "sha1")
             @assert isfile(sha1_file) "Not a file: $sha1_file"
             sha1fromfile = open(sha1_file) do f
                 readchomp(f)
@@ -29,33 +29,48 @@ for (pkg, versions) in Pkg.Read.available()
             @assert sha1fromfile == avail.sha1
         end
 
-        #Traverse the 'versions' directory and make sure that we understand its contents
-	#The only allowed subdirectories must be semvers and the only allowed
-        #files within are 'sha1' and 'requires'
-        #
-        #Ref: #2040
-        verinfodir = "METADATA/$pkg/versions"
-        for verdir in readdir(verinfodir)
-            if convert(VersionNumber, verdir) in keys(versions)
-               for filename in readdir(verinfodir * "/" * verdir)
-                   if !(filename=="sha1" || filename=="requires")
-                       error("Unknown file $verinfodir/$verdir/$filename encountered. Valid filenames are 'sha1' and 'requires'.")
-                   end
-               end
-            else
-                error("v$verdir of $pkg is not configured correctly. Check that METADATA/$pkg/versions/$verdir/sha1 exists.")
-            end
+        #TODO Replace warnings with assertions below once packages in Issue #2057 have been addressed.
+        if !(pkg in ["PEGParser", "CompressedSensing"]) #Legacy package
+            @assert !endswith(pkg, ".jl") "Package name $pkg should not end in .jl"
+            @assert endswith(repo, ".jl") "Repository name $repo does not end in .jl"
         end
 
-        #TODO Replace warnings with assertions below once packages in Issue #2057 have been addressed.
-        !endswith(pkg, ".jl") || warn("Package name $pkg should not end in .jl")
-        endswith(repo, ".jl") || warn("Repository name $repo does not end in .jl")
-        #@assert !endswith(pkg, ".jl") "Package name $pkg should not end in .jl"
-        #@assert endswith(repo, ".jl") "Repository name $repo does not end in .jl"
-        
-        sha1_file = "METADATA/$pkg/versions/$(maxv)/sha1"
-        @assert isfile(sha1_file) "File not found: $sha1_file" 
-        
+        sha1_file = joinpath("METADATA", pkg, "versions", string(maxv), "sha1")
+        @assert isfile(sha1_file) "File not found: $sha1_file"
+
+    end
+end
+
+#Scan all entries in METADATA for possibly unrecognized packages
+const pkgs = [pkg for (pkg, versions) in Pkg.Read.available()]
+for pkg in readdir("METADATA")
+    #Traverse the 'versions' directory and make sure that we understand its contents
+    #The only allowed subdirectories must be semvers and the only allowed
+    #files within are 'sha1' and 'requires'
+    #
+    #Ref: #2040
+    verinfodir = joinpath("METADATA", pkg, "versions")
+    isdir(verinfodir) || continue #Some packages are registered but have no tagged versions. See #2064
+
+    for verdir in readdir(verinfodir)
+        version = try
+            convert(VersionNumber, verdir)
+        catch ArgumentError
+            error("Invalid version number $verdir found in $verinfodir")
+        end
+
+        versions = Pkg.Read.available(pkg)
+        if version in keys(versions)
+           for filename in readdir(joinpath(verinfodir, verdir))
+               if !(filename=="sha1" || filename=="requires")
+                   relpath = joinpath(verinfodir, verdir, filename)
+                   error("Unknown file $relpath encountered. Valid filenames are 'sha1' and 'requires'.")
+               end
+           end
+        else
+            relpath = joinpath("METADATA", pkg, "versions", verdir, "sha1")
+            error("Version v$verdir of $pkg is not configured correctly. Check that $relpath exists.")
+        end
     end
 end
 


### PR DESCRIPTION
This PR addresses an edge case observed in #2095 in which a package was
registered and the user attempted to register versions manually but
placed sha1 under `"METADATA/$pkg/versions"` instead of
`"METADATA/$pkg/versions/v0.01"`.

The version check test introduced by #2040 is now placed in a new loop
that runs for each subdirectory of METADATA, regardless of whether each
subdirectory corresponds to a package entry recognized by `Pkg.Read`.
Doing so allows the tests to detect package entries that are
misconfigured and hence not recognized as such by the package manager.

Additionally, `joinpath` is used consistently instead of manually splicing
strings together.

Furthermore, as PEGParser is the only package left without a .jl
extension in #2057, the .jl extension check is now upgraded to an
assertion error except for PEGParser, which is grandfathered in.