### PR TITLE
Update URL for XGBoost

### DIFF
--- a/XGBoost/url
+++ b/XGBoost/url
@@ -1,1 +1,1 @@
-git://github.com/antinucleon/XGBoost.jl.git
+git://github.com/dmlc/XGBoost.jl.git


### PR DESCRIPTION
The package was moved to dmlc/XGBoost.jl. Pkg.add still works, but Pkg.submit fails due to the move