### PR TITLE
add Compat to Taro/versions/0.2.1/requires

### DIFF
--- a/Taro/versions/0.2.1/requires
+++ b/Taro/versions/0.2.1/requires
@@ -1,3 +1,4 @@
 julia 0.3
 JavaCall
 DataFrames
+Compat


### PR DESCRIPTION
ref https://github.com/aviks/Taro.jl/commit/ea056e03eec4880231a0cad1819ca78cf92064c4

defensive against the possibility that Taro's direct deps might not depend on Compat forever

cc @aviks