### PR TITLE
Fix issue with identification of unpushed tags

### DIFF
--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -50,7 +50,7 @@ for pkg in keys(modified)
     end)
 
     notpushed = setdiff(localtags, remotetags)
-    getmad = intersect(modified[pkg], notpushed)
+    getmad = intersect(modified[pkg], map(first, notpushed))
 
     if isempty(notpushed)
         # Tags match, so we can compare SHAs 1-1


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/METADATA.jl/pull/6504#issuecomment-249460877

The problem was that `notpushed` is a `Vector{Pair}`, and we're trying to compare it to a `Vector{VersionNumber}`.