### PR TITLE
Tag NormalizeQuantiles v0.2.0

### DIFF
--- a/NormalizeQuantiles/versions/0.2.0/requires
+++ b/NormalizeQuantiles/versions/0.2.0/requires
@@ -1,0 +1,2 @@
+julia 0.3
+DataArrays 0.2.16

--- a/NormalizeQuantiles/versions/0.2.0/sha1
+++ b/NormalizeQuantiles/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+56df258cafccbb92f3f7a38699dacddfeba38f57


### PR DESCRIPTION
For function sampleRanks removed methods with optional parameters in favor of methods with keyword parameters

This change has been motivated because of warnings in julia 0.5 and 0.6 with
`using NormalizeQuantiles`
`WARNING: Method definition sampleRanks(Array{Int64, N<:Any}) in module NormalizeQuantiles at c:\Program Files\Julia-0.4.1\packages\v0.5\NormalizeQuantiles\src\NormalizeQuantiles.jl:382 overwritten at c:\Progr.....`

This is a sample code which shows the problem:
```
function test(a,b=1,c=1)
	a+b+c
end

function test(a;b=1,c=1)
	a+b+c
end

```

The reasoning of the warnings is clear, but:

1. it would be better to suppress the warnings when the functions are imported from a package because the package user should not be irritated,
or
2. if the keyword parameter version implicitly creates the optional parameter functions:
```
function test(a;b=1,c=1)
	a+b+c
end

```
would result in 4 methods:
```
test(a)
test(a,b)
test(a,b,c)
test(a;b,c)
```

So if you do

```
function test(a;b=1,c=1)
	a+b+c
end

```

you can call:
```
test(1)
test(1,2)
test(1,2,3)
test(1,b=2)
test(1,c=3)
test(1,b=2,c=3)

```

I believe the last solution would not create any ambiguities, would result in shorter code because no need of extra definition of optional parameter method definitions. 

Even more consequent:
Why not making it equivalent?

test(a;b=1,c=1) is just the same as test(a,b=1,c=1)
The caller can decide: using ordered optional parameters OR keyworded parameters. Mixing should than be forbidden because only than ambiguities would arose.

Just my thoughts on this topic. I have read the other/older discussions about it.


