### PR TITLE
Tag Cubature v1.0.10 [git://github.com/stevengj/Cubature.jl.git]

### DIFF
--- a/Cubature/versions/1.0.10/requires
+++ b/Cubature/versions/1.0.10/requires
@@ -1,0 +1,3 @@
+BinDeps
+julia 0.3
+Compat 0.7

--- a/Cubature/versions/1.0.10/sha1
+++ b/Cubature/versions/1.0.10/sha1
@@ -1,0 +1,1 @@
+e30d4ebb823a255bdb31ad2af35171cb6ca0a4aa


### PR DESCRIPTION
Fixes stevengj/Cubature.jl#12 and some deprecation warnings.