### PR TITLE
Tag Combinatorics v0.3.1 [git://github.com/JuliaLang/Combinatorics.jl.git]

### DIFF
--- a/Combinatorics/versions/0.3.1/requires
+++ b/Combinatorics/versions/0.3.1/requires
@@ -1,0 +1,3 @@
+julia 0.5-
+Polynomials
+Iterators

--- a/Combinatorics/versions/0.3.1/sha1
+++ b/Combinatorics/versions/0.3.1/sha1
@@ -1,0 +1,1 @@
+3c08c9af9ebeaa54589e939c0cf2e652ef4ca6a0


### PR DESCRIPTION
Resolves name clash between code moved out of Base and the methods remaining that throw deprecation errors.

Ref: JuliaLang/Combinatorics.jl#13 JuliaLang/julia#13897 @sbromberger 