### PR TITLE
make most recent LowRankModels tag require 0.4

### DIFF
--- a/LowRankModels/versions/0.1.2/requires
+++ b/LowRankModels/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 DataFrames
 StatsBase
 ArrayViews


### PR DESCRIPTION
cc @madeleineudell the most recent tag of LowRankModels is failing tests on 0.3
```
julia> @time Pkg.test("LowRankModels")
INFO: Testing LowRankModels
ERROR: type: instantiate_type: expected TypeConstructor, got Function
 in include at ./boot.jl:245
 in include_from_node1 at ./loading.jl:128
 in include at ./boot.jl:245
 in include_from_node1 at ./loading.jl:128
 in reload_path at loading.jl:152
 in _require at loading.jl:67
 in require at loading.jl:51
 in include at ./boot.jl:245
 in include_from_node1 at loading.jl:128
 in process_options at ./client.jl:285
 in _start at ./client.jl:354
while loading /home/tkelman/.julia/v0.3/LowRankModels/src/glrm.jl, in expression starting on line 10
while loading /home/tkelman/.julia/v0.3/LowRankModels/src/LowRankModels.jl, in expression starting on line 16
while loading /home/tkelman/.julia/v0.3/LowRankModels/test/runtests.jl, in expression starting on line 1
```

I'll send across a PR soon to fix it, but for now this should help.