### PR TITLE
add some more debugging output to the travis script

### DIFF
--- a/.test/travis.sh
+++ b/.test/travis.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 cd $(dirname $0)/..
+echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
+echo "TRAVIS_PULL_REQUEST_SHA: $TRAVIS_PULL_REQUEST_SHA"
+git log -2
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge:
+  git log -2 FETCH_HEAD
+fi
 git checkout -b localbranch
 cd ..
 ln -s $PWD/METADATA.jl METADATA

--- a/ArrayViews/url
+++ b/ArrayViews/url
@@ -1,1 +1,1 @@
-git://github.com/JuliaLang/ArrayViews.jl.git
+git://github.com/JuliaArrays/ArrayViews.jl.git

--- a/Compose/url
+++ b/Compose/url
@@ -1,1 +1,1 @@
-git://github.com/dcjones/Compose.jl.git
+git://github.com/GiovineItalia/Compose.jl.git

--- a/Gadfly/url
+++ b/Gadfly/url
@@ -1,1 +1,1 @@
-git://github.com/dcjones/Gadfly.jl.git
+git://github.com/GiovineItalia/Gadfly.jl.git

--- a/Gettext/url
+++ b/Gettext/url
@@ -1,1 +1,1 @@
-git://github.com/garrison/Gettext.jl.git
+git://github.com/Julia-i18n/Gettext.jl.git

--- a/JavaCall/url
+++ b/JavaCall/url
@@ -1,1 +1,1 @@
-git://github.com/aviks/JavaCall.jl.git
+git://github.com/JuliaInterop/JavaCall.jl.git

--- a/MathLink/url
+++ b/MathLink/url
@@ -1,1 +1,1 @@
-git://github.com/MikeInnes/MathLink.jl.git
+git://github.com/JuliaInterop/MathLink.jl.git

--- a/Mathematica/url
+++ b/Mathematica/url
@@ -1,1 +1,1 @@
-git://github.com/MikeInnes/Mathematica.jl.git
+git://github.com/JuliaInterop/Mathematica.jl.git

--- a/ObjectiveC/url
+++ b/ObjectiveC/url
@@ -1,1 +1,1 @@
-git://github.com/MikeInnes/ObjectiveC.jl.git
+git://github.com/JuliaInterop/ObjectiveC.jl.git

--- a/RCall/url
+++ b/RCall/url
@@ -1,1 +1,1 @@
-git://github.com/JuliaStats/RCall.jl.git
+git://github.com/JuliaInterop/RCall.jl.git

--- a/TestImages/url
+++ b/TestImages/url
@@ -1,1 +1,1 @@
-git://github.com/timholy/TestImages.jl.git
+git://github.com/JuliaImages/TestImages.jl.git


### PR DESCRIPTION
I think the `git fetch origin +refs/pull/####/merge:` is sometimes getting stale data,
causing some builds to pass when they shouldn't

continuing from #6711 but this time opened from a fork to see if that behaves any differently