### PR TITLE
Deprecate KLDivergence

### DIFF
--- a/KLDivergence/versions/0.0.0/requires
+++ b/KLDivergence/versions/0.0.0/requires
@@ -1,1 +1,2 @@
+julia 0.1 0.5
 Distributions


### PR DESCRIPTION
Just saw this when skimming through PkgEval stuff

CC: @johnmyleswhite, who has already put an appropriate warning in the README