### PR TITLE
Deprecate RunTests

### DIFF
--- a/RunTests/versions/0.0.1/requires
+++ b/RunTests/versions/0.0.1/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.4
 ProgressMeter 0.0.1

--- a/RunTests/versions/0.0.2/requires
+++ b/RunTests/versions/0.0.2/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.4
 ProgressMeter 0.0.1

--- a/RunTests/versions/0.0.3/requires
+++ b/RunTests/versions/0.0.3/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.4
 ProgressMeter 0.0.1


### PR DESCRIPTION
Last commit > 1 year ago, last tagged version ~1.5 years ago, doesn't pass its tests on 0.3 or 0.4.

RIP RunTests.jl

@burrowsa