### PR TITLE
Register ConjugatePriors and Tag v0.1.0

### DIFF
--- a/ConjugatePriors/url
+++ b/ConjugatePriors/url
@@ -1,0 +1,1 @@
+git://github.com/JuliaStats/ConjugatePriors.jl.git

--- a/ConjugatePriors/versions/0.1.0/requires
+++ b/ConjugatePriors/versions/0.1.0/requires
@@ -1,0 +1,4 @@
+julia 0.3
+Compat 0.4.0
+PDMats 0.3.2
+Distributions 0.8.1

--- a/ConjugatePriors/versions/0.1.0/sha1
+++ b/ConjugatePriors/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+bf041a6004d98f905a3ec34e4a6fefa6660e8fcb


### PR DESCRIPTION
This package was part of Distributions.jl and was separated out in last refactoring (about couple months' ago during the tupocalypse). However, it had not been cleaned up until recently, by @hassaku. (see https://github.com/JuliaStats/ConjugatePriors.jl/pull/3)

Now it passes tests and it is ready to register. 


