### PR TITLE
Deprecate systemimagebuilder

### DIFF
--- a/SystemImageBuilder/versions/0.0.1/requires
+++ b/SystemImageBuilder/versions/0.0.1/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.4
 FunctionalData

--- a/SystemImageBuilder/versions/0.0.2/requires
+++ b/SystemImageBuilder/versions/0.0.2/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.4
 FunctionalData

--- a/SystemImageBuilder/versions/0.0.3/requires
+++ b/SystemImageBuilder/versions/0.0.3/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.4
 FunctionalData

--- a/SystemImageBuilder/versions/0.0.4/requires
+++ b/SystemImageBuilder/versions/0.0.4/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.4
 FunctionalData

--- a/SystemImageBuilder/versions/0.0.5/requires
+++ b/SystemImageBuilder/versions/0.0.5/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.4
 FunctionalData

--- a/SystemImageBuilder/versions/0.0.6/requires
+++ b/SystemImageBuilder/versions/0.0.6/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.4
 FunctionalData

--- a/SystemImageBuilder/versions/0.0.7/requires
+++ b/SystemImageBuilder/versions/0.0.7/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.4
 FunctionalData


### PR DESCRIPTION
Set a max ceiling of 0.3 for SystemImageBuilder - we don't need it on 0.4 any more.

