### PR TITLE
Bump Compat dependency for DataFrames 0.8.0 to 0.8.4

### DIFF
--- a/DataFrames/versions/0.8.0/requires
+++ b/DataFrames/versions/0.8.0/requires
@@ -4,4 +4,4 @@ StatsBase 0.8.3
 GZip
 SortingAlgorithms
 Reexport
-Compat 0.8
+Compat 0.8.4


### PR DESCRIPTION
DataFrames 0.8.0 uses `Compat.view` but the lower bound on its Compat dependency is 0.8. It needs to be at least 0.8.4, when `view` was added to Compat.