### PR TITLE
Tag BinDeps v0.3.17

### DIFF
--- a/BinDeps/versions/0.3.16/requires
+++ b/BinDeps/versions/0.3.16/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4-
 URIParser
 SHA
 Compat 0.7.1

--- a/BinDeps/versions/0.3.17/requires
+++ b/BinDeps/versions/0.3.17/requires
@@ -1,0 +1,4 @@
+julia 0.3
+URIParser
+SHA
+Compat 0.7.1

--- a/BinDeps/versions/0.3.17/sha1
+++ b/BinDeps/versions/0.3.17/sha1
@@ -1,0 +1,1 @@
+7eeef60901208e8ffb0ccbd557ba7cfc4cb6f28a


### PR DESCRIPTION
Also bump version requirement for BinDeps 0.3.16 to avoid installed by 0.3 users