### PR TITLE
Tag Cuba v0.2.0

### DIFF
--- a/Cuba/versions/0.2.0/requires
+++ b/Cuba/versions/0.2.0/requires
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.8.5

--- a/Cuba/versions/0.2.0/sha1
+++ b/Cuba/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+af57779864f33b3cb1c52ff8b0bc5da1f3c007ea


### PR DESCRIPTION
From the `NEWS.md` file:

> This release faces some changes to the user interface.  Be aware of them when
> upgrading.
> 
> ### New Features ###
> 
> * `ndim` and `ncomp` arguments can be omitted.  In that case they default to 1.
>   This change is not breaking, old syntax will continue to work.
> 
> ### Breaking Changes ###
> 
> All integrator functions and some optional keywords have been renamed for more
> consistency with the Julia environment.  Here is the detailed list:
> 
> * Integrators functions have been renamed to lowercase name: `Vegas` to `vegas`,
>   `Suave` to `suave`, `Divonne` to `divonne`, `Cuhre` to `cuhre`.  The uppercase
>   variants are still available but deprecated, they will be removed at some
>   point in the future.
> * Optional keywords changes: `epsabs` to `abstol`, `epsrel` to `reltol`,
>   `maxeval` to `maxevals`, `mineval` to `minevals`.