### PR TITLE
Register JuliaWebAPI.jl

### DIFF
--- a/JuliaWebAPI/url
+++ b/JuliaWebAPI/url
@@ -1,0 +1,1 @@
+git://github.com/tanmaykm/JuliaWebAPI.jl.git

--- a/JuliaWebAPI/versions/0.0.1/requires
+++ b/JuliaWebAPI/versions/0.0.1/requires
@@ -1,0 +1,7 @@
+julia 0.3
+ZMQ
+JSON
+Logging
+HttpCommon
+HttpServer
+Compat

--- a/JuliaWebAPI/versions/0.0.1/sha1
+++ b/JuliaWebAPI/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+c623ee3b73131efc91775dc2f7ed64ec19abec83


### PR DESCRIPTION
JuliaWebAPI facilitates wrapping Julia functions into a remote callable API via ZMQ and HTTP.

(closes https://github.com/tanmaykm/JuliaWebAPI.jl/issues/19)