### PR TITLE
Register ZIP

### DIFF
--- a/ZIP/url
+++ b/ZIP/url
@@ -1,0 +1,1 @@
+git://github.com/samoconnor/ZIP.jl.git

--- a/ZIP/versions/0.0.1/requires
+++ b/ZIP/versions/0.0.1/requires
@@ -1,0 +1,2 @@
+julia 0.4
+ZipFile 0.2.6

--- a/ZIP/versions/0.0.1/sha1
+++ b/ZIP/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+3babcc58c1689aae4a2f8ca2324ce91a8e003da9


### PR DESCRIPTION
High level interface for ZIP Archives.

Implemented using Fazlul Shahriar's [ZipFile](https://github.com/fhs/ZipFile.jl) IO module.
@fhs [suggested](https://github.com/fhs/ZipFile.jl/pull/24#issuecomment-167274810) that this kind of high level interface should go in a new package.

This module hides the heavy lifting and implementation detail of [ZipFile](https://github.com/fhs/ZipFile.jl) and exports only 3 symbols `open_zip`, `create_zip` and `unzip` (@timholy's unzip() function per fhs/ZipFile.jl#16)