### PR TITLE
Adjust BioMedQuery and Metamath's minimum julia version dependency to…

### DIFF
--- a/BioMedQuery/versions/0.0.1/requires
+++ b/BioMedQuery/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4.1
 ArgParse 0.3.0
 DataStreams 0.0.6 0.0.7
 Gumbo 0.2.0

--- a/BioMedQuery/versions/0.0.2/requires
+++ b/BioMedQuery/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4.1
 ArgParse 0.3.0
 DataStreams 0.0.6 0.0.7
 Gumbo 0.2.0

--- a/BioMedQuery/versions/0.0.3/requires
+++ b/BioMedQuery/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4.1
 ArgParse 0.3.0
 DataStreams 0.0.6 0.0.7
 Gumbo 0.2.0

--- a/BioMedQuery/versions/0.1.0/requires
+++ b/BioMedQuery/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4.1
 ArgParse 0.3.0
 DataStreams 0.0.10
 Gumbo 0.2.0

--- a/Metamath/versions/0.0.1/requires
+++ b/Metamath/versions/0.0.1/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4.1
 CSV 0.0.5
 Compat


### PR DESCRIPTION
… 0.4.1

since they depend on CSV.jl which depends on julia 0.4.1, ref #6297