### PR TITLE
Tag GLM v0.5.6

### DIFF
--- a/GLM/versions/0.5.6/requires
+++ b/GLM/versions/0.5.6/requires
@@ -1,0 +1,6 @@
+julia 0.4
+Distributions 0.4.6-
+StatsBase 0.8.3
+StatsFuns 0.3.0
+Reexport
+Compat 0.2.12-

--- a/GLM/versions/0.5.6/sha1
+++ b/GLM/versions/0.5.6/sha1
@@ -1,0 +1,1 @@
+5fc1cf1b5c45e9f4b2ce6fb1fc7619e443146ee2


### PR DESCRIPTION
Tag new release prior to bumping `REQUIRE` to `julia 0.5`

@andreasnoack or @simonbyrne should approve this before merging.  (We know how well git and I get along.) 