### PR TITLE
Tag KernelDensity v0.1.2

### DIFF
--- a/KernelDensity/versions/0.1.2/requires
+++ b/KernelDensity/versions/0.1.2/requires
@@ -1,0 +1,6 @@
+julia 0.3
+StatsBase
+Distributions
+Optim
+Grid
+Compat

--- a/KernelDensity/versions/0.1.2/sha1
+++ b/KernelDensity/versions/0.1.2/sha1
@@ -1,0 +1,1 @@
+48cfa6aec1acb6de62b2aee547281293a298eeef


### PR DESCRIPTION
Fixes 0.4 dep warnings, bumps to 0.3 from 0.3-

(one less dep warning for Gadfly!)