### PR TITLE
EndpointRanges does not actually work on 0.4

### DIFF
--- a/EndpointRanges/versions/0.0.1/requires
+++ b/EndpointRanges/versions/0.0.1/requires
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.5-


### PR DESCRIPTION
it uses `indices1`, cc @timholy