### PR TITLE
Register IJuliaPortrayals: v0.0.1

### DIFF
--- a/IJuliaPortrayals/url
+++ b/IJuliaPortrayals/url
@@ -1,0 +1,1 @@
+git://github.com/jbn/IJuliaPortrayals.jl.git

--- a/IJuliaPortrayals/versions/0.0.1/requires
+++ b/IJuliaPortrayals/versions/0.0.1/requires
@@ -1,0 +1,2 @@
+julia 0.3
+IJulia

--- a/IJuliaPortrayals/versions/0.0.1/sha1
+++ b/IJuliaPortrayals/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+8305e293c1ec5d5dd2c9d2c8510cb670effcd6a0


### PR DESCRIPTION
This package adds `IPython`-style (or, scrapbook-style) portrayals of common, html-embeddable resources to `IJulia`. I opted for a package rather an a patch of `IJulia`, because I think a modular approach makes sense. Not everyone needs these portrayals. And, alternative portrayals are possible. So, it shouldn't be part of IJulia proper. However, I use them pretty constantly in my work. And, other people echo a need.