### PR TITLE
Fall back to last passing versions of AppConf and Diversity on Julia 0.3

### DIFF
--- a/AppConf/versions/0.1.0/requires
+++ b/AppConf/versions/0.1.0/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.4
 Compat

--- a/Diversity/versions/0.2.4/requires
+++ b/Diversity/versions/0.2.4/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.4
 Docile 0.3.1-
 Lexicon


### PR DESCRIPTION
cc @tmlbl and @richardreeve - both of these tags fail on Julia 0.3. Diversity.jl is fixed on master and just needs a new tag, AppConf.jl can be fixed by https://github.com/tmlbl/AppConf.jl/pull/4. Adjusting the requires of these existing tags so these versions don't get installed by users on Julia 0.3 when they do `Pkg.update()` is good to do in the meantime, will get/keep them passing on PackageEvaluator for one thing.