### PR TITLE
add ForwardDiff 0.2 upper bound to Celeste.jl 0.1.0 tag

### DIFF
--- a/Celeste/versions/0.1.0/requires
+++ b/Celeste/versions/0.1.0/requires
@@ -3,7 +3,7 @@ Compat
 DataFrames
 Distributions
 DocOpt
-ForwardDiff
+ForwardDiff 0.0 0.2
 JLD
 Optim 0.0 0.5
 GaussianMixtures


### PR DESCRIPTION
fixes GradientNumber not defined