### PR TITLE
Register JukitLearn.jl

### DIFF
--- a/JukitLearn/url
+++ b/JukitLearn/url
@@ -1,0 +1,1 @@
+git://github.com/cstjean/JukitLearn.jl.git

--- a/JukitLearnBase/url
+++ b/JukitLearnBase/url
@@ -1,0 +1,1 @@
+git://github.com/cstjean/JukitLearnBase.jl.git


### PR DESCRIPTION
I would have liked to call it ScikitLearn.jl, but I asked for permission from the scikit-learn developers and [didn't get it](https://sourceforge.net/p/scikit-learn/mailman/scikit-learn-general/thread/CAEJt5f7XOArmC1vTdUkAM_t1qqV%2BF80UiLoyi2vYRSdjMW%2BOPA%40mail.gmail.com/#msg34907568). I'm not super fond of "JukitLearn" (though I'd like to preserve some kind of name association). Suggestions are welcome.