### PR TITLE
Tag Chemfiles v0.6.0

### DIFF
--- a/Chemfiles/versions/0.6.0/requires
+++ b/Chemfiles/versions/0.6.0/requires
@@ -1,0 +1,5 @@
+julia 0.4
+BinDeps
+Compat
+@unix Conda 0.2
+@windows WinRPM

--- a/Chemfiles/versions/0.6.0/sha1
+++ b/Chemfiles/versions/0.6.0/sha1
@@ -1,0 +1,1 @@
+980d92c5f67ea6ccf2c745ee49ce5fd30edb86be


### PR DESCRIPTION
I still have a build failure on win32-0.5.0 (https://ci.appveyor.com/project/Luthaf/chemfiles-jl/build/53), which is due to https://github.com/JuliaLang/WinRPM.jl/issues/76. I am nevertheless in favour of merging this, 0.5.0 is a nightly version.