### PR TITLE
Fix Optim version for NLsolve

### DIFF
--- a/KernelEstimator/versions/0.1.7/requires
+++ b/KernelEstimator/versions/0.1.7/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Distributions
-Optim 0.0 0.5
+Optim
 StatsBase
 Cubature
 Compat

--- a/NLsolve/versions/0.7.1/requires
+++ b/NLsolve/versions/0.7.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Optim 0.0 0.5
+Optim
 Calculus
 ForwardDiff 0.1.4 0.2
 Distances


### PR DESCRIPTION
ref https://github.com/JuliaOpt/Optim.jl/issues/217

It only uses linesearch, so it's not affected. I've run the tests in the package as an extra check.

The KernelEstimators will run fine as well.