### PR TITLE
Tag PDMats v0.4.0

### DIFF
--- a/PDMats/versions/0.4.0/requires
+++ b/PDMats/versions/0.4.0/requires
@@ -1,0 +1,2 @@
+julia 0.3
+Compat 0.7.7

--- a/PDMats/versions/0.4.0/sha1
+++ b/PDMats/versions/0.4.0/sha1
@@ -1,0 +1,1 @@
+3b6bf6142bd3b93d21a6afb1f6a22775b0cede67


### PR DESCRIPTION
~~This will break the Distributions tests (though most of the package will work): I'll tag a new version as soon as this is merged.~~

Actually, it won't, someone had the foresight to pre-set the REQUIRE file.