### PR TITLE
Register ZIP

### DIFF
--- a/ZIP/url
+++ b/ZIP/url
@@ -1,0 +1,1 @@
+git@octech.github.com:samoconnor/ZIP.jl.git


### PR DESCRIPTION
High level interface for ZIP Archives.

Implemented using Fazlul Shahriar's [ZipFile](https://github.com/fhs/ZipFile.jl) IO module.
@fhs [suggested](https://github.com/fhs/ZipFile.jl/pull/24#issuecomment-167274810) that this kind of high level interface should go in a new package.

This module hides the heavy lifting and implementation detail of [ZipFile](https://github.com/fhs/ZipFile.jl) and exports only 3 symbols `open_zip`, `create_zip` and `unzip` (@timholy's unzip() function per fhs/ZipFile.jl#16)