### PR TITLE
Bound PATHSolver's ForwardDiff dependency to max 0.2

### DIFF
--- a/PATHSolver/versions/0.0.1/requires
+++ b/PATHSolver/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ForwardDiff
+ForwardDiff 0.0 0.2
 BinDeps

--- a/PATHSolver/versions/0.0.2/requires
+++ b/PATHSolver/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ForwardDiff
+ForwardDiff 0.0 0.2
 BinDeps

--- a/PATHSolver/versions/0.0.3/requires
+++ b/PATHSolver/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ForwardDiff
+ForwardDiff 0.0 0.2
 BinDeps

--- a/PATHSolver/versions/0.0.4/requires
+++ b/PATHSolver/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ForwardDiff
+ForwardDiff 0.0 0.2
 BinDeps

--- a/PATHSolver/versions/0.0.5/requires
+++ b/PATHSolver/versions/0.0.5/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ForwardDiff
+ForwardDiff 0.0 0.2
 BinDeps

--- a/VariationalInequality/versions/0.0.1/requires
+++ b/VariationalInequality/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
-JuMP
+JuMP 0.12
 Ipopt

--- a/VariationalInequality/versions/0.0.2/requires
+++ b/VariationalInequality/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.4
-JuMP
+JuMP 0.12
 Ipopt

--- a/VariationalInequality/versions/0.0.3/requires
+++ b/VariationalInequality/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.4
-JuMP
+JuMP 0.12
 Ipopt


### PR DESCRIPTION
on existing tags since it tries to use single-argument `jacobian(f)`, ref https://github.com/chkwon/PATHSolver.jl/blob/f0958e51cf75eefa385b549f9a1f16080bf5b3f1/src/PATHSolver.jl#L18 and https://travis-ci.org/tkelman/PATHSolver.jl/jobs/146865420

cc @chkwon @jrevels