### PR TITLE
Tag GSL v0.3.0 [git://github.com/jiahao/GSL.jl.git]

### DIFF
--- a/GSL/versions/0.3.0/requires
+++ b/GSL/versions/0.3.0/requires
@@ -1,0 +1,4 @@
+julia 0.4
+BinDeps 0.2.12-
+@osx Homebrew 0.0.4-
+@windows WinRPM

--- a/GSL/versions/0.3.0/sha1
+++ b/GSL/versions/0.3.0/sha1
@@ -1,0 +1,1 @@
+37cac0c1b0ff1ead07acc8ea4c7e4804436a4b70


### PR DESCRIPTION
A bunch of fixes to GSL wrapper functions, especially to the root finding functions (thanks @AndyGreenwell)

Also drops Julia 0.3 support