### PR TITLE
Tag XMLconvert v0.1.0 [https://github.com/bcbi/XMLconvert.jl]

### DIFF
--- a/XMLconvert/versions/0.1.0/requires
+++ b/XMLconvert/versions/0.1.0/requires
@@ -1,0 +1,3 @@
+julia 0.5
+LightXML 0.2.1
+DataStructures 0.4.4

--- a/XMLconvert/versions/0.1.0/sha1
+++ b/XMLconvert/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+8bee6927afd8bf15864d02ca3bbdfc68c8ef4fa7


### PR DESCRIPTION
Drop support for Julia 0.4
@paulstey -- this is the new issue to track