### PR TITLE
Retroactively tighten JuMPeR requirements

### DIFF
--- a/JuMPeR/versions/0.1.0/requires
+++ b/JuMPeR/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.3
-JuMP 0.8
+JuMP 0.8 0.9

--- a/JuMPeR/versions/0.1.1/requires
+++ b/JuMPeR/versions/0.1.1/requires
@@ -1,2 +1,2 @@
 julia 0.3
-JuMP 0.9
+JuMP 0.9 0.10

--- a/JuMPeR/versions/0.1.2/requires
+++ b/JuMPeR/versions/0.1.2/requires
@@ -1,3 +1,3 @@
 julia 0.3
-JuMP 0.9
+JuMP 0.9 0.10
 Compat


### PR DESCRIPTION
Just to be very defensive, as they are so tightly coupled. I saw a strange downgrade case today because these old versions didn't have upper limits.