### PR TITLE
Tag PyCall v1.3.0

### DIFF
--- a/PyCall/versions/1.3.0/requires
+++ b/PyCall/versions/1.3.0/requires
@@ -1,0 +1,4 @@
+julia 0.4
+Compat 0.7.1
+Dates
+Conda 0.1.6

--- a/PyCall/versions/1.3.0/sha1
+++ b/PyCall/versions/1.3.0/sha1
@@ -1,0 +1,1 @@
+73c3db71e8e1eca4ef1e950e5aaabe65f544b159


### PR DESCRIPTION
Several bugfixes since 1.2, and also drops support for Julia 0.3, which is more trouble than it is worth at this point.