### PR TITLE
Ignore upstream tags that don't start with v

### DIFF
--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -5,7 +5,7 @@ function get_remote_tags(url)
     lines = split(ls, "\n")
 
     filter!(lines) do line
-        m = match(r"^\w+\trefs/tags/([^\^]+)(\^{})?$", line)
+        m = match(r"^\w+\trefs/tags/(v[^\^]+)(\^{})?$", line)
         if m === nothing
             return false
         else


### PR DESCRIPTION
This should address the issue noted in #6636.