### PR TITLE
Tag GitHub v2.1.0 [https://github.com/JuliaWeb/GitHub.jl]

### DIFF
--- a/GitHub/versions/2.1.0/requires
+++ b/GitHub/versions/2.1.0/requires
@@ -1,0 +1,8 @@
+julia 0.4
+Compat 0.8.4
+JSON
+HttpServer
+MbedTLS
+Dates
+HttpCommon
+Requests

--- a/GitHub/versions/2.1.0/sha1
+++ b/GitHub/versions/2.1.0/sha1
@@ -1,0 +1,1 @@
+adaa80b5b1115f2b420ed7e40f773feed2ad0688


### PR DESCRIPTION
This could break packages that rely on GitHub.jl's old pagination behavior. A description of the new behavior can be found [here](https://github.com/JuliaWeb/GitHub.jl/tree/master#pagination).