### PR TITLE
Tag DataFrames 0.7.8

### DIFF
--- a/DataFrames/versions/0.7.8/requires
+++ b/DataFrames/versions/0.7.8/requires
@@ -1,0 +1,7 @@
+julia 0.4
+DataArrays 0.3.4
+StatsBase 0.8.3
+GZip
+SortingAlgorithms
+Reexport
+Compat 0.8

--- a/DataFrames/versions/0.7.8/sha1
+++ b/DataFrames/versions/0.7.8/sha1
@@ -1,0 +1,1 @@
+084bfa7bff89ac5f52b9f36c41f0adea1df0f1e5


### PR DESCRIPTION
Tagging a commit from before contrast coding was introduced, which seems to have caused failures in other packages.