### PR TITLE
Tag PyLCM v0.0.3

### DIFF
--- a/PyLCM/versions/0.0.3/requires
+++ b/PyLCM/versions/0.0.3/requires
@@ -1,0 +1,5 @@
+julia 0.4
+PyCall
+BinDeps
+Compat
+@osx Homebrew

--- a/PyLCM/versions/0.0.3/sha1
+++ b/PyLCM/versions/0.0.3/sha1
@@ -1,0 +1,1 @@
+d90a709cc5b6a12c4de0ed400ceb851ea47394af


### PR DESCRIPTION
This version brings in fixes related to precompilation with Python modules and fixes the build process for PackageEvaluator and OSX on Travis. 