### PR TITLE
Register PyLCM

### DIFF
--- a/PyLCM/url
+++ b/PyLCM/url
@@ -1,0 +1,1 @@
+git://github.com/rdeits/PyLCM.jl.git


### PR DESCRIPTION
Registers PyLCM, which contains bindings to LCM, the [Lightweight Communications and Marshalling library](https://lcm-proj.github.io/) via PyCall. I chose the "Py" prefix because someone may eventually want to directly wrap the LCM C or C++ API without the Python overhead, so I'm leaving the `LCM.jl` name available. 