### PR TITLE
Make FixedPointNumbers 0.3.0 require Julia 0.5

### DIFF
--- a/FixedPointNumbers/versions/0.3.0/requires
+++ b/FixedPointNumbers/versions/0.3.0/requires
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.5
 Compat 0.9.1


### PR DESCRIPTION
to avoid introducing deprecations on Julia 0.4 where many packages
are no longer introducing new updates

cc @timholy 

corresponding package PR at https://github.com/JuliaMath/FixedPointNumbers.jl/pull/65