### PR TITLE
Bound JSON for packages that PkgEval identified as being broken by 0.6.0

### DIFF
--- a/GeoJSON/versions/0.0.1/requires
+++ b/GeoJSON/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.3
-JSON
+JSON 0.0 0.6
 Compat

--- a/GeoJSON/versions/0.0.2/requires
+++ b/GeoJSON/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.3
-JSON
+JSON 0.0 0.6
 Compat

--- a/GeoJSON/versions/0.0.3/requires
+++ b/GeoJSON/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.3
-JSON
+JSON 0.0 0.6
 Compat

--- a/Plotly/versions/0.0.1/requires
+++ b/Plotly/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 HTTPClient
-JSON
+JSON 0.0 0.6

--- a/Plotly/versions/0.0.2/requires
+++ b/Plotly/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 HTTPClient
-JSON
+JSON 0.0 0.6

--- a/Plotly/versions/0.0.3/requires
+++ b/Plotly/versions/0.0.3/requires
@@ -1,2 +1,2 @@
 HTTPClient
-JSON
+JSON 0.0 0.6

--- a/Plotly/versions/0.1.0/requires
+++ b/Plotly/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 Requests 0.3.5
-JSON
+JSON 0.0 0.6
 PlotlyJS 0.2.0
 Compat 0.7.20
 Reexport

--- a/Requests/versions/0.0.2/requires
+++ b/Requests/versions/0.0.2/requires
@@ -3,4 +3,4 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6

--- a/Requests/versions/0.0.3/requires
+++ b/Requests/versions/0.0.3/requires
@@ -3,4 +3,4 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6

--- a/Requests/versions/0.0.4/requires
+++ b/Requests/versions/0.0.4/requires
@@ -3,4 +3,4 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6

--- a/Requests/versions/0.0.5/requires
+++ b/Requests/versions/0.0.5/requires
@@ -3,4 +3,4 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6

--- a/Requests/versions/0.0.6/requires
+++ b/Requests/versions/0.0.6/requires
@@ -3,4 +3,4 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6

--- a/Requests/versions/0.0.7/requires
+++ b/Requests/versions/0.0.7/requires
@@ -3,5 +3,5 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat

--- a/Requests/versions/0.0.8/requires
+++ b/Requests/versions/0.0.8/requires
@@ -4,5 +4,5 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat

--- a/Requests/versions/0.1.0/requires
+++ b/Requests/versions/0.1.0/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat
 Zlib

--- a/Requests/versions/0.1.1/requires
+++ b/Requests/versions/0.1.1/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat
 Zlib

--- a/Requests/versions/0.2.0/requires
+++ b/Requests/versions/0.2.0/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat
 Zlib

--- a/Requests/versions/0.2.1/requires
+++ b/Requests/versions/0.2.1/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat
 Zlib

--- a/Requests/versions/0.2.2/requires
+++ b/Requests/versions/0.2.2/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat
 Zlib

--- a/Requests/versions/0.2.3/requires
+++ b/Requests/versions/0.2.3/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat
 Zlib

--- a/Requests/versions/0.2.4/requires
+++ b/Requests/versions/0.2.4/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat
 Zlib

--- a/Requests/versions/0.3.0/requires
+++ b/Requests/versions/0.3.0/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Compat
 Zlib

--- a/Requests/versions/0.3.1/requires
+++ b/Requests/versions/0.3.1/requires
@@ -4,5 +4,5 @@ HttpParser
 URIParser
 MbedTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Zlib

--- a/Requests/versions/0.3.2/requires
+++ b/Requests/versions/0.3.2/requires
@@ -4,5 +4,5 @@ HttpParser
 URIParser
 MbedTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Zlib

--- a/Requests/versions/0.3.3/requires
+++ b/Requests/versions/0.3.3/requires
@@ -4,5 +4,5 @@ HttpParser
 URIParser
 MbedTLS
 Codecs
-JSON
+JSON 0.0 0.6
 Libz

--- a/Requests/versions/0.3.4/requires
+++ b/Requests/versions/0.3.4/requires
@@ -4,5 +4,5 @@ HttpParser
 URIParser 0.1.1
 MbedTLS 0.1.4
 Codecs
-JSON
+JSON 0.0 0.6
 Libz

--- a/Requests/versions/0.3.5/requires
+++ b/Requests/versions/0.3.5/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser 0.1.1
 MbedTLS 0.2.1
 Codecs
-JSON
+JSON 0.0 0.6
 Libz
 Compat 0.7.9

--- a/Requests/versions/0.3.6/requires
+++ b/Requests/versions/0.3.6/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser 0.1.1
 MbedTLS 0.2.1
 Codecs
-JSON
+JSON 0.0 0.6
 Libz
 Compat 0.7.9

--- a/Requests/versions/0.3.7/requires
+++ b/Requests/versions/0.3.7/requires
@@ -4,6 +4,6 @@ HttpParser
 URIParser 0.1.1
 MbedTLS 0.2.1
 Codecs
-JSON
+JSON 0.0 0.6
 Libz
 Compat 0.7.9

--- a/Restful/versions/0.0.4/requires
+++ b/Restful/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 julia 0.4
 HttpServer
-JSON
+JSON 0.0 0.6
 Requests
 URIParser

--- a/Restful/versions/0.1.0/requires
+++ b/Restful/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 HttpServer
-JSON
+JSON 0.0 0.6
 Requests
 URIParser

--- a/Restful/versions/0.2.0/requires
+++ b/Restful/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 HttpServer
-JSON
+JSON 0.0 0.6
 Requests
 URIParser

--- a/Swifter/versions/0.0.1/requires
+++ b/Swifter/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Requests
-JSON
+JSON 0.0 0.6

--- a/Swifter/versions/0.0.2/requires
+++ b/Swifter/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Requests
-JSON
+JSON 0.0 0.6

--- a/Swifter/versions/0.0.3/requires
+++ b/Swifter/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Requests
-JSON
+JSON 0.0 0.6

--- a/Swifter/versions/0.0.4/requires
+++ b/Swifter/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Requests
-JSON
+JSON 0.0 0.6

--- a/Swifter/versions/0.0.5/requires
+++ b/Swifter/versions/0.0.5/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Requests
-JSON
+JSON 0.0 0.6

--- a/Swifter/versions/0.0.6/requires
+++ b/Swifter/versions/0.0.6/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Requests
-JSON
+JSON 0.0 0.6


### PR DESCRIPTION
ref https://github.com/JuliaLang/METADATA.jl/pull/5385, these are packages that PkgEval identified as broken by the JSON rewrite. Mostly of the form "Expected end of input," see http://pkg.julialang.org/pulse.html for more details.

cc @TotalVerb, I'm guessing you didn't expect this much breakage
cc @yeesian and @garborg on GeoJSON
plotly is already being fixed apparently
cc @malmaud on Requests
cc @ylxdzsw on Restful
cc @wookay on Swifter

Easiest would be if this can be fixed in JSON, but maybe it's just more picky now. Could easily have missed more packages than this that don't currently pass their tests on PkgEval.