### PR TITLE
Fix issue with the SHA being interpreted as a Char

### DIFF
--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -33,7 +33,7 @@ function get_remote_tags(url)
             error("Upstream tag $tag is possibly malformed")
         end
 
-        push!(remotetags, tag => first(sha))
+        push!(remotetags, tag => sha)
     end
 
     return remotetags


### PR DESCRIPTION
Addresses the issue noted in https://github.com/JuliaLang/METADATA.jl/pull/6534#issuecomment-249944670.

The `first` was erroneously left over from a previous approach, wherein the variable `sha` was an array, and we wanted the first element. Now it's a string, so using `first` gets the first character of the string, which definitely isn't right.

Sorry @tkelman and @timholy!