### PR TITLE
Tag KernelDensity v0.2.0

### DIFF
--- a/KernelDensity/versions/0.2.0/requires
+++ b/KernelDensity/versions/0.2.0/requires
@@ -1,0 +1,6 @@
+julia 0.3
+StatsBase
+Distributions
+Optim
+Grid
+Compat

--- a/KernelDensity/versions/0.2.0/sha1
+++ b/KernelDensity/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+2de1e7bae939d923cbfd4fb000921aca42d1a6fb


### PR DESCRIPTION
Fixes https://github.com/JuliaStats/KernelDensity.jl/issues/30.

I'm tagging this as a minor release since all plotting code has been removed. However, this should be fairly low-impact for other packages. Currently the only registered packages that depend on KernelDensity are plotting packages (StatPlots, Vega, and Gadfly).