### PR TITLE
Tag LightGraphs v0.5.0

### DIFF
--- a/LightGraphs/versions/0.5.0/requires
+++ b/LightGraphs/versions/0.5.0/requires
@@ -1,0 +1,9 @@
+julia 0.4
+Requires
+GZip 0.2.18
+StatsBase 0.7.4
+LightXML 0.2.1
+ParserCombinator 1.7.3
+Docile 0.5.3
+Clustering 0.4
+Combinatorics

--- a/LightGraphs/versions/0.5.0/sha1
+++ b/LightGraphs/versions/0.5.0/sha1
@@ -1,0 +1,1 @@
+44528ed35df7815cc36ff39c91cce20ad2cc1ff8


### PR DESCRIPTION
This has a few breaking changes but a lot of new functionality:

`stochastic_block_model` has been removed in favor of new Graph constructors that take a type of `StochasticBlockModel` which can handle various random generators

Persistence has been modularized and made consistent: graphs are now loaded using `load()` and `save()` methods with symbols indicating graph type

Static small graphs and MatrixDepot graphs have been moved into a new submodule, LightGraphs.Datasets.
