### PR TITLE
Add minimum JuMP 0.13 bounds to recent Spectra.jl tags

### DIFF
--- a/Spectra/versions/0.0.2/requires
+++ b/Spectra/versions/0.0.2/requires
@@ -1,7 +1,7 @@
 julia 0.4
 IJulia
 PyPlot
-JuMP
+JuMP 0.13
 Ipopt
 StatsBase
 Dierckx

--- a/Spectra/versions/0.1.0/requires
+++ b/Spectra/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 IJulia
 PyPlot
-JuMP
+JuMP 0.13
 Ipopt
 StatsBase
 Dierckx

--- a/Spectra/versions/0.1.1/requires
+++ b/Spectra/versions/0.1.1/requires
@@ -1,7 +1,7 @@
 julia 0.4
 IJulia
 PyPlot
-JuMP
+JuMP 0.13
 Ipopt
 StatsBase
 Dierckx


### PR DESCRIPTION
ref https://github.com/charlesll/Spectra.jl/pull/2, cc @charlesll

This recently caused a failure on PackageEvaluator. Now I'm not sure why PackageEvaluator was using an older version of JuMP here, still digging into that.