### PR TITLE
Tag PATHSolver v0.0.5

### DIFF
--- a/PATHSolver/versions/0.0.5/requires
+++ b/PATHSolver/versions/0.0.5/requires
@@ -1,0 +1,3 @@
+julia 0.4
+ForwardDiff
+BinDeps

--- a/PATHSolver/versions/0.0.5/sha1
+++ b/PATHSolver/versions/0.0.5/sha1
@@ -1,0 +1,1 @@
+bb89e79b088d41257d4badaab120b5d64af1b65b


### PR DESCRIPTION
Now supports Windows both 32bit and 64bit.