### PR TITLE
Tag MathProgBase v0.5.9 [https://github.com/JuliaOpt/MathProgBase.jl]

### DIFF
--- a/MathProgBase/versions/0.5.9/requires
+++ b/MathProgBase/versions/0.5.9/requires
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.7.13

--- a/MathProgBase/versions/0.5.9/sha1
+++ b/MathProgBase/versions/0.5.9/sha1
@@ -1,0 +1,1 @@
+e91bbd7432b946dac18c8427d505a01bfeab6a5d


### PR DESCRIPTION
Tagging a release before dropping support for 0.4.