### PR TITLE
Run METADATA test on Julia nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 julia:
-    - release
+    - nightly
 notifications:
     email: false
 script:


### PR DESCRIPTION
The Travis status is now completely unusable on Julia release, since the internal consistency check reliably times out Travis, exceeding 10 min with no output.

This PR runs the tests on Julia nightly, which has a speedier Pkg.Entry.check_metadata.