### PR TITLE
Tag Interpolations v0.3.6

### DIFF
--- a/Interpolations/versions/0.3.6/requires
+++ b/Interpolations/versions/0.3.6/requires
@@ -1,0 +1,6 @@
+julia 0.4
+
+WoodburyMatrices 0.1.5
+Ratios
+AxisAlgorithms
+Compat 0.8.0

--- a/Interpolations/versions/0.3.6/sha1
+++ b/Interpolations/versions/0.3.6/sha1
@@ -1,0 +1,1 @@
+e8464501689ac1fbdd53c42abde3bbab50196aa2


### PR DESCRIPTION
This is a patch release to make Interpolations.jl compatible with Julia 0.5.

No breaking changes for 0.4.x have been noted (all tests pass).