### PR TITLE
Deprecate Etcd.jl

### DIFF
--- a/Etcd/versions/0.0.1/requires
+++ b/Etcd/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.4
 
 Requests
 Lumberjack


### PR DESCRIPTION
`Current version: 0.0.1 (1 year, 3 months ago)`

Last commit over 1 year ago.

Doesn't seem to work on 0.3 (according to PkgEval).

RIP Etcd.nl

@forio @bass3m