### PR TITLE
DynamoDB 0.0.1 has upper bound on AWS 0.2

### DIFF
--- a/DynamoDB/versions/0.0.1/requires
+++ b/DynamoDB/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
-AWS
+AWS 0.0 0.2
 JSON
 HTTPClient


### PR DESCRIPTION
started failing when AWS 0.2 was tagged http://pkg.julialang.org/detail/DynamoDB.html