### PR TITLE
Make StatsFuns 0.3.0 require Julia 0.5- temporarily

### DIFF
--- a/StatsFuns/versions/0.3.0/requires
+++ b/StatsFuns/versions/0.3.0/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.5-
 Compat 0.8.4
 Rmath 0.1.0


### PR DESCRIPTION
Everything in JuliaStats is on fire and broken because of StatsFuns 0.3.0, so might be best to do this until we can get things sorted out. As suggested by @tkelman.
