### PR TITLE
Tag WriteVTK v0.4.2 [https://github.com/jipolanco/WriteVTK.jl]

### DIFF
--- a/WriteVTK/versions/0.4.2/requires
+++ b/WriteVTK/versions/0.4.2/requires
@@ -1,0 +1,5 @@
+julia 0.4
+LightXML 0.2.1
+Libz 0.1.1
+BufferedStreams 0.1.1
+Compat 0.8.4

--- a/WriteVTK/versions/0.4.2/sha1
+++ b/WriteVTK/versions/0.4.2/sha1
@@ -1,0 +1,1 @@
+509bca47f39fdd45268cad1a74fe77faf1ca16ec


### PR DESCRIPTION
Do-block syntax is now supported for generation of VTK files.