### PR TITLE
Pull request/3ba67554

### DIFF
--- a/Laplacians/versions/0.0.3/requires
+++ b/Laplacians/versions/0.0.3/requires
@@ -1,0 +1,4 @@
+julia 0.5
+PyPlot 
+DataStructures
+PyAMG

--- a/Laplacians/versions/0.0.3/sha1
+++ b/Laplacians/versions/0.0.3/sha1
@@ -1,0 +1,1 @@
+311b4de8087e1af2cb59171d6bc82b40acfd4ff6

--- a/Laplacians/versions/0.1.0/requires
+++ b/Laplacians/versions/0.1.0/requires
@@ -1,0 +1,4 @@
+julia 0.5
+PyPlot 
+DataStructures
+PyAMG

--- a/Laplacians/versions/0.1.0/sha1
+++ b/Laplacians/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+311b4de8087e1af2cb59171d6bc82b40acfd4ff6


### PR DESCRIPTION
As requested, changing the tag from version 0.0.3 to 0.1.0 because we dropped support for Julia 0.4 to support Julia 0.5