### PR TITLE
Add Images 0.6 upper bound on ColorSchemes, ImageQuilting, VideoIO

### DIFF
--- a/ColorSchemes/versions/0.0.1/requires
+++ b/ColorSchemes/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
-Images
+Images 0.0- 0.6
 Colors
 Clustering

--- a/ColorSchemes/versions/0.0.2/requires
+++ b/ColorSchemes/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Images
+Images 0.0- 0.6
 Colors
 Clustering
 FileIO

--- a/ColorSchemes/versions/0.0.3/requires
+++ b/ColorSchemes/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Images
+Images 0.0- 0.6
 Colors
 Clustering
 FileIO

--- a/ColorSchemes/versions/1.0.0/requires
+++ b/ColorSchemes/versions/1.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Images
+Images 0.0- 0.6
 Colors
 Clustering
 FileIO

--- a/ColorSchemes/versions/1.1.0/requires
+++ b/ColorSchemes/versions/1.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Images
+Images 0.0- 0.6
 Colors
 Clustering
 FileIO

--- a/ColorSchemes/versions/1.2.1/requires
+++ b/ColorSchemes/versions/1.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Images
+Images 0.0- 0.6
 Colors
 Clustering
 FileIO

--- a/ImageQuilting/versions/0.0.1/requires
+++ b/ImageQuilting/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.3.3-
+Images 0.3.3- 0.6

--- a/ImageQuilting/versions/0.0.2/requires
+++ b/ImageQuilting/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.4-
+Images 0.4.4- 0.6

--- a/ImageQuilting/versions/0.0.3/requires
+++ b/ImageQuilting/versions/0.0.3/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.20-
+Images 0.4.20- 0.6

--- a/ImageQuilting/versions/0.0.4/requires
+++ b/ImageQuilting/versions/0.0.4/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.20-
+Images 0.4.20- 0.6

--- a/ImageQuilting/versions/0.1.0/requires
+++ b/ImageQuilting/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.30-
+Images 0.4.30- 0.6

--- a/ImageQuilting/versions/0.1.1/requires
+++ b/ImageQuilting/versions/0.1.1/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.30-
+Images 0.4.30- 0.6

--- a/ImageQuilting/versions/0.1.2/requires
+++ b/ImageQuilting/versions/0.1.2/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.30-
+Images 0.4.30- 0.6

--- a/ImageQuilting/versions/0.1.3/requires
+++ b/ImageQuilting/versions/0.1.3/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.30-
+Images 0.4.30- 0.6

--- a/ImageQuilting/versions/0.2.0/requires
+++ b/ImageQuilting/versions/0.2.0/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.40-
+Images 0.4.40- 0.6

--- a/ImageQuilting/versions/0.2.1/requires
+++ b/ImageQuilting/versions/0.2.1/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.40-
+Images 0.4.40- 0.6

--- a/ImageQuilting/versions/0.2.2/requires
+++ b/ImageQuilting/versions/0.2.2/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.40-
+Images 0.4.40- 0.6

--- a/ImageQuilting/versions/0.2.3/requires
+++ b/ImageQuilting/versions/0.2.3/requires
@@ -1,2 +1,2 @@
 julia 0.4-
-Images 0.4.40-
+Images 0.4.40- 0.6

--- a/ImageQuilting/versions/0.2.4/requires
+++ b/ImageQuilting/versions/0.2.4/requires
@@ -1,3 +1,3 @@
 julia 0.4
-Images 0.4.40
+Images 0.4.40 0.6
 Combinatorics

--- a/ImageQuilting/versions/0.2.5/requires
+++ b/ImageQuilting/versions/0.2.5/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Combinatorics
-Images
+Images 0.0- 0.6

--- a/ImageQuilting/versions/0.2.6/requires
+++ b/ImageQuilting/versions/0.2.6/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Combinatorics
 StatsBase
-Images
+Images 0.0- 0.6

--- a/ImageQuilting/versions/0.2.7/requires
+++ b/ImageQuilting/versions/0.2.7/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Combinatorics
 StatsBase
-Images
+Images 0.0- 0.6
 LightGraphs 0.5.2

--- a/ImageQuilting/versions/0.2.8/requires
+++ b/ImageQuilting/versions/0.2.8/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Combinatorics
 StatsBase
-Images
+Images 0.0- 0.6
 LightGraphs 0.5.2

--- a/ImageQuilting/versions/0.3.0/requires
+++ b/ImageQuilting/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Combinatorics
 StatsBase
-Images
+Images 0.0- 0.6
 LightGraphs 0.5.2

--- a/ImageQuilting/versions/0.3.1/requires
+++ b/ImageQuilting/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Combinatorics
 StatsBase
-Images
+Images 0.0- 0.6
 LightGraphs 0.5.2

--- a/ImageQuilting/versions/0.3.2/requires
+++ b/ImageQuilting/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Combinatorics
 StatsBase
-Images
+Images 0.0- 0.6
 LightGraphs 0.6.1

--- a/ImageQuilting/versions/0.4.0/requires
+++ b/ImageQuilting/versions/0.4.0/requires
@@ -2,6 +2,6 @@ julia 0.5
 Combinatorics
 StatsBase
 Primes
-Images
+Images 0.0- 0.6
 LightGraphs 0.6.1
 ProgressMeter

--- a/ImageQuilting/versions/0.4.1/requires
+++ b/ImageQuilting/versions/0.4.1/requires
@@ -2,7 +2,7 @@ julia 0.5
 Combinatorics
 StatsBase
 Primes
-Images
+Images 0.0- 0.6
 LightGraphs 0.6.1
 ProgressMeter
 Hwloc

--- a/ImageQuilting/versions/0.4.2/requires
+++ b/ImageQuilting/versions/0.4.2/requires
@@ -2,7 +2,7 @@ julia 0.5
 Combinatorics
 StatsBase
 Primes
-Images
+Images 0.0- 0.6
 LightGraphs 0.6.1
 ProgressMeter
 Hwloc

--- a/ImageQuilting/versions/0.4.3/requires
+++ b/ImageQuilting/versions/0.4.3/requires
@@ -2,7 +2,7 @@ julia 0.5
 Combinatorics
 StatsBase
 Primes
-Images
+Images 0.0- 0.6
 LightGraphs 0.6.1
 ProgressMeter
 Hwloc

--- a/VideoIO/versions/0.0.1/requires
+++ b/VideoIO/versions/0.0.1/requires
@@ -1,3 +1,4 @@
 julia v0.3-
 BinDeps
 @osx Homebrew
+Images 0.0- 0.6

--- a/VideoIO/versions/0.0.10/requires
+++ b/VideoIO/versions/0.0.10/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.11/requires
+++ b/VideoIO/versions/0.0.11/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.12/requires
+++ b/VideoIO/versions/0.0.12/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.13/requires
+++ b/VideoIO/versions/0.0.13/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.14/requires
+++ b/VideoIO/versions/0.0.14/requires
@@ -2,7 +2,7 @@ julia v0.3
 Compat
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.15/requires
+++ b/VideoIO/versions/0.0.15/requires
@@ -2,7 +2,7 @@ julia v0.4
 Compat
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.16/requires
+++ b/VideoIO/versions/0.0.16/requires
@@ -2,7 +2,7 @@ julia 0.3
 Compat
 ZipFile
 BinDeps 0.3.4
-Images 0.4.4
+Images 0.4.4 0.6
 ImageView 0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.2/requires
+++ b/VideoIO/versions/0.0.2/requires
@@ -1,3 +1,4 @@
 julia v0.3-
 BinDeps
 @osx Homebrew
+Images 0.0- 0.6

--- a/VideoIO/versions/0.0.3/requires
+++ b/VideoIO/versions/0.0.3/requires
@@ -2,3 +2,4 @@ julia v0.3-
 ZipFile
 BinDeps
 @osx Homebrew
+Images 0.0- 0.6

--- a/VideoIO/versions/0.0.4/requires
+++ b/VideoIO/versions/0.0.4/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.3
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.5/requires
+++ b/VideoIO/versions/0.0.5/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.6/requires
+++ b/VideoIO/versions/0.0.6/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.7/requires
+++ b/VideoIO/versions/0.0.7/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.8/requires
+++ b/VideoIO/versions/0.0.8/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.0.9/requires
+++ b/VideoIO/versions/0.0.9/requires
@@ -1,7 +1,7 @@
 julia v0.3-
 ZipFile
 BinDeps v0.3.4
-Images v0.4.4
+Images v0.4.4 0.6
 ImageView v0.1.4
 @osx Homebrew
 @linux Glob

--- a/VideoIO/versions/0.1.0/requires
+++ b/VideoIO/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Compat 0.8.7
 BinDeps 0.3.4
-Images 0.4.4
+Images 0.4.4 0.6
 ImageView 0.1.4
 @osx Homebrew
 @linux Glob


### PR DESCRIPTION
to postpone upcoming breakage, ref https://github.com/timholy/Images.jl/pull/577#issuecomment-275918132

for the 3 earliest versions of VideoIO, adding artificial Images.jl dependency
to avoid letting Pkg downgrading VideoIO in order to upgrade Images

cc @cormullion, @juliohm, @kmsquire