### PR TITLE
Deprecate ProjectTemplate.jl

### DIFF
--- a/ProjectTemplate/versions/0.0.0/requires
+++ b/ProjectTemplate/versions/0.0.0/requires
@@ -1,2 +1,3 @@
+julia 0.2 0.4
 JSON
 DataFrames

--- a/ProjectTemplate/versions/0.0.1/requires
+++ b/ProjectTemplate/versions/0.0.1/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.4
 JSON
 DataFrames


### PR DESCRIPTION
PkgEval has recorded tests passing on this (although now it doesn't even try to find them), but last commit was Feb 2014, and it is unsupported.

RIP ProjectTemplates.jl

@johnmyleswhite 