### PR TITLE
Tag MXNet v0.0.7

### DIFF
--- a/MXNet/versions/0.0.7/requires
+++ b/MXNet/versions/0.0.7/requires
@@ -1,0 +1,4 @@
+julia 0.4
+Formatting
+BinDeps
+JSON

--- a/MXNet/versions/0.0.7/sha1
+++ b/MXNet/versions/0.0.7/sha1
@@ -1,0 +1,1 @@
+8edb94be2a4c6250ef4bb26e58ca5fb0b9fee6ff


### PR DESCRIPTION
Mainly a minor version tagged to maintain compatibility with Julia 0.4.2.

# v0.0.7 (2015.12.14)

* Fix compatability with Julia v0.4.2 (@BigEpsilon)
* Metrics in epoch callbacks (@kasiabozek)
