### PR TITLE
Register ROOT: v0.0.1

### DIFF
--- a/ROOT/url
+++ b/ROOT/url
@@ -1,0 +1,1 @@
+git://github.com/jpata/ROOT.jl.git

--- a/ROOT/versions/0.0.1/requires
+++ b/ROOT/versions/0.0.1/requires
@@ -1,0 +1,2 @@
+julia 0.4
+BinDeps

--- a/ROOT/versions/0.0.1/sha1
+++ b/ROOT/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+7cbe1f4cef10f8bd682fe5aa58b65f78d89a0616


### PR DESCRIPTION
This library wraps parts of the [ROOT package](https://root.cern.ch/) used in high-energy physics. 