### PR TITLE
Tag Combinatorics v0.3.2/v0.2.1

### DIFF
--- a/Combinatorics/versions/0.2.1/requires
+++ b/Combinatorics/versions/0.2.1/requires
@@ -1,0 +1,3 @@
+julia 0.4
+Polynomials
+Iterators

--- a/Combinatorics/versions/0.2.1/sha1
+++ b/Combinatorics/versions/0.2.1/sha1
@@ -1,0 +1,1 @@
+2aaeef708947dbfd76e1e238d385327c1badb0cc

--- a/Combinatorics/versions/0.3.2/requires
+++ b/Combinatorics/versions/0.3.2/requires
@@ -1,0 +1,3 @@
+julia 0.5-
+Polynomials
+Iterators

--- a/Combinatorics/versions/0.3.2/sha1
+++ b/Combinatorics/versions/0.3.2/sha1
@@ -1,0 +1,1 @@
+3c08c9af9ebeaa54589e939c0cf2e652ef4ca6a0


### PR DESCRIPTION
They are actually the same commit since the Julia 0.5-only branch (v0.3.x) is still fully compatible with Julia 0.4, except for the method redefinition warnings from moving all those functions out of `Base`.

Includes fixes to JuliaLang/Iterators.jl#56.

Closes JuliaLang/Combinatorics.jl#17