### PR TITLE
Tag WAV v0.8.3 [https://github.com/dancasimiro/WAV.jl]

### DIFF
--- a/WAV/versions/0.8.3/requires
+++ b/WAV/versions/0.8.3/requires
@@ -1,0 +1,3 @@
+julia 0.4
+Compat 0.9.5
+FileIO 0.2.0

--- a/WAV/versions/0.8.3/sha1
+++ b/WAV/versions/0.8.3/sha1
@@ -1,0 +1,1 @@
+c32ae53ffd6a62e15e3119b6bccb2a7df1d33adf


### PR DESCRIPTION
v0.8.3 is the same as v0.8.2, but it requires the correct version of Compat (0.9.5). These two minor versions add support for Julia v0.6.