### PR TITLE
Pull request/05dc307e

### DIFF
--- a/Spectra/url
+++ b/Spectra/url
@@ -1,0 +1,1 @@
+git://github.com/charlesll/Spectra.jl.git

--- a/Spectra/versions/0.0.1/requires
+++ b/Spectra/versions/0.0.1/requires
@@ -1,0 +1,7 @@
+julia 0.4
+PyPlot
+JuMP
+Ipopt
+Gadfly
+Cairo
+

--- a/Spectra/versions/0.0.1/sha1
+++ b/Spectra/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+2fa5956aecd04156fea681f722e0c0edbe04eb5f

--- a/SpectraJu/url
+++ b/SpectraJu/url
@@ -1,0 +1,1 @@
+git://github.com/charlesll/SpectraJu.jl.git


### PR DESCRIPTION
Pull request to publish Spectra:

Package name SpectraJu was changed to Spectra, package was tagged, commit for adding gfortran for Ipopt was accepted,  and everything was updated in regards of the new name.

