### PR TITLE
Tag BlackBoxOptim v0.2.0

### DIFF
--- a/BlackBoxOptim/versions/0.1.4/requires
+++ b/BlackBoxOptim/versions/0.1.4/requires
@@ -1,0 +1,5 @@
+julia 0.4
+FactCheck
+StatsBase
+Distributions
+Compat

--- a/BlackBoxOptim/versions/0.1.4/sha1
+++ b/BlackBoxOptim/versions/0.1.4/sha1
@@ -1,0 +1,1 @@
+bd0745c543ad4b5f5c03a6b459b3c9a97edef27f

--- a/BlackBoxOptim/versions/0.2.0/requires
+++ b/BlackBoxOptim/versions/0.2.0/requires
@@ -1,0 +1,5 @@
+julia 0.4
+FactCheck
+StatsBase
+Distributions
+Compat

--- a/BlackBoxOptim/versions/0.2.0/sha1
+++ b/BlackBoxOptim/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+bd0745c543ad4b5f5c03a6b459b3c9a97edef27f


### PR DESCRIPTION
v0.2.0 is a major new version that includes support for multi-objective optimization with the BorgMOEA algorithm.

I accidently first tagged it as v0.1.4 but was not sure how to safely delete that tag. `git tag -d v0.1.4` at the command line was not enough since Pkg.publish() later complained.