### PR TITLE
Tag MatrixDepot v0.2.5

### DIFF
--- a/MatrixDepot/versions/0.2.5/requires
+++ b/MatrixDepot/versions/0.2.5/requires
@@ -1,0 +1,3 @@
+Compat
+GZip
+MatrixMarket

--- a/MatrixDepot/versions/0.2.5/sha1
+++ b/MatrixDepot/versions/0.2.5/sha1
@@ -1,0 +1,1 @@
+819ec552d48850ccb46c2d0bed6e63c8eba8dd3c


### PR DESCRIPTION
Main changes:

* support accessing matrices by number and UnitRange

* matrices in the collection are ordered alphabetically

* temporarily suspend the NIST Matrix Market interface

* use base Matrix Market reader for Julia 0.4