### PR TITLE
Maximum versions on DiffEqBase for StochasticDiffEq

### DIFF
--- a/StochasticDiffEq/versions/0.0.1/requires
+++ b/StochasticDiffEq/versions/0.0.1/requires
@@ -2,3 +2,4 @@ julia 0.5
 ParameterizedFunctions 0.1.0
 Parameters 0.5.0
 ChunkedArrays 0.1.0
+DiffEqBase 0.0.0 0.7.0

--- a/StochasticDiffEq/versions/0.0.2/requires
+++ b/StochasticDiffEq/versions/0.0.2/requires
@@ -2,4 +2,4 @@ julia 0.5
 ParameterizedFunctions 0.1.0
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0

--- a/StochasticDiffEq/versions/0.0.3/requires
+++ b/StochasticDiffEq/versions/0.0.3/requires
@@ -2,4 +2,4 @@ julia 0.5
 ParameterizedFunctions 0.1.0
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0

--- a/StochasticDiffEq/versions/0.0.4/requires
+++ b/StochasticDiffEq/versions/0.0.4/requires
@@ -2,5 +2,5 @@ julia 0.5
 ParameterizedFunctions 0.1.0
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0
 RecursiveArrayTools

--- a/StochasticDiffEq/versions/0.0.5/requires
+++ b/StochasticDiffEq/versions/0.0.5/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0
 RecursiveArrayTools

--- a/StochasticDiffEq/versions/0.1.0/requires
+++ b/StochasticDiffEq/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.1.1/requires
+++ b/StochasticDiffEq/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.2.0/requires
+++ b/StochasticDiffEq/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.3.0/requires
+++ b/StochasticDiffEq/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 RecursiveArrayTools 0.0.2
 DataStructures
 ResettableStacks

--- a/StochasticDiffEq/versions/0.4.0/requires
+++ b/StochasticDiffEq/versions/0.4.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.4.0
+DiffEqBase 0.4.0 0.7.0
 RecursiveArrayTools 0.1.2
 DataStructures 0.4.6
 ResettableStacks 0.0.1

--- a/StochasticDiffEq/versions/0.5.0/requires
+++ b/StochasticDiffEq/versions/0.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.4.0
+DiffEqBase 0.4.0 0.7.0
 RecursiveArrayTools 0.1.2
 DataStructures 0.4.6
 ResettableStacks 0.0.1


### PR DESCRIPTION
There will be a tag in DiffEqBase and a corresponding update in StochasticDiffEq which changes the noise interface to allow for in-place RNGs. No previous version will be compatible with the defaults in the new version, so this will block the release until a compatible version of StochasticDiffEq.jl is available.