### PR TITLE
Tag TimeSeries v0.5.7

### DIFF
--- a/TimeSeries/versions/0.5.7/requires
+++ b/TimeSeries/versions/0.5.7/requires
@@ -1,0 +1,2 @@
+julia 0.3-
+Dates

--- a/TimeSeries/versions/0.5.7/sha1
+++ b/TimeSeries/versions/0.5.7/sha1
@@ -1,0 +1,1 @@
+d39db57c09df9698eea9cd02b8ea580ade341dd5


### PR DESCRIPTION
revert to using the `iround` method that has been deprecated in `v0.4` in favor of `round`