### PR TITLE
Tag BDF v0.1.6

### DIFF
--- a/BDF/versions/0.1.6/requires
+++ b/BDF/versions/0.1.6/requires
@@ -1,0 +1,4 @@
+Compat 0.7.18
+Docile
+HDF5
+julia 0.5-

--- a/BDF/versions/0.1.6/sha1
+++ b/BDF/versions/0.1.6/sha1
@@ -1,0 +1,1 @@
+5fe6a0b5e5a90bfc2d22cadf9dea288c122ce0b6


### PR DESCRIPTION
this version supports julia v0.5, including pre-release versions of 0.5, but not julia v0.4. I've put `julia 0.5-` in `REQUIRE` to specify this, I hope that's correct.