### PR TITLE
Register ArbFloats v0.1.0 (faster extended precision floats)

### DIFF
--- a/ArbFloats/url
+++ b/ArbFloats/url
@@ -1,0 +1,1 @@
+git://github.com/JuliaArbTypes/ArbFloats.jl.git

--- a/ArbFloats/versions/0.1.0/requires
+++ b/ArbFloats/versions/0.1.0/requires
@@ -1,0 +1,3 @@
+julia 0.5-
+Nemo
+FactCheck

--- a/ArbFloats/versions/0.1.0/sha1
+++ b/ArbFloats/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+7e7d7d5af2fb055cd07da0f2e20bed7c07bdd020


### PR DESCRIPTION
[git://github.com/JuliaArbTypes/ArbFloats.jl.git]
renumbered the tag for simplicity: this is v0.1.0 for Julia v0.5.0-
