### PR TITLE
Tag WriteVTK v0.3.2

### DIFF
--- a/WriteVTK/versions/0.3.2/requires
+++ b/WriteVTK/versions/0.3.2/requires
@@ -1,0 +1,4 @@
+julia 0.4
+LightXML 0.2
+Libz 0.0.1
+BufferedStreams 0.0.3

--- a/WriteVTK/versions/0.3.2/sha1
+++ b/WriteVTK/versions/0.3.2/sha1
@@ -1,0 +1,1 @@
+15aea7dc1ffbd0a7d7b29b7aaea5aa06a3620349


### PR DESCRIPTION
Fixes issue with recent version of the BufferedStreams package.