### PR TITLE
Disable Compat 0.7.1 and 0.7.2 for Julia 0.3

### DIFF
--- a/Compat/versions/0.7.1/requires
+++ b/Compat/versions/0.7.1/requires
@@ -1,1 +1,1 @@
-julia 0.3
+julia 0.4

--- a/Compat/versions/0.7.2/requires
+++ b/Compat/versions/0.7.2/requires
@@ -1,1 +1,1 @@
-julia 0.3
+julia 0.4


### PR DESCRIPTION
Since they might break 0.3 code

Ref https://github.com/JuliaLang/Compat.jl/pull/143 and https://github.com/JuliaLang/Compat.jl/pull/144 for the fixes.

Cc. @simonster 
