### PR TITLE
LightGraphs: Add 0.9.0 as an upper bound on StatsBase requirement

### DIFF
--- a/LightGraphs/versions/0.1.0/requires
+++ b/LightGraphs/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.1/requires
+++ b/LightGraphs/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.10/requires
+++ b/LightGraphs/versions/0.1.10/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.11/requires
+++ b/LightGraphs/versions/0.1.11/requires
@@ -4,3 +4,4 @@ GZip 0.2
 Distributions 0.6.6
 DataStructures 0.3
 LightXML 0.1.10
+StatsBase 0.6 0.9.0

--- a/LightGraphs/versions/0.1.12/requires
+++ b/LightGraphs/versions/0.1.12/requires
@@ -4,3 +4,4 @@ GZip 0.2
 Distributions 0.6.6
 DataStructures 0.3
 LightXML 0.1.10
+StatsBase 0.6 0.9.0

--- a/LightGraphs/versions/0.1.13/requires
+++ b/LightGraphs/versions/0.1.13/requires
@@ -4,4 +4,5 @@ GZip 0.2
 Distributions 0.6.6
 DataStructures 0.3
 LightXML 0.1.10
-Docile 0.5.3 
+Docile 0.5.3
+StatsBase 0.6 0.9.0

--- a/LightGraphs/versions/0.1.14/requires
+++ b/LightGraphs/versions/0.1.14/requires
@@ -4,4 +4,5 @@ GZip 0.2
 Distributions 0.6.6
 DataStructures 0.3
 LightXML 0.1.10
-Docile 0.5.3 
+Docile 0.5.3
+StatsBase 0.6 0.9.0

--- a/LightGraphs/versions/0.1.15/requires
+++ b/LightGraphs/versions/0.1.15/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.1.10
 Docile 0.5.3

--- a/LightGraphs/versions/0.1.2/requires
+++ b/LightGraphs/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.3/requires
+++ b/LightGraphs/versions/0.1.3/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.4/requires
+++ b/LightGraphs/versions/0.1.4/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.5/requires
+++ b/LightGraphs/versions/0.1.5/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.6/requires
+++ b/LightGraphs/versions/0.1.6/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.7/requires
+++ b/LightGraphs/versions/0.1.7/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.8/requires
+++ b/LightGraphs/versions/0.1.8/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.1.9/requires
+++ b/LightGraphs/versions/0.1.9/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat 0.2.6
 GZip 0.2
-StatsBase 0.6
+StatsBase 0.6 0.9.0
 DataStructures 0.3

--- a/LightGraphs/versions/0.2.0/requires
+++ b/LightGraphs/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.1.10
 Docile 0.5.3

--- a/LightGraphs/versions/0.2.1/requires
+++ b/LightGraphs/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.1.10
 Docile 0.5.3

--- a/LightGraphs/versions/0.2.2/requires
+++ b/LightGraphs/versions/0.2.2/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.1.10
 Docile 0.5.3

--- a/LightGraphs/versions/0.3.0/requires
+++ b/LightGraphs/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.2.0
 ParserCombinator 1.6.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.3.1/requires
+++ b/LightGraphs/versions/0.3.1/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.2.0
 ParserCombinator 1.6.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.3.2/requires
+++ b/LightGraphs/versions/0.3.2/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.2.0
 ParserCombinator 1.6.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.3.3/requires
+++ b/LightGraphs/versions/0.3.3/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.2.0
 ParserCombinator 1.6.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.3.4/requires
+++ b/LightGraphs/versions/0.3.4/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.2.0
 ParserCombinator 1.6.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.3.5/requires
+++ b/LightGraphs/versions/0.3.5/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.2.0
 ParserCombinator 1.7.1
 Docile 0.5.3

--- a/LightGraphs/versions/0.3.6/requires
+++ b/LightGraphs/versions/0.3.6/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.2.0
 ParserCombinator 1.7.1
 Docile 0.5.3

--- a/LightGraphs/versions/0.3.7/requires
+++ b/LightGraphs/versions/0.3.7/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat 0.4.9
 GZip 0.2.16
-StatsBase 0.6.15
+StatsBase 0.6.15 0.9.0
 LightXML 0.2.0
 ParserCombinator 1.7.1
 Docile 0.5.3

--- a/LightGraphs/versions/0.4.0/requires
+++ b/LightGraphs/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 GZip 0.2.18
-StatsBase 0.7.4
+StatsBase 0.7.4 0.9.0
 LightXML 0.2.1
 ParserCombinator 1.7.1
 Docile 0.5.3

--- a/LightGraphs/versions/0.4.1/requires
+++ b/LightGraphs/versions/0.4.1/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Requires
 GZip 0.2.18
-StatsBase 0.7.4
+StatsBase 0.7.4 0.9.0
 LightXML 0.2.1
 ParserCombinator 1.7.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.4.2/requires
+++ b/LightGraphs/versions/0.4.2/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Requires
 GZip 0.2.18
-StatsBase 0.7.4
+StatsBase 0.7.4 0.9.0
 LightXML 0.2.1
 ParserCombinator 1.7.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.5.0/requires
+++ b/LightGraphs/versions/0.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Requires
 GZip 0.2.18
-StatsBase 0.7.4
+StatsBase 0.7.4 0.9.0
 LightXML 0.2.1
 ParserCombinator 1.7.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.5.2/requires
+++ b/LightGraphs/versions/0.5.2/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Requires
 GZip 0.2.18
-StatsBase 0.7.4
+StatsBase 0.7.4 0.9.0
 LightXML 0.2.1
 ParserCombinator 1.7.3
 Docile 0.5.3

--- a/LightGraphs/versions/0.5.3/requires
+++ b/LightGraphs/versions/0.5.3/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Requires
 GZip 0.2.18
-StatsBase 0.7.4
+StatsBase 0.7.4 0.9.0
 LightXML 0.2.1
 ParserCombinator 1.7.3
 JLD

--- a/LightGraphs/versions/0.5.4/requires
+++ b/LightGraphs/versions/0.5.4/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Requires
 GZip 0.2.18
-StatsBase 0.7.4
+StatsBase 0.7.4 0.9.0
 LightXML 0.2.1
 ParserCombinator 1.7.3
 JLD

--- a/LightGraphs/versions/0.5.5/requires
+++ b/LightGraphs/versions/0.5.5/requires
@@ -1,7 +1,7 @@
 julia 0.4 0.5-
 Requires
 GZip 0.2.18
-StatsBase 0.7.4
+StatsBase 0.7.4 0.9.0
 LightXML 0.2.1
 ParserCombinator 1.7.3
 JLD


### PR DESCRIPTION
0.9.0 introduces breaking changes.

Ref https://github.com/JuliaGraphs/LightGraphs.jl/pull/383#issuecomment-233534888