### PR TITLE
Fix BinDeps julia requirements v0.3.7/v0.3.8

### DIFF
--- a/BinDeps/versions/0.3.7/requires
+++ b/BinDeps/versions/0.3.7/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.3-
 URIParser
 SHA

--- a/BinDeps/versions/0.3.8/requires
+++ b/BinDeps/versions/0.3.8/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.3-
 URIParser
 SHA

--- a/BinDeps/versions/0.3.9/requires
+++ b/BinDeps/versions/0.3.9/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3-
 URIParser
 SHA
 Compat 0.3.6


### PR DESCRIPTION
I just found out that those versions don't work on julia 0.2.