### PR TITLE
Register SkyCoords.jl

### DIFF
--- a/SkyCoords/url
+++ b/SkyCoords/url
@@ -1,0 +1,1 @@
+git://github.com/kbarbary/SkyCoords.jl.git

--- a/SkyCoords/versions/0.1.0/requires
+++ b/SkyCoords/versions/0.1.0/requires
@@ -1,0 +1,2 @@
+julia 0.3-
+Compat

--- a/SkyCoords/versions/0.1.0/sha1
+++ b/SkyCoords/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+9f247e64a30d4e1ccaaf3a6f2e1ffb02a62c9e01


### PR DESCRIPTION
Package for basic conversions between astronomical coordinate systems.
https://github.com/kbarbary/SkyCoords.jl

The name is borrowed from the `astropy.coordinates.SkyCoord` class in Python. "SkyCoordinates" would also be fine with me. Alternatives that I considered were "AstroCoord[inate]s" and "AstroSkyCoord[inate]s". The former is not specific enough and the later is a bit awkward. 
