### PR TITLE
Tag HTTPClient v0.2.1

### DIFF
--- a/HTTPClient/versions/0.2.1/requires
+++ b/HTTPClient/versions/0.2.1/requires
@@ -1,0 +1,3 @@
+julia 0.4
+Compat 0.8.0
+LibCURL

--- a/HTTPClient/versions/0.2.1/sha1
+++ b/HTTPClient/versions/0.2.1/sha1
@@ -1,0 +1,1 @@
+0cf86c1d4beb6787cce7a2c5eb79dd2050af19fd


### PR DESCRIPTION
WinRPM depends on this, so I thought I'd fix it. 