### PR TITLE
Update LeastSquaresOptim

### DIFF
--- a/LeastSquaresOptim/versions/0.1.0/requires
+++ b/LeastSquaresOptim/versions/0.1.0/requires
@@ -1,0 +1,2 @@
+julia 0.4
+ForwardDiff 0.1.1

--- a/LeastSquaresOptim/versions/0.1.0/sha1
+++ b/LeastSquaresOptim/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+89ed22bd398b8e0f5119af981fa20abdfa9b9a33


### PR DESCRIPTION
Includes compatibility with ForwardDiff 0.2.0 #5400