### PR TITLE
put an upper bound on ReverseDiffSparse dependencies

### DIFF
--- a/JuMP/versions/0.10.0/requires
+++ b/JuMP/versions/0.10.0/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Compat 0.4.0
 Calculus

--- a/JuMP/versions/0.10.1/requires
+++ b/JuMP/versions/0.10.1/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Compat 0.4.0
 Calculus

--- a/JuMP/versions/0.10.2/requires
+++ b/JuMP/versions/0.10.2/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Compat 0.7.1
 Calculus

--- a/JuMP/versions/0.10.3/requires
+++ b/JuMP/versions/0.10.3/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Compat 0.7.1
 Calculus

--- a/JuMP/versions/0.11.0/requires
+++ b/JuMP/versions/0.11.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 MathProgBase 0.4.0 0.5.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Calculus

--- a/JuMP/versions/0.11.1/requires
+++ b/JuMP/versions/0.11.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 MathProgBase 0.4.0 0.5.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Calculus

--- a/JuMP/versions/0.5.0/requires
+++ b/JuMP/versions/0.5.0/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.0.0 0.3.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.1/requires
+++ b/JuMP/versions/0.5.1/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.0.0 0.3.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.2/requires
+++ b/JuMP/versions/0.5.2/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.0.0 0.3.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.3/requires
+++ b/JuMP/versions/0.5.3/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.0.0 0.3.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.4/requires
+++ b/JuMP/versions/0.5.4/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.0.0 0.3.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.5/requires
+++ b/JuMP/versions/0.5.5/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.0.0 0.3.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.6/requires
+++ b/JuMP/versions/0.5.6/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.3.0- 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.7/requires
+++ b/JuMP/versions/0.5.7/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.3.0- 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.8/requires
+++ b/JuMP/versions/0.5.8/requires
@@ -1,3 +1,3 @@
 julia 0.2
 MathProgBase 0.3.0- 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.6.0/requires
+++ b/JuMP/versions/0.6.0/requires
@@ -1,3 +1,3 @@
 julia 0.3
 MathProgBase 0.3.0- 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.6.1/requires
+++ b/JuMP/versions/0.6.1/requires
@@ -1,3 +1,3 @@
 julia 0.3
 MathProgBase 0.3.0- 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.6.2/requires
+++ b/JuMP/versions/0.6.2/requires
@@ -1,3 +1,3 @@
 julia 0.3
 MathProgBase 0.3.1 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.6.3/requires
+++ b/JuMP/versions/0.6.3/requires
@@ -1,4 +1,4 @@
 julia 0.3
 MathProgBase 0.3.1 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4
 ArrayViews

--- a/JuMP/versions/0.7.0/requires
+++ b/JuMP/versions/0.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4
 ArrayViews
 Compat

--- a/JuMP/versions/0.7.1/requires
+++ b/JuMP/versions/0.7.1/requires
@@ -1,5 +1,5 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4
 ArrayViews
 Compat

--- a/JuMP/versions/0.7.2/requires
+++ b/JuMP/versions/0.7.2/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4
 ArrayViews
 Compat
 Calculus

--- a/JuMP/versions/0.7.3/requires
+++ b/JuMP/versions/0.7.3/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse
+ReverseDiffSparse 0.1 0.4
 ArrayViews
 Compat
 Calculus

--- a/JuMP/versions/0.9.0/requires
+++ b/JuMP/versions/0.9.0/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews
 Compat 0.4.0
 Calculus

--- a/JuMP/versions/0.9.1/requires
+++ b/JuMP/versions/0.9.1/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Compat 0.4.0
 Calculus

--- a/JuMP/versions/0.9.2/requires
+++ b/JuMP/versions/0.9.2/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Compat 0.4.0
 Calculus

--- a/JuMP/versions/0.9.3/requires
+++ b/JuMP/versions/0.9.3/requires
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.2.2
+ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12
 Compat 0.4.0
 Calculus


### PR DESCRIPTION
ReverseDiffSparse 0.4 (currently being developed at https://github.com/mlubin/ReverseDiffSparse2.jl) will be a completely breaking release. This is still likely a month away, but getting prepared anyway.