### PR TITLE
Release Homebrew v0.1.16

### DIFF
--- a/Homebrew/versions/0.1.16/requires
+++ b/Homebrew/versions/0.1.16/requires
@@ -1,0 +1,4 @@
+julia 0.3-
+BinDeps
+JSON
+Compat

--- a/Homebrew/versions/0.1.16/sha1
+++ b/Homebrew/versions/0.1.16/sha1
@@ -1,0 +1,1 @@
+afade35b9b54c5a9532f7dfc6d77b681437ad8fe


### PR DESCRIPTION
I've jumped to v0.1.16, since v0.1.15 exists in the Homebrew repository, but wasn't ever actually pushed to METADATA.  This release fixes some issues with the latest 0.4 `using` search methods, as well as brings minimum compatibility up to julia v0.2.