### PR TITLE
Tag Playground v0.2.0 [https://github.com/Rory-Finnegan/Playground.jl]

### DIFF
--- a/Playground/versions/0.2.0/requires
+++ b/Playground/versions/0.2.0/requires
@@ -1,0 +1,5 @@
+julia 0.4
+ArgParse
+YAML
+Mocking
+Compat

--- a/Playground/versions/0.2.0/sha1
+++ b/Playground/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+d4ea10dccdeefeb1572cddb6acac25734cb1b114


### PR DESCRIPTION
I realize it has taken me a while to update Playground to 0.5, but I was hoping a couple of my dependencies would get updated. I've updated the minor version number as I've dropped support for DeclarativePackages.