### PR TITLE
Tag ApproxFun 0.4

### DIFF
--- a/ApproxFun/versions/0.4.0/requires
+++ b/ApproxFun/versions/0.4.0/requires
@@ -1,0 +1,9 @@
+julia 0.4
+FastGaussQuadrature 0.1
+FastTransforms 0.0.6
+Plots 0.8.2
+Compat 0.8.6
+DualNumbers 0.2.2
+BandedMatrices 0.1.2
+ToeplitzMatrices 0.1.1
+Calculus 0.1.15

--- a/ApproxFun/versions/0.4.0/sha1
+++ b/ApproxFun/versions/0.4.0/sha1
@@ -1,0 +1,1 @@
+7c6dad842f227bab7fb5234d5c8c11d6467fbca1

--- a/SingularIntegralEquations/versions/0.1.4/requires
+++ b/SingularIntegralEquations/versions/0.1.4/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ApproxFun 0.3.1
+ApproxFun 0.3.1 0.4-
 Compat 0.8.4

--- a/SingularIntegralEquations/versions/0.1.5/requires
+++ b/SingularIntegralEquations/versions/0.1.5/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ApproxFun 0.3.2
+ApproxFun 0.3.2 0.4-
 Compat 0.8.4


### PR DESCRIPTION
This is a major update to ApproxFun, in particular, revamps how PDE solving is done so that it is more efficient for variable coefficients.

It also adds upper bounds to the requires for SingularIntegralEquations (with a new tag forthcoming there as well).