### PR TITLE
Tag MathProgBase v0.5.10 [https://github.com/JuliaOpt/MathProgBase.jl]

### DIFF
--- a/MathProgBase/versions/0.5.10/requires
+++ b/MathProgBase/versions/0.5.10/requires
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.7.13

--- a/MathProgBase/versions/0.5.10/sha1
+++ b/MathProgBase/versions/0.5.10/sha1
@@ -1,0 +1,1 @@
+0ae3dc86f8d2f9e9f8abff5643ff00da3fa0a634


### PR DESCRIPTION
Backports a fix (https://github.com/JuliaOpt/MathProgBase.jl/commit/ed759de5e946e6221522131cbc6ae1b06ffa24a3) which affects rotated second order cone solvers.