### PR TITLE
Tag Vega v0.4.0

### DIFF
--- a/Vega/versions/0.4.0/requires
+++ b/Vega/versions/0.4.0/requires
@@ -1,0 +1,4 @@
+julia 0.3
+JSON
+ColorBrewer
+Compat

--- a/Vega/versions/0.4.0/sha1
+++ b/Vega/versions/0.4.0/sha1
@@ -1,0 +1,1 @@
+b3420e517fd0b85a44dc0dc70acb70f283ad46af


### PR DESCRIPTION
Bump Vega up to reflect move to vega2 as the base engine for graphics and make Julia code match the documentation examples!