### PR TITLE
Upper bound Julia version for Reel

### DIFF
--- a/Reel/versions/0.1.0/requires
+++ b/Reel/versions/0.1.0/requires
@@ -1,1 +1,2 @@
+julia 0.3 0.5
 Compat

--- a/Reel/versions/0.1.0/requires
+++ b/Reel/versions/0.1.0/requires
@@ -1,2 +1,2 @@
-julia 0.3 0.5
+julia 0.0- 0.5
 Compat


### PR DESCRIPTION
Through a discussion on Gitter with fuzzybear3965, it came up that there is currently a dependency conflict between Reel 0.2.0+ and Images 0.6.0+. Pkg prefers to install Images 0.6.0 over Reel 0.2.1, and so keeps Reel back to 0.1.0. Unfortunately, the [Reel 0.1.0 source code](https://github.com/shashi/Reel.jl/blob/v0.1.0/src/Reel.jl#L16) will not even load on 0.5. Using the philosophy that if Reel is required, it is better to have a functional Reel 0.2.1 and Images 0.5.14 than a dysfunctional Reel 0.1.0 and Images 0.6.0, I think it is desirable to block installing Reel 0.1.0 on 0.5 entirely.