### PR TITLE
Deprecate Resampling.jl

### DIFF
--- a/Resampling/versions/0.0.0/requires
+++ b/Resampling/versions/0.0.0/requires
@@ -1,1 +1,2 @@
+julia 0.2 0.4
 DataFrames

--- a/SliceSampler/versions/0.0.0/requires
+++ b/SliceSampler/versions/0.0.0/requires
@@ -1,1 +1,2 @@
+julia 0.1 0.4
 Options


### PR DESCRIPTION
Also managed to include #3303, woops.

Last commit Nov 14, 2013. Package does load on 0.3, but it doesn't work.

RIP Resampling.jl

@johnmyleswhite 