### PR TITLE
Tag FixedSizeArrays v0.2.1

### DIFF
--- a/FixedSizeArrays/versions/0.2.1/requires
+++ b/FixedSizeArrays/versions/0.2.1/requires
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.7.15

--- a/FixedSizeArrays/versions/0.2.1/sha1
+++ b/FixedSizeArrays/versions/0.2.1/sha1
@@ -1,0 +1,1 @@
+bc3c8fe24e49e422ca276deca4797ddad7a1dc4d


### PR DESCRIPTION
A quick fix for a depwarn oversight in 0.2.0 see #5357 

cc @SimonDanisch Changes here are very minimal vs 0.2.0, I wanted to get this in quickly to fix problems with GeometryTypes tests (which in any case should be upgraded for the new API, but shouldn't just have broken without a depwarn.)