### PR TITLE
Tag CRlibm v0.3.0 [https://github.com/dpsanders/CRlibm.jl]

### DIFF
--- a/CRlibm/versions/0.3.0/requires
+++ b/CRlibm/versions/0.3.0/requires
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.8.8

--- a/CRlibm/versions/0.3.0/sha1
+++ b/CRlibm/versions/0.3.0/sha1
@@ -1,0 +1,1 @@
+00e8f51aa20e3ab35b59ebebdfb6d074018d1ef3


### PR DESCRIPTION
0.5 deprecations, and include the source code of the `CRlibm` library in the repository rather than downloading it.