### PR TITLE
Update ArgParse's 0.3.1 Compat requirement

### DIFF
--- a/ArgParse/versions/0.3.1/requires
+++ b/ArgParse/versions/0.3.1/requires
@@ -1,3 +1,3 @@
 julia 0.3
-Compat 0.7.3
+Compat 0.8.0
 TextWrap 0.1.4


### PR DESCRIPTION
Thanks to @abhijithch for pointing this out (see https://github.com/carlobaldassi/ArgParse.jl/pull/32).