### PR TITLE
Tag Sundials v0.4.0 [https://github.com/JuliaDiffEq/Sundials.jl]

### DIFF
--- a/Sundials/versions/0.4.0/requires
+++ b/Sundials/versions/0.4.0/requires
@@ -1,0 +1,4 @@
+julia 0.5
+BinDeps 0.4.3
+Compat 0.9.0
+DiffEqBase

--- a/Sundials/versions/0.4.0/sha1
+++ b/Sundials/versions/0.4.0/sha1
@@ -1,0 +1,1 @@
+1c6ac7466bb4b5bc3a9dbc50b52ac5a1f0cee772


### PR DESCRIPTION
This tag updates the Sundials extra APIs to include the DiffEq common interface. The `cvode_fulloutput` function, created for the "1st-edition" of  the common interface, has been deprecated for the function `solve(prob,alg;kwargs)` to match the rest of the packages in the ecosystem. A requirement on DiffEqBase has been added accordingly (for now, no minimum version, but will add the minimum version in a patch which may be coming)