### PR TITLE
Revert "Make StatsFuns 0.3.0 require Julia 0.5- temporarily"

### DIFF
--- a/StatsFuns/versions/0.3.0/requires
+++ b/StatsFuns/versions/0.3.0/requires
@@ -1,3 +1,3 @@
-julia 0.5-
+julia 0.4
 Compat 0.8.4
 Rmath 0.1.0


### PR DESCRIPTION
Reverts JuliaLang/METADATA.jl#5624

once we do https://github.com/JuliaLang/METADATA.jl/pull/5613 then this should be safe again. @ararslan or @andreasnoack correct me if I'm wrong.