### PR TITLE
Tag IJulia v1.1.5

### DIFF
--- a/IJulia/versions/1.1.5/requires
+++ b/IJulia/versions/1.1.5/requires
@@ -1,0 +1,6 @@
+julia 0.3
+Nettle 0.2
+JSON 0.5
+ZMQ 0.3
+Compat 0.7
+Conda 0.1.5

--- a/IJulia/versions/1.1.5/sha1
+++ b/IJulia/versions/1.1.5/sha1
@@ -1,0 +1,1 @@
+cce2225ff59b2425eab8b3b4dadac65d5d0aa24f


### PR DESCRIPTION
Enables precompilation, fixes a problem with the `notebook()` function with Conda, and makes `notebook()` properly killable.