### PR TITLE
Deprecate Catalan, MetaTools, RobustStats

### DIFF
--- a/Catalan/versions/0.0.0/requires
+++ b/Catalan/versions/0.0.0/requires
@@ -1,1 +1,2 @@
+julia 0.1 0.4
 Polynomial

--- a/Catalan/versions/0.0.1/requires
+++ b/Catalan/versions/0.0.1/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.4
 Polynomial

--- a/Catalan/versions/0.0.2/requires
+++ b/Catalan/versions/0.0.2/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.4
 Polynomial

--- a/Catalan/versions/0.0.3/requires
+++ b/Catalan/versions/0.0.3/requires
@@ -1,2 +1,2 @@
-julia 0.2-0.4
+julia 0.2- 0.4
 Polynomial

--- a/MetaTools/versions/0.0.1/requires
+++ b/MetaTools/versions/0.0.1/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.4
 RunTests 0.0.2

--- a/RobustStats/versions/0.0.0/requires
+++ b/RobustStats/versions/0.0.0/requires
@@ -1,3 +1,4 @@
+julia 0.1 0.4
 DataFrames
 Rmath
 StatsBase

--- a/RobustStats/versions/0.0.1/requires
+++ b/RobustStats/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.4
 
 DataFrames 0.5-
 DataArrays


### PR DESCRIPTION
These all have dependencies on other packages that have already been deprecated. So does PEGParser.jl, but at least that has been fixed on its master and just needs a new tag.