### PR TITLE
Only check SHA matches for modified package versions

### DIFF
--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -93,10 +93,11 @@ for pkg in keys(modified)
 
     if isempty(notpushed)
         # Tags match, so we can compare SHAs 1-1
-        for tag in keys(localtags)
+        for tag in modified[pkg]
             if localtags[tag] != remotetags[tag]
                 msg = string("The commit SHA for $pkg $tag does not match between METADATA ",
-                             "and the upstream package repository.")
+                             "and the upstream package repository.\nMETADATA SHA: ",
+                             localtags[tag], "\nUpstream SHA: ", remotetags[tag])
                 error(msg)
             end
         end

--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -3,6 +3,17 @@ const BUILD_DIR = ENV["TRAVIS_BUILD_DIR"]
 function get_remote_tags(url)
     ls = readchomp(`git ls-remote --tags -q $url`)
     lines = split(ls, "\n")
+
+    filter!(lines) do line
+        m = match(r"^\w+\trefs/tags/([^\^]+)(\^{})?$", line)
+        if m === nothing
+            return false
+        else
+            tag = m.captures[1]
+            return ismatch(Base.VERSION_REGEX, tag)
+        end
+    end
+
     n = length(lines)
 
     tags = Vector{VersionNumber}(n)


### PR DESCRIPTION
Currently when all tags have been pushed to the upstream package repository, we check that the SHA for _every_ tag matches between what's in METADATA and what's in the upstream repo. With this change, we'll only be checking whether the SHA matches for versions that were modified in the PR.

This also includes a fix that will ignore tags in the upstream repo with names that aren't valid version numbers. It's fine to have those upstream, just not in METADATA. Attempting to create a version in METADATA with an invalid version number will still fail.