### PR TITLE
Tag PairwiseListMatrices v0.3.0

### DIFF
--- a/PairwiseListMatrices/versions/0.3.0/requires
+++ b/PairwiseListMatrices/versions/0.3.0/requires
@@ -1,0 +1,3 @@
+julia 0.4
+IndexedArrays
+Requires

--- a/PairwiseListMatrices/versions/0.3.0/sha1
+++ b/PairwiseListMatrices/versions/0.3.0/sha1
@@ -1,0 +1,1 @@
+0a85c61aaba996d4dce0d6ca66d510fa3fd3d562


### PR DESCRIPTION
This version [adds a **join** method](https://github.com/diegozea/PairwiseListMatrices.jl/blob/master/src/pairwiselistmatrix.jl#L899) needed for [MIToS' Pfam module](https://github.com/diegozea/MIToS.jl/blob/master/src/Pfam/pdb.jl#L148).