### PR TITLE
Tag MFCC v0.0.2, replaces #3431

### DIFF
--- a/MFCC/versions/0.0.2/requires
+++ b/MFCC/versions/0.0.2/requires
@@ -1,0 +1,5 @@
+julia 0.3
+DSP
+Compat
+HDF5
+WAV

--- a/MFCC/versions/0.0.2/sha1
+++ b/MFCC/versions/0.0.2/sha1
@@ -1,0 +1,1 @@
+3b6ebbea7d062fb4fb3abca24a65f353af06e6dc


### PR DESCRIPTION
Long since this package was updated. 

 - added Julia version in REQUIRE
 - added minimal consistency test
 - Julia 0.4 syntax
 - inclusion of higher-level feature calculation routines. 