### PR TITLE
Register ODEInterfaceDiffEq.jl

### DIFF
--- a/ODEInterfaceDiffEq/url
+++ b/ODEInterfaceDiffEq/url
@@ -1,1 +1,1 @@
-https://github.com/JuliaDiffEq/ODEInterfaceDiffEq.git
+https://github.com/JuliaDiffEq/ODEInterfaceDiffEq.jl.git

--- a/ODEInterfaceDiffEq/url
+++ b/ODEInterfaceDiffEq/url
@@ -1,0 +1,1 @@
+https://github.com/JuliaDiffEq/ODEInterfaceDiffEq.git

--- a/ODEInterfaceDiffEq/versions/0.0.1/requires
+++ b/ODEInterfaceDiffEq/versions/0.0.1/requires
@@ -1,0 +1,3 @@
+julia 0.5
+ODEInterface
+DiffEqBase

--- a/ODEInterfaceDiffEq/versions/0.0.1/sha1
+++ b/ODEInterfaceDiffEq/versions/0.0.1/sha1
@@ -1,0 +1,1 @@
+13abceabd4e12c6fca95e6ce7ef5834f47bfcf6d


### PR DESCRIPTION
ODEInterfaceDiffEq.jl is a glue package for ODEInterface with gives it JuliaDiffEq common interface bindings and all of the advantages that come with it. This code was previously included in OrdinaryDiffEq.jl and was the code which required conditional dependencies, but using this common API, conditional dependencies are no longer required. This does need to be registered as it is at least a crucial part of the OrdinaryDiffEq.jl tests (for testing native Julia versions vs the FORTRAN wrapper package), and the `radau` methods have no parallel in Julia as of right now, making them a strong contribution to the common interface.

It wasn't included in ODEInterface.jl directly because of the dependencies it adds, and so it keeps ODEInterface.jl a dependency-free library. For more discussion on this, see the following issue:

https://github.com/luchr/ODEInterface.jl/issues/9