### PR TITLE
Tag Combinatorics v0.2.2, MLBase v0.5.3

### DIFF
--- a/Combinatorics/versions/0.2.2/requires
+++ b/Combinatorics/versions/0.2.2/requires
@@ -1,0 +1,3 @@
+julia 0.4
+Polynomials
+Iterators

--- a/Combinatorics/versions/0.2.2/sha1
+++ b/Combinatorics/versions/0.2.2/sha1
@@ -1,0 +1,1 @@
+92f47e4647ebd6eb5feec06f2ea46b430a1e7c66

--- a/MLBase/versions/0.5.3/requires
+++ b/MLBase/versions/0.5.3/requires
@@ -1,0 +1,6 @@
+julia 0.3
+Reexport
+ArrayViews 0.4.8-
+StatsBase 0.6.9-
+Iterators
+Compat

--- a/MLBase/versions/0.5.3/sha1
+++ b/MLBase/versions/0.5.3/sha1
@@ -1,0 +1,1 @@
+efe2c38e5c54a3a5a1525092cea2ce67da4299bf


### PR DESCRIPTION
Combinatorics v0.2.2 has the methods from `Base` expunged (leaving them only on the v0.3.x branch which is Julia 0.5-only)

cc: @spencerlyon2 

---

MLBase v0.5.3 is tagged to propagate fix for deprecation warnings on Julia 0.4 introduced in JuliaStats/MLBase.jl#25

Ref: JuliaStats/MLBase.jl#27 