### PR TITLE
latest tag of Media is broken on Julia 0.3

### DIFF
--- a/Media/versions/0.1.2/requires
+++ b/Media/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 Requires
 Lazy
 MacroTools


### PR DESCRIPTION
Any users still on 0.3 would have their code broken from a Pkg.update
due to the latest tag. Using require bounds correctly makes this easy to avoid.
So does having tests.