### PR TITLE
Fix Plotly/PlotlyJS bounds

### DIFF
--- a/Plotly/versions/0.0.1/requires
+++ b/Plotly/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 HTTPClient
-JSON 0.0 0.6
+JSON

--- a/Plotly/versions/0.0.2/requires
+++ b/Plotly/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 HTTPClient
-JSON 0.0 0.6
+JSON

--- a/Plotly/versions/0.0.3/requires
+++ b/Plotly/versions/0.0.3/requires
@@ -1,2 +1,2 @@
 HTTPClient
-JSON 0.0 0.6
+JSON

--- a/Plotly/versions/0.1.0/requires
+++ b/Plotly/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 Requests 0.3.5
-JSON 0.0 0.6
+JSON
 PlotlyJS 0.2.0
 Compat 0.7.20
 Reexport

--- a/PlotlyJS/versions/0.1.0/requires
+++ b/PlotlyJS/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON 0.0 0.5.2
+JSON 0.0 0.6
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.0/requires
+++ b/PlotlyJS/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON
+JSON 0.0 0.5.2
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.1/requires
+++ b/PlotlyJS/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON 0.0 0.5.2
+JSON 0.0 0.6
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.1/requires
+++ b/PlotlyJS/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON
+JSON 0.0 0.5.2
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.2/requires
+++ b/PlotlyJS/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON 0.0 0.5.2
+JSON 0.0 0.6
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.2/requires
+++ b/PlotlyJS/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON
+JSON 0.0 0.5.2
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.3/requires
+++ b/PlotlyJS/versions/0.1.3/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON 0.0 0.5.2
+JSON 0.0 0.6
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.3/requires
+++ b/PlotlyJS/versions/0.1.3/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON
+JSON 0.0 0.5.2
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.4/requires
+++ b/PlotlyJS/versions/0.1.4/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON 0.0 0.5.2
+JSON 0.0 0.6
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.1.4/requires
+++ b/PlotlyJS/versions/0.1.4/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON
+JSON 0.0 0.5.2
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.2.0/requires
+++ b/PlotlyJS/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON 0.0 0.5.2
+JSON 0.0 0.6
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.2.0/requires
+++ b/PlotlyJS/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-JSON
+JSON 0.0 0.5.2
 Blink 0.3.3
 Colors

--- a/PlotlyJS/versions/0.3.0/requires
+++ b/PlotlyJS/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-JSON
+JSON 0.5.3
 Blink 0.3.3
 Colors
 Compat 0.7.16

--- a/PlotlyJS/versions/0.3.0/requires
+++ b/PlotlyJS/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-JSON 0.5.3
+JSON 0.6
 Blink 0.3.3
 Colors
 Compat 0.7.16


### PR DESCRIPTION
 - Plotly does not require any particular version of JSON
 - PlotlyJS versions before 0.3.0 require at most 0.5.1. Changes introduced in 0.5.2 and kept in 0.5.3 broke PlotlyJS.
 - PlotlyJS versions 0.3.0 or later require at least 0.5.2. I set it to 0.5.3 to avoid downgrade/upgrade surprises, since 0.5.2 is the same as 0.6.