### PR TITLE
Update HTTPClient version dependency of AWS.jl

### DIFF
--- a/AWS/versions/0.1.8/requires
+++ b/AWS/versions/0.1.8/requires
@@ -2,5 +2,5 @@ julia 0.3-
 Calendar
 Codecs
 LibExpat
-HTTPClient
+HTTPClient 0.1.4
 


### PR DESCRIPTION
Last version of AWS.jl that works with Julia 0.3 is only compatible HTTPClient 0.1.4 

See issue - https://github.com/amitmurthy/AWS.jl/issues/29