### PR TITLE
Tag GLFW v1.0.0-alpha.5

### DIFF
--- a/GLFW/versions/1.0.0-alpha.5/requires
+++ b/GLFW/versions/1.0.0-alpha.5/requires
@@ -1,0 +1,2 @@
+julia 0.3
+Compat

--- a/GLFW/versions/1.0.0-alpha.5/sha1
+++ b/GLFW/versions/1.0.0-alpha.5/sha1
@@ -1,0 +1,1 @@
+9d3f5432cdf3eef4f5a562dd28dbf4cc7b080465


### PR DESCRIPTION
Fixes some 0.4 warnings and retains 0.3 support via the Compat package.