### PR TITLE
Changed URL for SwitchTimeOpt.jl repository

### DIFF
--- a/SwitchTimeOpt/url
+++ b/SwitchTimeOpt/url
@@ -1,1 +1,1 @@
-git://github.com/bstellato/SwitchTimeOpt.jl.git
+git://github.com/OxfordControl/SwitchTimeOpt.jl.git


### PR DESCRIPTION
Repository transferred to OxfordControl organization.