### PR TITLE
Register Git.jl

### DIFF
--- a/Git/url
+++ b/Git/url
@@ -1,0 +1,1 @@
+git://github.com/JuliaPackaging/Git.jl.git

--- a/Git/versions/0.1.0/requires
+++ b/Git/versions/0.1.0/requires
@@ -1,0 +1,4 @@
+julia 0.4
+Compat 0.8.4
+BinDeps
+@osx Homebrew

--- a/Git/versions/0.1.0/sha1
+++ b/Git/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+2ffbf6eb79929e54deed706fd84ab8e3e74bf79c


### PR DESCRIPTION
https://github.com/JuliaPackaging/Git.jl (still needs moar docs)
ref https://github.com/JuliaLang/julia/pull/17294, this is the `Git` module that was formerly part of Base but is no longer used by the package manager on 0.5 so is being removed