### PR TITLE
Adjust requirements on JuliaParser 0.6.3

### DIFF
--- a/JuliaParser/versions/0.6.3/requires
+++ b/JuliaParser/versions/0.6.3/requires
@@ -1,3 +1,3 @@
-julia 0.3-
+julia 0.4-
 FactCheck
 Compat


### PR DESCRIPTION
This has been reported as broken on Julia 0.3, causing Juno to stop working
ref https://groups.google.com/forum/#!topic/julia-users/ntOb9HNm0ac