### PR TITLE
Tighten FixedEffectModels bound on DataFrames further

### DIFF
--- a/FixedEffectModels/versions/0.0.1/requires
+++ b/FixedEffectModels/versions/0.0.1/requires
@@ -3,5 +3,5 @@ Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
 DataArrays
-DataFrames 0.6 0.8.0
+DataFrames 0.6 0.7.7
 GLM

--- a/FixedEffectModels/versions/0.0.2/requires
+++ b/FixedEffectModels/versions/0.0.2/requires
@@ -3,5 +3,5 @@ Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
 DataArrays
-DataFrames 0.6 0.8.0
+DataFrames 0.6 0.7.7
 GLM

--- a/FixedEffectModels/versions/0.0.3/requires
+++ b/FixedEffectModels/versions/0.0.3/requires
@@ -3,5 +3,5 @@ Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
 DataArrays
-DataFrames 0.6 0.8.0
+DataFrames 0.6 0.7.7
 GLM

--- a/FixedEffectModels/versions/0.1.0/requires
+++ b/FixedEffectModels/versions/0.1.0/requires
@@ -3,4 +3,4 @@ Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6 0.8.0
+DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.1.1/requires
+++ b/FixedEffectModels/versions/0.1.1/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6 0.8.0
+DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.2.0/requires
+++ b/FixedEffectModels/versions/0.2.0/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6 0.8.0
+DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.2.1/requires
+++ b/FixedEffectModels/versions/0.2.1/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6 0.8.0
+DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.2.2/requires
+++ b/FixedEffectModels/versions/0.2.2/requires
@@ -3,4 +3,4 @@ Compat
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6 0.8.0
+DataFrames 0.6 0.7.7


### PR DESCRIPTION
0.7.8 didn't fix the issue with reducing over an empty collection
and FixedEffectModels 0.3.0 is Julia-0.5-only
ref http://pkg.julialang.org/detail/FixedEffectModels.html

#6244 wasn't tight enough, cc @matthieugomez @ararslan and ref https://github.com/JuliaStats/DataFrames.jl/pull/1017#issuecomment-243803777

If one of the more recent DataFrames tags has fixed the issue, then we can instead loosen or remove the upper bounds, let me know.