### PR TITLE
Register Mandrill: v0.1.0

### DIFF
--- a/Mandrill/url
+++ b/Mandrill/url
@@ -1,0 +1,1 @@
+git://github.com/aviks/Mandrill.jl.git

--- a/Mandrill/versions/0.1.0/requires
+++ b/Mandrill/versions/0.1.0/requires
@@ -1,0 +1,4 @@
+julia 0.3
+Requests
+JSON
+Compat

--- a/Mandrill/versions/0.1.0/sha1
+++ b/Mandrill/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+8a378fc878f340e5c95930a763f6dcfe9fcbfccc


### PR DESCRIPTION
A Julia package for Mandrill's REST API. Mandril is an email delivery provider for transactional emails. 

https://mandrill.com/

https://github.com/aviks/Mandrill.jl