### PR TITLE
Tag NamedArrays v0.5.3 [https://github.com/davidavdav/NamedArrays.jl]

### DIFF
--- a/NamedArrays/versions/0.5.3/requires
+++ b/NamedArrays/versions/0.5.3/requires
@@ -1,0 +1,3 @@
+julia 0.4
+Combinatorics 0.2.1
+DataStructures 0.4.4

--- a/NamedArrays/versions/0.5.3/sha1
+++ b/NamedArrays/versions/0.5.3/sha1
@@ -1,0 +1,1 @@
+f9dbffcab67cede7227538f98ac71eda96eb78d9


### PR DESCRIPTION
A number of bugfixes and PRs: more efficient use of julia-0.5 possibilities (`Vararg`)

It turned out that all the `@compat`s were for julia-0.3, so the whole Compat requirement could be relaxed. 