### PR TITLE
Tag CodeTools v0.2.0

### DIFF
--- a/CodeTools/versions/0.2.0/requires
+++ b/CodeTools/versions/0.2.0/requires
@@ -1,0 +1,6 @@
+julia 0.4
+Lazy
+LNR
+JuliaParser
+MacroTools
+Compat

--- a/CodeTools/versions/0.2.0/sha1
+++ b/CodeTools/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+c9e2b14e31eeeb406fd55ebc7407b47faf56cbc4


### PR DESCRIPTION
Just noticed that we have `julia 0.4-` in REQUIRE, should I change this to `julia 0.4`?