### PR TITLE
Tag WAV v0.8.0 [git://github.com/dancasimiro/WAV.jl.git]

### DIFF
--- a/WAV/versions/0.8.0/requires
+++ b/WAV/versions/0.8.0/requires
@@ -1,0 +1,3 @@
+julia 0.4
+Compat 0.8.0
+FileIO 0.0.2

--- a/WAV/versions/0.8.0/sha1
+++ b/WAV/versions/0.8.0/sha1
@@ -1,0 +1,1 @@
+6dfa91602f85725eeac0bdeee1a83b2a6f1cb238


### PR DESCRIPTION
Fixes dancasimiro/WAV.jl#35
Various syntax updates for Julia v0.5.0
Drop support for Julia v0.3.x