### PR TITLE
Bump DataStreams and cap existing DataStream packages

### DIFF
--- a/CSV/versions/0.0.1/requires
+++ b/CSV/versions/0.0.1/requires
@@ -2,4 +2,4 @@ julia 0.4
 Compat
 NullableArrays
 Libz
-DataStreams
+DataStreams 0.0.1 0.0.13

--- a/CSV/versions/0.0.11/requires
+++ b/CSV/versions/0.0.11/requires
@@ -1,4 +1,4 @@
 julia 0.4.1
-DataStreams 0.0.8
+DataStreams 0.0.8 0.0.13
 DataFrames
 WeakRefStrings 0.1.2

--- a/CSV/versions/0.0.12/requires
+++ b/CSV/versions/0.0.12/requires
@@ -1,4 +1,4 @@
 julia 0.4.1
-DataStreams 0.0.10
+DataStreams 0.0.10 0.0.13
 DataFrames
 WeakRefStrings 0.1.3

--- a/CSV/versions/0.0.13/requires
+++ b/CSV/versions/0.0.13/requires
@@ -1,4 +1,4 @@
 julia 0.4.1
-DataStreams 0.0.12
+DataStreams 0.0.12 0.0.13
 DataFrames
 WeakRefStrings 0.1.3

--- a/CSV/versions/0.0.2/requires
+++ b/CSV/versions/0.0.2/requires
@@ -2,4 +2,4 @@ julia 0.4
 Compat
 NullableArrays
 Libz
-DataStreams
+DataStreams 0.0.1 0.0.13

--- a/CSV/versions/0.0.3/requires
+++ b/CSV/versions/0.0.3/requires
@@ -2,4 +2,4 @@ julia 0.4.1
 Compat
 NullableArrays
 Libz
-DataStreams
+DataStreams 0.0.1 0.0.13

--- a/CSV/versions/0.0.4/requires
+++ b/CSV/versions/0.0.4/requires
@@ -2,4 +2,4 @@ julia 0.4.1
 Compat
 NullableArrays
 Libz
-DataStreams
+DataStreams 0.0.1 0.0.13

--- a/CSV/versions/0.0.5/requires
+++ b/CSV/versions/0.0.5/requires
@@ -1,4 +1,4 @@
 julia 0.4.1
 Compat
 NullableArrays
-DataStreams
+DataStreams 0.0.1 0.0.13

--- a/CSV/versions/0.0.6/requires
+++ b/CSV/versions/0.0.6/requires
@@ -1,5 +1,5 @@
 julia 0.4.1
-DataStreams
+DataStreams 0.0.1 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings

--- a/CSV/versions/0.0.7/requires
+++ b/CSV/versions/0.0.7/requires
@@ -1,5 +1,5 @@
 julia 0.4.1
-DataStreams
+DataStreams 0.0.1 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings

--- a/CSV/versions/0.0.8/requires
+++ b/CSV/versions/0.0.8/requires
@@ -1,5 +1,5 @@
 julia 0.4.1
-DataStreams
+DataStreams 0.0.1 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings

--- a/CSV/versions/0.0.9/requires
+++ b/CSV/versions/0.0.9/requires
@@ -1,5 +1,5 @@
 julia 0.4.1
-DataStreams
+DataStreams 0.0.1 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings

--- a/DataStreams/versions/0.0.13/requires
+++ b/DataStreams/versions/0.0.13/requires
@@ -1,7 +1,5 @@
 julia 0.4
-FlatBuffers 0.1.1
+DataFrames
 NullableArrays 0.0.8
 CategoricalArrays 0.0.4
-DataFrames
-DataStreams 0.0.12 0.0.13
 WeakRefStrings 0.1.3

--- a/DataStreams/versions/0.0.13/sha1
+++ b/DataStreams/versions/0.0.13/sha1
@@ -1,0 +1,1 @@
+7ef58fbaef1c4bb848b1123f5b6332abc7a4e456

--- a/Feather/versions/0.1.1/requires
+++ b/Feather/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.4
 FlatBuffers
-DataStreams
+DataStreams 0.0.1 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings

--- a/Feather/versions/0.1.2/requires
+++ b/Feather/versions/0.1.2/requires
@@ -1,6 +1,6 @@
 julia 0.4
 FlatBuffers
-DataStreams
+DataStreams 0.0.1 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings

--- a/Feather/versions/0.1.3/requires
+++ b/Feather/versions/0.1.3/requires
@@ -1,6 +1,6 @@
 julia 0.4
 FlatBuffers 0.1.1
-DataStreams 0.0.10
+DataStreams 0.0.10 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings 0.1.3

--- a/SQLite/versions/0.1.0/requires
+++ b/SQLite/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 DataFrames 0.2
-julia 0.2-
+julia 0.2- 0.4

--- a/SQLite/versions/0.1.1/requires
+++ b/SQLite/versions/0.1.1/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.4
 DataFrames
 DataArrays

--- a/SQLite/versions/0.1.2/requires
+++ b/SQLite/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.4
 DataFrames
 DataArrays
 BinDeps

--- a/SQLite/versions/0.1.3/requires
+++ b/SQLite/versions/0.1.3/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.4
 DataFrames
 DataArrays
 BinDeps

--- a/SQLite/versions/0.1.4/requires
+++ b/SQLite/versions/0.1.4/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.4
 DataFrames
 DataArrays
 BinDeps

--- a/SQLite/versions/0.1.5/requires
+++ b/SQLite/versions/0.1.5/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.4
 DataFrames
 DataArrays
 BinDeps

--- a/SQLite/versions/0.1.6/requires
+++ b/SQLite/versions/0.1.6/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.4
 DataFrames
 DataArrays
 BinDeps

--- a/SQLite/versions/0.2.0/requires
+++ b/SQLite/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.4
 BinDeps
 @osx Homebrew
 @windows WinRPM

--- a/SQLite/versions/0.2.1/requires
+++ b/SQLite/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.4
 BinDeps
 Compat
 @osx Homebrew

--- a/SQLite/versions/0.2.2/requires
+++ b/SQLite/versions/0.2.2/requires
@@ -1,7 +1,7 @@
 julia 0.4
 BinDeps
 Compat
-DataStreams
+DataStreams 0.0.1 0.0.13
 NullableArrays
 CSV
 @osx Homebrew

--- a/SQLite/versions/0.3.0/requires
+++ b/SQLite/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 BinDeps
 Compat
-DataStreams
+DataStreams 0.0.1 0.0.13
 NullableArrays
 CSV
 @osx Homebrew

--- a/SQLite/versions/0.3.1/requires
+++ b/SQLite/versions/0.3.1/requires
@@ -1,7 +1,7 @@
 julia 0.4.1
 BinDeps
 Compat
-DataStreams
+DataStreams 0.0.1 0.0.13
 NullableArrays
 CSV
 @osx Homebrew

--- a/SQLite/versions/0.3.2/requires
+++ b/SQLite/versions/0.3.2/requires
@@ -1,7 +1,7 @@
 julia 0.4.1
 BinDeps
 CSV 0.0.8
-DataStreams
+DataStreams 0.0.1 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings

--- a/SQLite/versions/0.3.3/requires
+++ b/SQLite/versions/0.3.3/requires
@@ -1,7 +1,7 @@
 julia 0.4.1
 BinDeps
 CSV 0.0.8
-DataStreams
+DataStreams 0.0.1 0.0.13
 DataFrames
 NullableArrays
 WeakRefStrings

--- a/SQLite/versions/0.3.4/requires
+++ b/SQLite/versions/0.3.4/requires
@@ -2,7 +2,7 @@ julia 0.4.1
 BinDeps
 @osx Homebrew
 @windows WinRPM
-DataStreams 0.0.9
+DataStreams 0.0.9 0.0.13
 DataFrames
 WeakRefStrings 0.1.3
 LegacyStrings

--- a/SQLite/versions/0.3.5/requires
+++ b/SQLite/versions/0.3.5/requires
@@ -2,7 +2,7 @@ julia 0.4.1
 BinDeps
 @osx Homebrew
 @windows WinRPM
-DataStreams 0.0.10
+DataStreams 0.0.10 0.0.13
 DataFrames
 WeakRefStrings 0.1.3
 LegacyStrings

--- a/SQLite/versions/0.3.6/requires
+++ b/SQLite/versions/0.3.6/requires
@@ -2,7 +2,7 @@ julia 0.4.1
 BinDeps
 @osx Homebrew
 @windows WinRPM
-DataStreams 0.0.12
+DataStreams 0.0.12 0.0.13
 DataFrames
 WeakRefStrings 0.1.3
 LegacyStrings


### PR DESCRIPTION
CC @tkelman: I think I have the upper-bounds correct here, but I'd appreciate a look; essentially, the current tagged versions of CSV/SQLite/Feather should only ever be allowed to use v0.0.12 of DataStreams. New tags for those packages will follow this merge.