### PR TITLE
Fix redirects

### DIFF
--- a/.test/update-redirects.jl
+++ b/.test/update-redirects.jl
@@ -1,0 +1,70 @@
+using Requests, URIParser, ProgressMeter
+fix = true && !("--dry-run" in ARGS)
+tofix = []
+@showprogress for pkg in readdir(Pkg.dir("METADATA"))
+    urlfile = Pkg.dir("METADATA", pkg, "url")
+    if isfile(urlfile)
+        url = readchomp(urlfile)
+        req = get(replace(replace(url, "git://", "https://"),
+            ".jl.git", ".jl"); allow_redirects = false)
+        if !(endswith(url, "/$pkg.jl.git") #= || endswith(url, "/$pkg.jl") =# )
+            println()
+            warn("Unexpected end of url for $pkg: $url")
+        end
+        if statuscode(req) == 404
+            println()
+            info("$pkg Not Found")
+            push!(tofix, (pkg, urlfile, url, req))
+        elseif statuscode(req) == 301
+            println()
+            info("$pkg relocated from $url to $(req.headers["Location"])")
+            push!(tofix, (pkg, urlfile, url, req))
+        elseif statuscode(req) != 200
+            println()
+            warn("$pkg unexpected status: $req")
+        end
+    else
+        println()
+        println("No url file for $pkg")
+    end
+end
+if fix
+    info("Fixing redirects")
+    for (pkg, urlfile, url, req) in tofix
+        uri = URI(url)
+        if uri.host != "github.com"
+            warn("Skipping non-github package at $url")
+            continue
+        end
+        status = statuscode(req)
+        if endswith(uri.path, "/$pkg.jl.git")
+            if status == 404
+                newurl = "$(uri.scheme)://github.com/JuliaPackageMirrors/$pkg.jl.git"
+            elseif status == 301
+                reluri = URI(req.headers["Location"])
+                if reluri.host != "github.com"
+                    warn("Skipping non-github redirect at $reluri")
+                    continue
+                end
+                if endswith(reluri.path, "/$pkg.jl")
+                    newurl = "$(uri.scheme)://github.com$(reluri.path).git"
+                else
+                    warn("Not changing $url to $reluri because of unexpected end of new url")
+                    continue
+                end
+            end
+            newreq = get(replace(replace(newurl, "git://", "https://"),
+                ".jl.git", ".jl"); allow_redirects = false)
+            if statuscode(newreq) == 200
+                info("Replacing $url with $newurl")
+                open(urlfile, "w") do f
+                    println(f, newurl)
+                end
+            else
+                warn("Package from $url returned $status but not found at $newurl")
+            end
+        else
+            warn("Not fixing $status from $url because of unexpected end of url")
+        end
+    end
+end

--- a/AWS/url
+++ b/AWS/url
@@ -1,1 +1,1 @@
-git://github.com/amitmurthy/AWS.jl.git
+git://github.com/JuliaParallel/AWS.jl.git

--- a/Bootstrap/url
+++ b/Bootstrap/url
@@ -1,1 +1,1 @@
-git://github.com/julian-gehring/Bootstrap.jl.git
+git://github.com/juliangehring/Bootstrap.jl.git

--- a/DReal/url
+++ b/DReal/url
@@ -1,1 +1,1 @@
-git://github.com/dreal/dReal.jl.git
+git://github.com/dreal/DReal.jl.git

--- a/Discretizers/url
+++ b/Discretizers/url
@@ -1,1 +1,1 @@
-git://github.com/tawheeler/Discretizers.jl.git
+git://github.com/sisl/Discretizers.jl.git

--- a/Formatting/url
+++ b/Formatting/url
@@ -1,1 +1,1 @@
-git://github.com/lindahua/Formatting.jl.git
+git://github.com/JuliaLang/Formatting.jl.git

--- a/FreeType/url
+++ b/FreeType/url
@@ -1,1 +1,1 @@
-git://github.com/jhasse/FreeType.jl.git
+git://github.com/JuliaGraphics/FreeType.jl.git

--- a/JDBC/url
+++ b/JDBC/url
@@ -1,1 +1,1 @@
-git://github.com/aviks/JDBC.jl.git
+git://github.com/JuliaDB/JDBC.jl.git

--- a/JLDArchives/url
+++ b/JLDArchives/url
@@ -1,1 +1,1 @@
-git://github.com/timholy/JLDArchives.jl.git
+git://github.com/JuliaIO/JLDArchives.jl.git

--- a/Jewel/url
+++ b/Jewel/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/Jewel.jl.git
+git://github.com/JuliaIDE/Jewel.jl.git

--- a/KDTrees/url
+++ b/KDTrees/url
@@ -1,1 +1,1 @@
-git://github.com/KristofferC/KDTrees.jl.git
+git://github.com/JuliaGeometry/KDTrees.jl.git

--- a/LNR/url
+++ b/LNR/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/LNR.jl.git
+git://github.com/JunoLab/LNR.jl.git

--- a/Lazy/url
+++ b/Lazy/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/Lazy.jl.git
+git://github.com/MikeInnes/Lazy.jl.git

--- a/MacroTools/url
+++ b/MacroTools/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/MacroTools.jl.git
+git://github.com/MikeInnes/MacroTools.jl.git

--- a/Markdown/url
+++ b/Markdown/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/Markdown.jl.git
+git://github.com/JuliaArchive/Markdown.jl.git

--- a/MathLink/url
+++ b/MathLink/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/MathLink.jl.git
+git://github.com/MikeInnes/MathLink.jl.git

--- a/Mathematica/url
+++ b/Mathematica/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/Mathematica.jl.git
+git://github.com/MikeInnes/Mathematica.jl.git

--- a/Miniball/url
+++ b/Miniball/url
@@ -1,1 +1,1 @@
-git://github.com/JuliaFEM/MiniBall.jl.git
+git://github.com/JuliaFEM/Miniball.jl.git

--- a/MultidimensionalTables/url
+++ b/MultidimensionalTables/url
@@ -1,1 +1,1 @@
-git://github.com/c-s/MultidimensionalTables.jl.git
+git://github.com/JuliaPackageMirrors/MultidimensionalTables.jl.git

--- a/MultipleTesting/url
+++ b/MultipleTesting/url
@@ -1,1 +1,1 @@
-git://github.com/julian-gehring/MultipleTesting.jl.git
+git://github.com/juliangehring/MultipleTesting.jl.git

--- a/ObjectiveC/url
+++ b/ObjectiveC/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/ObjectiveC.jl.git
+git://github.com/MikeInnes/ObjectiveC.jl.git

--- a/Pardiso/url
+++ b/Pardiso/url
@@ -1,1 +1,1 @@
-git://github.com/KristofferC/Pardiso.jl.git
+git://github.com/JuliaSparse/Pardiso.jl.git

--- a/Requires/url
+++ b/Requires/url
@@ -1,1 +1,1 @@
-git://github.com/one-more-minute/Requires.jl.git
+git://github.com/MikeInnes/Requires.jl.git

--- a/SQLite/url
+++ b/SQLite/url
@@ -1,1 +1,1 @@
-git://github.com/quinnj/SQLite.jl.git
+git://github.com/JuliaDB/SQLite.jl.git

--- a/SignedDistanceFields/url
+++ b/SignedDistanceFields/url
@@ -1,1 +1,1 @@
-git://github.com/yurivish/SignedDistanceFields.jl.git
+git://github.com/JuliaGraphics/SignedDistanceFields.jl.git

--- a/Soundex/url
+++ b/Soundex/url
@@ -1,1 +1,1 @@
-git://github.com/JuliaArchive/Soundex.jl.git
+git://github.com/johnmyleswhite/Soundex.jl.git

--- a/SpikingNetworks/url
+++ b/SpikingNetworks/url
@@ -1,1 +1,1 @@
-git://github.com/YaoLuCNS/SpikingNetworks.jl.git
+git://github.com/AStupidBear/SpikingNetworks.jl.git

--- a/VLFeat/url
+++ b/VLFeat/url
@@ -1,1 +1,1 @@
-git://github.com/IHPostal/VLFeat.jl.git
+git://github.com/IHPSystems/VLFeat.jl.git

--- a/VML/url
+++ b/VML/url
@@ -1,1 +1,1 @@
-git://github.com/simonster/VML.jl.git
+git://github.com/JuliaLang/VML.jl.git

--- a/VStatistic/url
+++ b/VStatistic/url
@@ -1,1 +1,1 @@
-git://github.com/dostodabsi/VStatistic.jl.git
+git://github.com/fdabl/VStatistic.jl.git


### PR DESCRIPTION
And add the script I used to do so. Takes about 4 minutes to run with the current size of METADATA (with some async or only requesting headers you could probably make it much faster, I didn't bother for now) which is a bit too large to run on Travis every time, and these redirects are subject to happen arbitrarily when people rename their accounts or move things rather than just as a consequence of proposed changes here in METADATA.