### PR TITLE
bump minimum julia version on previous tag of VideoIO

### DIFF
--- a/VideoIO/versions/0.0.15/requires
+++ b/VideoIO/versions/0.0.15/requires
@@ -1,4 +1,4 @@
-julia v0.3
+julia v0.4
 Compat
 ZipFile
 BinDeps v0.3.4


### PR DESCRIPTION
ref #5177 and #5182 - this tag was broken on Julia 0.3

cc @kmsquire