### PR TITLE
Tag SampledSignals v0.3.0 [https://github.com/JuliaAudio/SampledSignals.jl]

### DIFF
--- a/SampledSignals/versions/0.3.0/requires
+++ b/SampledSignals/versions/0.3.0/requires
@@ -1,0 +1,5 @@
+julia 0.4
+SIUnits
+FixedPointNumbers
+Compat 0.8.8
+DSP

--- a/SampledSignals/versions/0.3.0/sha1
+++ b/SampledSignals/versions/0.3.0/sha1
@@ -1,0 +1,1 @@
+045aaad4febb0f43fd62c66ebfbaa1e1491644cb


### PR DESCRIPTION
Makes SIUnits stuff less general but easier to reason about and extend. Now we have separate `SampleBuf` and `SpectrumBuf` types for time-domain and frequency-domain signals.