### PR TITLE
Tag FITSIO v0.8.0

### DIFF
--- a/FITSIO/versions/0.8.0/requires
+++ b/FITSIO/versions/0.8.0/requires
@@ -1,0 +1,3 @@
+julia 0.3
+BinDeps 0.3.12
+Compat 0.4.1

--- a/FITSIO/versions/0.8.0/sha1
+++ b/FITSIO/versions/0.8.0/sha1
@@ -1,0 +1,1 @@
+87484f6b1c81f889f0d1ebdeeb203da3e066bf5e


### PR DESCRIPTION
Release notes:

## New features

- Windows support (32-bit & 64-bit), thanks to help from Tony Kelman
  (requires master of BinDeps)
- New method `read_header(hdu, ASCIIString)` returns entire header as
  a single string.
- bump cfitsio version from 3.360 to 3.370

## Bug fixes

- fix `show()` for an empty FITS file.
- fix several issues with `Clong` on 64-bit Windows.

