### PR TITLE
Tag Distances v0.2.2

### DIFF
--- a/Distances/versions/0.2.2/requires
+++ b/Distances/versions/0.2.2/requires
@@ -1,0 +1,3 @@
+julia 0.3
+ArrayViews 0.4.8-
+Compat

--- a/Distances/versions/0.2.2/sha1
+++ b/Distances/versions/0.2.2/sha1
@@ -1,0 +1,1 @@
+3dec24cdd3d92892bc9b9abf9fe4570cae2aead4


### PR DESCRIPTION
Tagging this as the last julia v0.3 version.

I plan to make a PR for a new v0.3.0  version that is for julia 0.4 only and thereby can remove some dependencies.