### PR TITLE
max versions on DiffEqDevTools

### DIFF
--- a/DiffEqDevTools/versions/0.0.1/requires
+++ b/DiffEqDevTools/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase
+DiffEqBase 0.0.0 0.5.0
 StochasticDiffEq
 OrdinaryDiffEq
 FiniteElementDiffEq

--- a/DiffEqDevTools/versions/0.0.2/requires
+++ b/DiffEqDevTools/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase
+DiffEqBase 0.0.0 0.5.0
 StochasticDiffEq
 OrdinaryDiffEq
 FiniteElementDiffEq

--- a/DiffEqDevTools/versions/0.1.0/requires
+++ b/DiffEqDevTools/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase
+DiffEqBase 0.0.0 0.5.0
 StochasticDiffEq
 OrdinaryDiffEq
 FiniteElementDiffEq

--- a/DiffEqDevTools/versions/0.1.1/requires
+++ b/DiffEqDevTools/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase 0.1.3
+DiffEqBase 0.1.3 0.5.0
 StochasticDiffEq 0.0.5
 OrdinaryDiffEq 0.1.1
 FiniteElementDiffEq 0.0.5

--- a/DiffEqDevTools/versions/0.2.0/requires
+++ b/DiffEqDevTools/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.5.0
 FiniteElementDiffEq 0.0.5
 RecursiveArrayTools 0.0.2

--- a/DiffEqDevTools/versions/0.2.1/requires
+++ b/DiffEqDevTools/versions/0.2.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase 0.3.0
+DiffEqBase 0.3.0 0.5.0
 RecursiveArrayTools 0.0.2

--- a/DiffEqDevTools/versions/0.3.0/requires
+++ b/DiffEqDevTools/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase 0.3.0
+DiffEqBase 0.3.0 0.5.0
 RecursiveArrayTools 0.0.2

--- a/DiffEqDevTools/versions/0.4.0/requires
+++ b/DiffEqDevTools/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase 0.4.0
+DiffEqBase 0.4.0 0.5.0
 RecursiveArrayTools 0.1.2

--- a/DiffEqDevTools/versions/0.5.0/requires
+++ b/DiffEqDevTools/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase 0.4.0
+DiffEqBase 0.4.0 0.5.0
 RecursiveArrayTools 0.1.2
 DiffEqPDEBase


### PR DESCRIPTION
This is preparing for the DiffEqBase  tag.  A change in the tableau representation will cause breakage.