### PR TITLE
Register SynthesisFilters: v0.0.1

### DIFF
--- a/SynthesisFilters/url
+++ b/SynthesisFilters/url
@@ -1,0 +1,1 @@
+git://github.com/r9y9/SynthesisFilters.jl.git

--- a/SynthesisFilters/versions/0.0.1/requires
+++ b/SynthesisFilters/versions/0.0.1/requires
@@ -1,0 +1,3 @@
+julia 0.4-
+SPTK
+MelGeneralizedCepstrums

--- a/SynthesisFilters/versions/0.0.1/sha1
+++ b/SynthesisFilters/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+c19aaa925dd5c5df5b80a9ff07155a50ceffb44c


### PR DESCRIPTION
Speech waveform synthesis filters, especially from mel-generalized cepstrum variants. See https://github.com/r9y9/SynthesisFilters.jl for details. 

Synthesized audio examples (Japanese) are available on [the introduction notebook](http://nbviewer.ipython.org/github/r9y9/SynthesisFilters.jl/blob/master/examples/Introduction%20to%20SynthesisFilters.jl.ipynb).