### PR TITLE
Tag Mimi v0.2.1 [https://github.com/anthofflab/Mimi.jl]

### DIFF
--- a/Mimi/versions/0.2.1/requires
+++ b/Mimi/versions/0.2.1/requires
@@ -1,0 +1,6 @@
+julia 0.4
+DataStructures
+Distributions
+DataFrames
+Documenter
+Compat 0.8.6

--- a/Mimi/versions/0.2.1/sha1
+++ b/Mimi/versions/0.2.1/sha1
@@ -1,0 +1,1 @@
+2f8bf04eff52585ae75e3dd71afdbcf9a6988a00


### PR DESCRIPTION
This should fix the current package test failures.