### PR TITLE
Tag DataFrames v0.8.1

### DIFF
--- a/DataFrames/versions/0.8.1/requires
+++ b/DataFrames/versions/0.8.1/requires
@@ -4,5 +4,5 @@ StatsBase 0.8.3
 GZip
 SortingAlgorithms
 Reexport
-Compat 0.8
+Compat 0.8.4
 FileIO 0.1.2

--- a/DataFrames/versions/0.8.1/requires
+++ b/DataFrames/versions/0.8.1/requires
@@ -1,0 +1,8 @@
+julia 0.4
+DataArrays 0.3.4
+StatsBase 0.8.3
+GZip
+SortingAlgorithms
+Reexport
+Compat 0.8
+FileIO 0.1.2

--- a/DataFrames/versions/0.8.1/sha1
+++ b/DataFrames/versions/0.8.1/sha1
@@ -1,0 +1,1 @@
+058c65bcb532da80ca9d9229d9ee75cbcf08ae78


### PR DESCRIPTION
Accompanies #5909. It fixes some of the stuff that 0.8.0 will break.

cc @tkelman, who IIRC said we should merge these around the same time.