### PR TITLE
add an unnecessary JSON dependency with bound to Requests 0.0.1

### DIFF
--- a/Requests/versions/0.0.1/requires
+++ b/Requests/versions/0.0.1/requires
@@ -3,3 +3,4 @@ HttpParser
 URIParser
 GnuTLS
 Codecs
+JSON 0.0 0.6


### PR DESCRIPTION
#5398 had some unintended consequences where if you have the newest
JSON installed and want to install Requests, it prefers installing Requests
0.0.1 instead of downgrading JSON to 0.5.3. JSON may not have been required
here but adding it with an upper bound should make the package resolution better.