### PR TITLE
add an upper bound on GeneralizedSampling's dependency on NFFT

### DIFF
--- a/GeneralizedSampling/versions/0.0.4/requires
+++ b/GeneralizedSampling/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 julia 0.4
-NFFT 0.1.1
+NFFT 0.1.1 0.1.2
 Wavelets 0.4.1
 ArrayViews 0.6.4
 VoronoiCells 0.1.1


### PR DESCRIPTION
ref https://github.com/JuliaLang/METADATA.jl/pull/6355

cc @robertdj - if you later tag a version of GeneralizedSampling that works with the latest NFFT, then this won't be noticeable.