### PR TITLE
Register LGmatching

### DIFF
--- a/LGmatching/url
+++ b/LGmatching/url
@@ -1,0 +1,1 @@
+git://github.com/JuliaGraphs/LGmatching.jl.git


### PR DESCRIPTION
LGmatching is the first of several efforts to reduce the dependencies of the core LightGraphs.jl package. In this case, JuMP was required for a single matching function.