### PR TITLE
upper bound on MathProgBase dependencies for Convex.jl

### DIFF
--- a/Convex/versions/0.0.1/requires
+++ b/Convex/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.3
-MathProgBase 0.3.1
+MathProgBase 0.3.1 0.4
 ECOS

--- a/Convex/versions/0.0.2/requires
+++ b/Convex/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.3
-MathProgBase 0.3.8
+MathProgBase 0.3.8 0.4
 ECOS 0.4.1

--- a/Convex/versions/0.0.3/requires
+++ b/Convex/versions/0.0.3/requires
@@ -1,2 +1,2 @@
 julia 0.3
-MathProgBase 0.3.8
+MathProgBase 0.3.8 0.4

--- a/Convex/versions/0.0.4/requires
+++ b/Convex/versions/0.0.4/requires
@@ -1,2 +1,2 @@
 julia 0.3
-MathProgBase 0.3.8
+MathProgBase 0.3.8 0.4

--- a/Convex/versions/0.0.5/requires
+++ b/Convex/versions/0.0.5/requires
@@ -1,3 +1,3 @@
 julia 0.3
-MathProgBase 0.3.8
+MathProgBase 0.3.8 0.4
 Compat 0.4.4

--- a/Convex/versions/0.0.6/requires
+++ b/Convex/versions/0.0.6/requires
@@ -1,3 +1,3 @@
 julia 0.3
-MathProgBase 0.3.8
+MathProgBase 0.3.8 0.4
 Compat 0.4.4

--- a/Convex/versions/0.1.0/requires
+++ b/Convex/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.3
-MathProgBase 0.3.8
+MathProgBase 0.3.8 0.4
 Compat 0.4.4
 DataStructures


### PR DESCRIPTION
This will keep things working until Convex.jl is updated for MathProgBase 0.5. Only the most recent tag (0.2.0) had a safe upper bound on the dependency.
CC @madeleineudell @tkelman