### PR TITLE
Add a bunch of maximum versions to ParameterizedFunctions

### DIFF
--- a/ParameterizedFunctions/versions/0.0.1/requires
+++ b/ParameterizedFunctions/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
-DiffEqBase 0.0 0.0
+DiffEqBase 0.0 0.5.0

--- a/ParameterizedFunctions/versions/0.0.1/requires
+++ b/ParameterizedFunctions/versions/0.0.1/requires
@@ -1,3 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
+DiffEqBase 0.0 0.0

--- a/ParameterizedFunctions/versions/0.1.0/requires
+++ b/ParameterizedFunctions/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
-DiffEqBase 0.0 0.0
+DiffEqBase 0.0 0.5.0

--- a/ParameterizedFunctions/versions/0.1.0/requires
+++ b/ParameterizedFunctions/versions/0.1.0/requires
@@ -1,3 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
+DiffEqBase 0.0 0.0

--- a/ParameterizedFunctions/versions/0.1.1/requires
+++ b/ParameterizedFunctions/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
-DiffEqBase 0.0 0.0
+DiffEqBase 0.0 0.5.0

--- a/ParameterizedFunctions/versions/0.1.1/requires
+++ b/ParameterizedFunctions/versions/0.1.1/requires
@@ -1,3 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
+DiffEqBase 0.0 0.0

--- a/ParameterizedFunctions/versions/0.2.0/requires
+++ b/ParameterizedFunctions/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
-DiffEqBase 0.0 0.0
+DiffEqBase 0.0 0.5.0

--- a/ParameterizedFunctions/versions/0.2.0/requires
+++ b/ParameterizedFunctions/versions/0.2.0/requires
@@ -1,3 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
+DiffEqBase 0.0 0.0

--- a/ParameterizedFunctions/versions/0.2.1/requires
+++ b/ParameterizedFunctions/versions/0.2.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
-DiffEqBase 0.0 0.0
+DiffEqBase 0.0 0.5.0

--- a/ParameterizedFunctions/versions/0.2.1/requires
+++ b/ParameterizedFunctions/versions/0.2.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
-DiffEqBase
+DiffEqBase 0.0 0.0

--- a/ParameterizedFunctions/versions/0.2.2/requires
+++ b/ParameterizedFunctions/versions/0.2.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
-DiffEqBase 0.0 0.0
+DiffEqBase 0.0 0.5.0

--- a/ParameterizedFunctions/versions/0.2.2/requires
+++ b/ParameterizedFunctions/versions/0.2.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.1
 DataStructures 0.4.6
-DiffEqBase
+DiffEqBase 0.0 0.0

--- a/ParameterizedFunctions/versions/0.3.0/requires
+++ b/ParameterizedFunctions/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.1.0
+DiffEqBase 0.1.0 0.5.0

--- a/ParameterizedFunctions/versions/0.3.1/requires
+++ b/ParameterizedFunctions/versions/0.3.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.1.0
+DiffEqBase 0.1.0 0.5.0

--- a/ParameterizedFunctions/versions/0.3.2/requires
+++ b/ParameterizedFunctions/versions/0.3.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.1.0
+DiffEqBase 0.1.0 0.5.0

--- a/ParameterizedFunctions/versions/0.3.3/requires
+++ b/ParameterizedFunctions/versions/0.3.3/requires
@@ -1,4 +1,4 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.5.0

--- a/ParameterizedFunctions/versions/0.4.0/requires
+++ b/ParameterizedFunctions/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.5.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/0.4.1/requires
+++ b/ParameterizedFunctions/versions/0.4.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.5.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/0.4.2/requires
+++ b/ParameterizedFunctions/versions/0.4.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.5.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/0.5.0/requires
+++ b/ParameterizedFunctions/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.4.0
+DiffEqBase 0.4.0 0.5.0
 SimpleTraits 0.1.1


### PR DESCRIPTION
This is to make sure DiffEqBase v0.5 won't be enabled until the ParameterizedFunction update.

Is this right? @tkelman