### PR TITLE
Register DC.jl

### DIFF
--- a/DC/url
+++ b/DC/url
@@ -1,0 +1,1 @@
+git://github.com/tawheeler/DC.jl.git


### PR DESCRIPTION
I would like to register DC.jl -a Julia package for automagical DC.js linked charts in your IJulia notebook.

The base api is extremely simple - `dc(::DataFrame)`

Advanced users still have access to what is generated.

Preemptive Concern: I understand that package names should be as general as possible. This package produces visualizations using the DC.js package, hence its name. DC.js stands for D3 and Crossfilter, and D3Crossfilter.jl sounds like a horrible package name. Please let me know if you think of something better, or if naming it DC.jl is a non-issue.
