### PR TITLE
Tag Laplacians v0.0.3 [https://github.com/danspielman/Laplacians.jl], compat with Julia 0.5.0

### DIFF
--- a/Laplacians/versions/0.0.3/requires
+++ b/Laplacians/versions/0.0.3/requires
@@ -1,0 +1,4 @@
+julia 0.5
+PyPlot 
+DataStructures
+PyAMG

--- a/Laplacians/versions/0.0.3/sha1
+++ b/Laplacians/versions/0.0.3/sha1
@@ -1,0 +1,1 @@
+311b4de8087e1af2cb59171d6bc82b40acfd4ff6


### PR DESCRIPTION
This is the first version compatible with Julia 0.5.0.
Laplacians v0.0.2 is compatible with Julia 0.4.7
