### PR TITLE
Tag DifferentialEquations v0.4.0

### DIFF
--- a/DifferentialEquations/versions/0.3.1/requires
+++ b/DifferentialEquations/versions/0.3.1/requires
@@ -1,0 +1,10 @@
+julia 0.5
+Parameters 0.3.1
+ForwardDiff 0.2.4
+ChunkedArrays 0.0.2
+IterativeSolvers 0.2.2
+GenericSVD 0.0.2
+Compat 0.8.8
+Plots 0.9.2
+InplaceOps 0.0.5
+SIUnits 0.0.6

--- a/DifferentialEquations/versions/0.3.1/sha1
+++ b/DifferentialEquations/versions/0.3.1/sha1
@@ -1,0 +1,1 @@
+d4f35822bbc9882fbfc6951330acfbd26d99a7ed


### PR DESCRIPTION
Added dense output via call-overloading, so that way the interpolated solutions are given by `sol(t)` using the same solution object as the timeseries of the output. The new version is also compatible with unit-checked arithmetic via SIUnits.jl (and should be automatically compatible with Unitful.jl, haven't checked it yet). Added a benchmarking suite, and it shows really good results for native DifferentialEquations algorithms over Sundials, ODE, and ODEInterface on nonstiff equations. Extensions to handle explicit parameters for additional features was handled by the creation of ParameterizedFunctions.jl (still experimental). 

Included this time are minimum versions for each dependency. 