### PR TITLE
Deprecate SliceSampler/ doobwa/MCMC

### DIFF
--- a/SliceSampler/versions/0.0.0/requires
+++ b/SliceSampler/versions/0.0.0/requires
@@ -1,1 +1,2 @@
+julia 0.1 0.4
 Options


### PR DESCRIPTION
Package redirects to (another) MCMC.jl. Last commit Apr 16, 2013.

RIP SliceSampler.jl

@doobwa