### PR TITLE
Update requirements to reflect changes to dependency

### DIFF
--- a/CoordinateTransformations/versions/0.2.0/requires
+++ b/CoordinateTransformations/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Compat 0.8
 FixedSizeArrays 0.2.2
-Rotations
+Rotations 0.1.0 0.2+


### PR DESCRIPTION
Rotations 0.3 has a different API to Rotations 0.1/0.2, and this version of CoordinateTransformations requires one of the latter.