### PR TITLE
Tag ForwardDiff v0.1.1

### DIFF
--- a/ForwardDiff/versions/0.1.1/requires
+++ b/ForwardDiff/versions/0.1.1/requires
@@ -1,0 +1,3 @@
+julia 0.4-
+Calculus
+NaNMath

--- a/ForwardDiff/versions/0.1.1/sha1
+++ b/ForwardDiff/versions/0.1.1/sha1
@@ -1,0 +1,1 @@
+5efb62e1c17fc36f74abf3be7d41baef4d4c2b57


### PR DESCRIPTION
- The target function passed to `jacobian` can now take the form `f!(output, x)` (JuliaDiff/ForwardDiff.jl#45)
- Added a couple more function definitions (JuliaDiff/ForwardDiff.jl#47, JuliaDiff/ForwardDiff.jl#53)
- Better inferencing for `derivative` when the target function is a type (JuliaDiff/ForwardDiff.jl#54)
- Turned on precompilation (JuliaDiff/ForwardDiff.jl#56)
- More robust conversion/promotion rules for nested differentiation (JuliaDiff/ForwardDiff.jl#59)
