### PR TITLE
Bump Compose and Gadfly

### DIFF
--- a/Compose/versions/0.4.1/requires
+++ b/Compose/versions/0.4.1/requires
@@ -1,0 +1,7 @@
+julia 0.4
+Colors
+Compat 0.2.3
+DataStructures
+Iterators 0.1.5
+JSON
+Measures

--- a/Compose/versions/0.4.1/sha1
+++ b/Compose/versions/0.4.1/sha1
@@ -1,0 +1,1 @@
+a4efa5347ad6fd9f653d71d4eff174d9b5604eb5

--- a/Gadfly/versions/0.4.1/requires
+++ b/Gadfly/versions/0.4.1/requires
@@ -1,0 +1,17 @@
+julia 0.4
+Codecs
+Colors 0.3.4
+Compat
+Compose 0.3.11
+Contour
+DataFrames 0.4.2
+DataStructures
+Dates
+Distributions
+Hexagons
+Iterators 0.1.5
+JSON
+KernelDensity
+Loess
+Showoff 0.0.3
+StatsBase

--- a/Gadfly/versions/0.4.1/sha1
+++ b/Gadfly/versions/0.4.1/sha1
@@ -1,0 +1,1 @@
+51e245da67aa97e8a3cc3ae5731ac1e8e6d8bc95


### PR DESCRIPTION
Once again daring in the absence of @dcjones, but this contains several fixes:
Compose:
- `get` nullable fontfamily before writing to file (@darwindarak)
- Apply matrix transforms when resolving points (@rohitvarkey)
- CI fixes (@shashi, @timholy)
- Cairo build fixes (@mortenpi)
- Check whether backend is finished prior to attempting to draw to it. (@Sacha0)
- Escape ampersands (@glesica)
- Escape latex in pgf backend (@bastinat0r)

Gadfly:
- Fixed y-axis bug for histogram2d (@kshyatt)
- Lots of work on color scales (@simleb)
- Improve `spy` plots (@mortenpi)
- Move patchwork conditional loading to `__init__` (@shashi)
- Doc improvements (@simleb, @kshyatt, @amellnik)
