### PR TITLE
Tag IJulia v1.3.0

### DIFF
--- a/IJulia/versions/1.3.0/requires
+++ b/IJulia/versions/1.3.0/requires
@@ -1,0 +1,6 @@
+julia 0.4
+Nettle 0.2
+JSON 0.5
+ZMQ 0.3.1
+Compat 0.7.20
+Conda 0.1.5

--- a/IJulia/versions/1.3.0/sha1
+++ b/IJulia/versions/1.3.0/sha1
@@ -1,0 +1,1 @@
+1b1cf6fcd2ecb35fc0ba95278a02f1ceae46ede3


### PR DESCRIPTION
I just realized that I hadn't tagged a new version in a while.

This version fixes a serious problem (JuliaLang/IJulia.jl#421), implements help if the user tries an IPython "magic", defaults to the user's home directory in `notebook()` and adds a keyword to change it.

Closes JuliaLang/IJulia.jl#460