### PR TITLE
Tag LibExpat v0.2.1 [https://github.com/amitmurthy/LibExpat.jl]

### DIFF
--- a/LibExpat/versions/0.2.1/requires
+++ b/LibExpat/versions/0.2.1/requires
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.8.0

--- a/LibExpat/versions/0.2.1/sha1
+++ b/LibExpat/versions/0.2.1/sha1
@@ -1,0 +1,1 @@
+a0228aebbc9365bf6a2fdb4646f0b6f615d8db2b


### PR DESCRIPTION
Fixes a depwarn when doing `Pkg.build` of WinRPM.