### PR TITLE
Change url for CoverageBase

### DIFF
--- a/CoverageBase/url
+++ b/CoverageBase/url
@@ -1,1 +1,1 @@
-git://github.com/timholy/CoverageBase.jl.git
+git://github.com/JuliaCI/CoverageBase.jl.git


### PR DESCRIPTION
Package moved to JuliaCI, see https://github.com/JuliaCI/CoverageBase.jl/issues/17.