### PR TITLE
Test the sanity of package tags when running Travis on a PR

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -234,6 +234,12 @@ for pkg in readdir("METADATA")
     end
 end
 
+if haskey(ENV, "TRAVIS_PULL_REQUEST") && ENV["TRAVIS_PULL_REQUEST"] != "false"
+    info("Checking repository tags...")
+    Pkg.add("JSON")
+    include("check-pr.jl")
+end
+
 info("Verifying METADATA...")
 if isdefined(Pkg.Entry, :check_metadata)
     Pkg.Entry.check_metadata()

--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -1,0 +1,66 @@
+using JSON
+
+const PR_NUM = ENV["TRAVIS_PULL_REQUEST"]
+const BUILD_DIR = ENV["TRAVIS_BUILD_DIR"]
+const API_URL = "https://api.github.com/repos/JuliaLang/METADATA.jl"
+const CURL_URL = "$API_URL/pulls/$PR_NUM/files?per_page=100"
+
+# Get files modified in the PR from the GitHub API
+changes = JSON.parse(readchomp(`curl "$CURL_URL"`))
+
+# If all went well, `changes` will be an array, or a dict without that key
+if typeof(changes) <: Dict && haskey(changes, "message")
+    msg = changes["message"]
+    error("GitHub API gave result \"$msg\" from `$CURL_URL` GET request")
+end
+
+# Get the associated package and version for each affected file
+modified = Dict() # package => [versions...]
+for diff in changes
+    pkg = split(diff["filename"], "/")[1]
+    if isdir(joinpath(BUILD_DIR, pkg)) && pkg != ".test"
+        v = VersionNumber(match(r"^[^/]+/versions/([\d.]+)", diff["filename"]).captures[1])
+        if haskey(modified, pkg)
+            in(v, modified[pkg]) || push!(modified[pkg], v)
+        else
+            push!(modified, pkg => VersionNumber[v])
+        end
+    end
+end
+
+# Check that tagging makes sense
+for pkg in keys(modified)
+    dir = joinpath(BUILD_DIR, pkg)
+
+    remote_url = readchomp(joinpath(dir, "url"))
+    lines = split(readchomp(`git ls-remote --tags --refs -q $remote_url`), "\n")
+
+    remotetags = Dict(map(lines) do s
+        t = split(s, "\t")
+        VersionNumber(t[2][11:end]) => t[1]
+    end)
+
+    localtags = Dict(map(readdir(joinpath(dir, "versions"))) do v
+        sha = readchomp(joinpath(dir, "versions", v, "sha1"))
+        VersionNumber(v) => sha
+    end)
+
+    notpushed = setdiff(localtags, remotetags)
+    getmad = intersect(modified[pkg], notpushed)
+
+    if isempty(notpushed)
+        # Tags match, so we can compare SHAs 1-1
+        for tag in keys(localtags)
+            if localtags[tag] != remotetags[tag]
+                msg = string("The commit SHA for $pkg $tag does not match between METADATA ",
+                             "and the upstream package repository.")
+                error(msg)
+            end
+        end
+    elseif !isempty(getmad) # just those added in this PR
+        msg = string("The following tags for $pkg have not been pushed to upstream ",
+                     "repository: ", join(getmad, ", "), ".\nTo fix this, navigate to ",
+                     "the package directory and run `git push --follow-tags`.")
+        error(msg)
+    end
+end

--- a/.test/travis.sh
+++ b/.test/travis.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)/..
 git checkout -b localbranch
 cd ..
 ln -s $PWD/METADATA.jl METADATA
-for ver in 0.4 0.5; do # add 0.6 once nightly is 0.6-dev
+for ver in 0.4 0.5 0.6; do
   mkdir -p ~/.julia/v$ver julia-$ver
   ln -s $PWD/METADATA.jl ~/.julia/v$ver/METADATA
   if [ $ver = 0.6 ]; then
@@ -18,6 +18,6 @@ for ver in 0.4 0.5; do # add 0.6 once nightly is 0.6-dev
     touch success-$ver &
 done
 wait
-if ! [ -e success-0.4 -a -e success-0.5 ]; then # add success-0.6 once nightly is 0.6-dev
+if ! [ -e success-0.4 -a -e success-0.5 ]; then # add success-0.6 once there are any 0.6-only package versions
   exit 1
 fi


### PR DESCRIPTION
When someone submits a pull request on METADATA, this addition to the CI tests will ensure that, for each modified package,

1. All local tags are present on the remote,
2. If so, that the commit SHAs match between the local and remote tags, and
3. ~~If more than one tag is available for a package, that multiple tags don't share a commit SHA.~~

Items 1 and 2 produce errors, ~~3 produces warnings.~~

I've also made the (unrelated) change of adding 0.6 to the testing list. This is a separate commit so it can be removed if necessary.

cc @tkelman 