### PR TITLE
Tag MLBase v0.6.0 [https://github.com/JuliaStats/MLBase.jl]

### DIFF
--- a/MLBase/versions/0.6.0/requires
+++ b/MLBase/versions/0.6.0/requires
@@ -1,0 +1,5 @@
+julia 0.4
+Reexport
+StatsBase 0.6.9-
+Iterators
+Compat 0.8.7

--- a/MLBase/versions/0.6.0/sha1
+++ b/MLBase/versions/0.6.0/sha1
@@ -1,0 +1,1 @@
+8903112732bddee02d25cadc44a5a1cfde3431dd


### PR DESCRIPTION
Fixes 0.5 compatibility issues.