### PR TITLE
Simplify and (hopefully!) fix tag checking for PRs

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -234,9 +234,8 @@ for pkg in readdir("METADATA")
     end
 end
 
-if false #haskey(ENV, "TRAVIS_PULL_REQUEST") && ENV["TRAVIS_PULL_REQUEST"] != "false"
+if haskey(ENV, "TRAVIS_PULL_REQUEST") && ENV["TRAVIS_PULL_REQUEST"] != "false"
     info("Checking repository tags...")
-    Pkg.add("JSON")
     include("check-pr.jl")
 end
 


### PR DESCRIPTION
There are a number of simplifications and corrections to the tag checking code:

* No more dependency on JSON.jl
* No more use of the GitHub API (which means no more quotas and rate limits)
* Get both annotated and lightweight tags when fetching remote tags
* Correctly identify when a tag hasn't been pushed to the remote

In simulations it's shown to exhibit the desired behavior in all of the circumstances I could think of. I think it runs a little faster too now. Maybe.

~~I also made the unrelated change of having the Bash script print the Julia version it's running. It's helpful for debugging when looking at the Travis log to have that be obvious.~~

cc @tkelman 