### PR TITLE
Tag WAV v0.8.2 [https://github.com/dancasimiro/WAV.jl]

### DIFF
--- a/WAV/versions/0.8.2/requires
+++ b/WAV/versions/0.8.2/requires
@@ -1,0 +1,3 @@
+julia 0.4
+Compat 0.8.0
+FileIO 0.0.2

--- a/WAV/versions/0.8.2/sha1
+++ b/WAV/versions/0.8.2/sha1
@@ -1,0 +1,1 @@
+61cdc0ac47f0a0f04e2a3d8c60985d3ff9beabdb


### PR DESCRIPTION
This version adds support for Julia v0.6. It uses compat to remove a couple of deprecated functions.