### PR TITLE
Point Showoff at JuliaPackageMirrors

### DIFF
--- a/Showoff/url
+++ b/Showoff/url
@@ -1,1 +1,1 @@
-git://github.com/dcjones/Showoff.jl.git
+git://github.com/JuliaPackageMirrors/Showoff.jl.git


### PR DESCRIPTION
@dcjones is currently not checking his packages so there are changes accumulating that make it difficult to get those packages running on 0.5. Most of them have other people with commit access, but Showoff.jl does not. Thus, I propose temporarily moving development of that package to JuliaPackageMirrors until @dcjones returns. 

Will this work? I'm afraid of the old remote staying in people's local copies causing all sorts of ruckus. cc @tkelman @wildart 