### PR TITLE
Make Polynomials 0.0.6 tag 0.4-only

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -346,6 +346,7 @@ for (pkg, versions) in Pkg.Read.available()
             ("PicoSAT", v"0.1.0"),
             ("Playground", v"0.0.5"),
             ("Polynomial", v"0.1.1"),
+            ("Polynomials", v"0.0.6"),
             ("ProjectTemplate", v"0.0.1"),
             ("PropertyGraph", v"0.1.0"),
             ("Push", v"0.0.1"),

--- a/Polynomials/versions/0.0.6/requires
+++ b/Polynomials/versions/0.0.6/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.4
 Compat 0.7.15


### PR DESCRIPTION
since it uses `__precompile__` without checking for it first

ref https://github.com/JuliaLang/METADATA.jl/pull/5969#discussion_r74868810, cc @jverzani