### PR TITLE
Add DataFrames 0.8.0 as a FixedEffectModels upper bound

### DIFF
--- a/FixedEffectModels/versions/0.0.1/requires
+++ b/FixedEffectModels/versions/0.0.1/requires
@@ -3,5 +3,5 @@ Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0
 GLM

--- a/FixedEffectModels/versions/0.0.2/requires
+++ b/FixedEffectModels/versions/0.0.2/requires
@@ -3,5 +3,5 @@ Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0
 GLM

--- a/FixedEffectModels/versions/0.0.3/requires
+++ b/FixedEffectModels/versions/0.0.3/requires
@@ -3,5 +3,5 @@ Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0
 GLM

--- a/FixedEffectModels/versions/0.1.0/requires
+++ b/FixedEffectModels/versions/0.1.0/requires
@@ -3,4 +3,4 @@ Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0

--- a/FixedEffectModels/versions/0.1.1/requires
+++ b/FixedEffectModels/versions/0.1.1/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0

--- a/FixedEffectModels/versions/0.2.0/requires
+++ b/FixedEffectModels/versions/0.2.0/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0

--- a/FixedEffectModels/versions/0.2.1/requires
+++ b/FixedEffectModels/versions/0.2.1/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0

--- a/FixedEffectModels/versions/0.2.2/requires
+++ b/FixedEffectModels/versions/0.2.2/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0

--- a/FixedEffectModels/versions/0.3.0/requires
+++ b/FixedEffectModels/versions/0.3.0/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.8.0


### PR DESCRIPTION
DataFrames 0.8.0 will introduce breaking changes to FixedEffectModels, so this PR specifies 0.8.0 as an upper bound on the DataFrames dependency for all tagged versions of FixedEffectModels.

As requested by @tkelman in #6238.