### PR TITLE
Upper bound Compat on packages at risk of breaking with 0.11

### DIFF
--- a/Cliffords/versions/0.2.0/requires
+++ b/Cliffords/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.3-
 Iterators
-Compat
+Compat 0.0 0.11

--- a/Cliffords/versions/0.2.1/requires
+++ b/Cliffords/versions/0.2.1/requires
@@ -1,3 +1,3 @@
 julia 0.3-
 Iterators
-Compat
+Compat 0.0 0.11

--- a/Cliffords/versions/0.2.2/requires
+++ b/Cliffords/versions/0.2.2/requires
@@ -1,3 +1,3 @@
 julia 0.3-
 Iterators
-Compat
+Compat 0.0 0.11

--- a/Cliffords/versions/0.2.3/requires
+++ b/Cliffords/versions/0.2.3/requires
@@ -1,3 +1,3 @@
 julia 0.3-
 Iterators
-Compat
+Compat 0.0 0.11

--- a/Cliffords/versions/0.3.0/requires
+++ b/Cliffords/versions/0.3.0/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Iterators
-Compat
+Compat 0.0 0.11

--- a/CoordinateTransformations/versions/0.2.0/requires
+++ b/CoordinateTransformations/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-Compat 0.8
+Compat 0.8 0.11
 FixedSizeArrays 0.2.2
 Rotations 0.1.0 0.2+

--- a/Geodesy/versions/0.1.0/requires
+++ b/Geodesy/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.4
-Compat
+Compat 0.0 0.11
 CoordinateTransformations 0.1 0.2-

--- a/Geodesy/versions/0.2.0/requires
+++ b/Geodesy/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-Compat
+Compat 0.0 0.11
 CoordinateTransformations 0.2.0 0.3-
 FixedSizeArrays


### PR DESCRIPTION
Compat 0.11 introduces the ∘ operator from Base. Out of caution, we should ensure that packages that depend on Compat are not broken by this change.

## Cliffords

cc @marcusps @blakejohnson 
Since your package no longer depends on Compat, you don't need to take any action. It also looks like you have already fixed the ∘ operator.

## CoordinateTransforms

cc @c42f @andyferris 
Your package also no longer depends on Compat so there is no rush to tag a new version. But if the package will depend on Compat in the future again, it should probably avoid defining the ∘ operator locally if possible. I don't think it will break this package, but...

## Geodesy

Geodesy imports ∘ from CoordinateTransforms, so if it also uses Compat, then there will likely be an error due to importing the same name from multiple packages. Geodesy also does not currently depend on Compat, but this should be addressed for the future.

cc @tkelman 
related #7502