### PR TITLE
Tag FixedPointNumbers v0.2.0

### DIFF
--- a/FixedPointNumbers/versions/0.2.0/requires
+++ b/FixedPointNumbers/versions/0.2.0/requires
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.9.1

--- a/FixedPointNumbers/versions/0.2.0/sha1
+++ b/FixedPointNumbers/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+a00d54cb2a06e2bbafc8a1dad27bdfec0390635d


### PR DESCRIPTION
Main changes:
- implement `isapprox`
- be more consistent about choice of `Float32` or `Float64` when converting to `AbstractFloat`

The latter has a chance of being breaking for operations that really care about the specific element type. Not sure whether this should be a minor version bump as a consequence (it's a pretty tiny change, really).
