### PR TITLE
Register CUDAdrv

### DIFF
--- a/CUDAdrv/url
+++ b/CUDAdrv/url
@@ -1,0 +1,1 @@
+git://github.com/JuliaGPU/CUDAdrv.jl.git

--- a/CUDAdrv/versions/0.1.0/requires
+++ b/CUDAdrv/versions/0.1.0/requires
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.7.20

--- a/CUDAdrv/versions/0.1.0/sha1
+++ b/CUDAdrv/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+c0cb8c0ea447ab4c9943e2a3653b0cebf8feb216


### PR DESCRIPTION
CUDA driver wrapper (split off of EOL'd CUDA.jl + CUDAnative.jl) for reuse in CUDArt.jl and CUDAnative.jl