### PR TITLE
Add upper bound on LeastSquaresOptim's ForwardDiff requirement

### DIFF
--- a/LeastSquaresOptim/versions/0.0.1/requires
+++ b/LeastSquaresOptim/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-ForwardDiff 0.1.1
+ForwardDiff 0.1.1 0.2

--- a/LeastSquaresOptim/versions/0.0.2/requires
+++ b/LeastSquaresOptim/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 julia 0.4
-ForwardDiff 0.1.1
+ForwardDiff 0.1.1 0.2

--- a/LeastSquaresOptim/versions/0.0.3/requires
+++ b/LeastSquaresOptim/versions/0.0.3/requires
@@ -1,2 +1,2 @@
 julia 0.4
-ForwardDiff 0.1.1
+ForwardDiff 0.1.1 0.2


### PR DESCRIPTION
ref #5389, jacobian is now gone in 0.2.0

cc @jrevels @matthieugomez 

there's also a new failure in CoordinateTransformations.jl, cc @andyferris, but since that only depends on ForwardDiff in `test/REQUIRE` it needs a new tag to fix.