### PR TITLE
Run Travis test on 0.4 and 0.5, add Julia upper bounds on some old BayesNets tags

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -1,3 +1,7 @@
+if VERSION < v"0.4-"
+    startswith = beginswith
+end
+
 const url_reg = r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?"
 const gh_path_reg_git=r"^/(.*)?/(.*)?.git$"
 
@@ -501,7 +505,10 @@ for pkg in readdir("METADATA")
 end
 
 info("Verifying METADATA...")
-run(setenv(`git checkout -b makegithappy`, dir="METADATA"))
-Pkg.add("PkgDev")
-import PkgDev
-PkgDev.Entry.check_metadata()
+if isdefined(Pkg.Entry, :check_metadata)
+    Pkg.Entry.check_metadata()
+else
+    Pkg.add("PkgDev")
+    import PkgDev
+    PkgDev.Entry.check_metadata()
+end

--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -1,7 +1,3 @@
-if VERSION < v"0.4-"
-    startswith = beginswith
-end
-
 const url_reg = r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?"
 const gh_path_reg_git=r"^/(.*)?/(.*)?.git$"
 
@@ -505,4 +501,7 @@ for pkg in readdir("METADATA")
 end
 
 info("Verifying METADATA...")
-Pkg.Entry.check_metadata()
+run(setenv(`git checkout -b makegithappy`, dir="METADATA"))
+Pkg.add("PkgDev")
+import PkgDev
+PkgDev.Entry.check_metadata()

--- a/.test/travis.sh
+++ b/.test/travis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+cd $(dirname $0)/..
+git checkout -b localbranch
+cd ..
+ln -s $PWD/METADATA.jl METADATA
+for ver in 0.4 0.5; do # add 0.6 once nightly is 0.6-dev
+  mkdir -p ~/.julia/v$ver julia-$ver
+  ln -s $PWD/METADATA.jl ~/.julia/v$ver/METADATA
+  if [ $ver = 0.6 ]; then
+    url="julianightlies/bin/linux/x64/julia-latest-linux64"
+  else
+    url="julialang/bin/linux/x64/$ver/julia-$ver-latest-linux-x86_64"
+  fi
+  curl -L --retry 5 https://s3.amazonaws.com/$url.tar.gz | \
+    tar -C julia-$ver --strip-components=1 -xzf - && \
+    julia-$ver/bin/julia -e 'versioninfo(); include("METADATA/.test/METADATA.jl")' && \
+    touch success-$ver &
+done
+wait
+if ! [ -e success-0.4 -a -e success-0.5 ]; then # add success-0.6 once nightly is 0.6-dev
+  exit 1
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: julia
 julia:
-    - 0.4
+    - nightly
 sudo: false # use a docker worker for hopefully faster queue times
 notifications:
     email: false
 script:
     - cd ..
-    - ln -s METADATA.jl METADATA
+    - ln -s $PWD/METADATA.jl METADATA
+    - mkdir -p ~/.julia/v0.5 ~/.julia/v0.6
+    - ln -s $PWD/METADATA.jl ~/.julia/v0.5/METADATA
+    - ln -s $PWD/METADATA.jl ~/.julia/v0.6/METADATA # future proof a little
     - julia METADATA/.test/METADATA.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
-language: julia
-julia:
-    - nightly
+language: generic
 sudo: false # use a docker worker for hopefully faster queue times
 notifications:
     email: false
 script:
-    - cd ..
-    - ln -s $PWD/METADATA.jl METADATA
-    - mkdir -p ~/.julia/v0.5 ~/.julia/v0.6
-    - ln -s $PWD/METADATA.jl ~/.julia/v0.5/METADATA
-    - ln -s $PWD/METADATA.jl ~/.julia/v0.6/METADATA # future proof a little
-    - julia METADATA/.test/METADATA.jl
+    - sh .test/travis.sh

--- a/BayesNets/versions/0.0.1/requires
+++ b/BayesNets/versions/0.0.1/requires
@@ -1,3 +1,3 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames

--- a/BayesNets/versions/0.0.10/requires
+++ b/BayesNets/versions/0.0.10/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.0.2/requires
+++ b/BayesNets/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.0.3/requires
+++ b/BayesNets/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.0.4/requires
+++ b/BayesNets/versions/0.0.4/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.0.5/requires
+++ b/BayesNets/versions/0.0.5/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.0.6/requires
+++ b/BayesNets/versions/0.0.6/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.0.7/requires
+++ b/BayesNets/versions/0.0.7/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.0.8/requires
+++ b/BayesNets/versions/0.0.8/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.0.9/requires
+++ b/BayesNets/versions/0.0.9/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs

--- a/BayesNets/versions/0.1.0/requires
+++ b/BayesNets/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3- 0.5.0-rc0
 Graphs
 DataFrames
 TikzGraphs


### PR DESCRIPTION
otherwise packages that are 0.5-only do not get verified

I suspect this will fail because #5453 put METADATA in an invalid state on nightly. @Keno please use PkgDev.publish so your metadata changes get verified locally.