### PR TITLE
Deprecate Jumos formally

### DIFF
--- a/Jumos/versions/0.1.0/requires
+++ b/Jumos/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4- 0.5
 Reexport
 NetCDF
 Calculus

--- a/Jumos/versions/0.2.0/requires
+++ b/Jumos/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4- 0.5
 Reexport
 Calculus
 SIUnits

--- a/Jumos/versions/0.2.1/requires
+++ b/Jumos/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4- 0.5
 Reexport
 Calculus
 Distances


### PR DESCRIPTION
As I understand it, this package is now deprecated by its author, @Luthaf.