### PR TITLE
Max versions to prepare for next release

### DIFF
--- a/DelayDiffEq/versions/0.0.1/requires
+++ b/DelayDiffEq/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
-DiffEqBase 0.5.0
-OrdinaryDiffEq 1.0.0
+DiffEqBase 0.5.0 0.7.0
+OrdinaryDiffEq 1.0.0 1.1.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.1.2
 Combinatorics

--- a/DelayDiffEq/versions/0.0.1/requires
+++ b/DelayDiffEq/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.5.0 0.7.0
-OrdinaryDiffEq 1.0.0 1.1.0
+OrdinaryDiffEq 1.0.0 1.2.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.1.2
 Combinatorics

--- a/DifferentialEquations/versions/0.0.1/requires
+++ b/DifferentialEquations/versions/0.0.1/requires
@@ -5,3 +5,4 @@ IterativeSolvers
 PyPlot
 Atom
 NLsolve
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.0.1/requires
+++ b/DifferentialEquations/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 LaTeXStrings
 Plots
 IterativeSolvers

--- a/DifferentialEquations/versions/0.0.1/requires
+++ b/DifferentialEquations/versions/0.0.1/requires
@@ -6,3 +6,4 @@ PyPlot
 Atom
 NLsolve
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.0.1/requires
+++ b/DifferentialEquations/versions/0.0.1/requires
@@ -1,9 +1,7 @@
-julia 0.4
+julia 0.4 0.4
 LaTeXStrings
 Plots
 IterativeSolvers
 PyPlot
 Atom
 NLsolve
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.0.2/requires
+++ b/DifferentialEquations/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 LaTeXStrings
 Plots
 IterativeSolvers

--- a/DifferentialEquations/versions/0.0.2/requires
+++ b/DifferentialEquations/versions/0.0.2/requires
@@ -1,9 +1,7 @@
-julia 0.4
+julia 0.4 0.4
 LaTeXStrings
 Plots
 IterativeSolvers
 PyPlot
 NLsolve
 Parameters
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.0.2/requires
+++ b/DifferentialEquations/versions/0.0.2/requires
@@ -6,3 +6,4 @@ PyPlot
 NLsolve
 Parameters
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.0.2/requires
+++ b/DifferentialEquations/versions/0.0.2/requires
@@ -5,3 +5,4 @@ IterativeSolvers
 PyPlot
 NLsolve
 Parameters
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.0.3/requires
+++ b/DifferentialEquations/versions/0.0.3/requires
@@ -9,3 +9,4 @@ JLD
 ForwardDiff
 IterativeSolvers
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.0.3/requires
+++ b/DifferentialEquations/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.4
 Parameters
 GrowableArrays
 ChunkedArrays
@@ -8,5 +8,3 @@ Plots
 JLD
 ForwardDiff
 IterativeSolvers
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.0.3/requires
+++ b/DifferentialEquations/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 Parameters
 GrowableArrays
 ChunkedArrays

--- a/DifferentialEquations/versions/0.0.3/requires
+++ b/DifferentialEquations/versions/0.0.3/requires
@@ -8,3 +8,4 @@ Plots
 JLD
 ForwardDiff
 IterativeSolvers
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.1.0/requires
+++ b/DifferentialEquations/versions/0.1.0/requires
@@ -1,9 +1,7 @@
-julia 0.4
+julia 0.4 0.4
 Parameters
 GrowableArrays
 ChunkedArrays
 EllipsisNotation
 IterativeSolvers
 Plots
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.0/requires
+++ b/DifferentialEquations/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 Parameters
 GrowableArrays
 ChunkedArrays

--- a/DifferentialEquations/versions/0.1.0/requires
+++ b/DifferentialEquations/versions/0.1.0/requires
@@ -5,3 +5,4 @@ ChunkedArrays
 EllipsisNotation
 IterativeSolvers
 Plots
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.1.0/requires
+++ b/DifferentialEquations/versions/0.1.0/requires
@@ -6,3 +6,4 @@ EllipsisNotation
 IterativeSolvers
 Plots
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.1/requires
+++ b/DifferentialEquations/versions/0.1.1/requires
@@ -1,9 +1,7 @@
-julia 0.4
+julia 0.4 0.4
 Parameters
 GrowableArrays
 ChunkedArrays
 EllipsisNotation
 IterativeSolvers
 Plots
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.1/requires
+++ b/DifferentialEquations/versions/0.1.1/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 Parameters
 GrowableArrays
 ChunkedArrays

--- a/DifferentialEquations/versions/0.1.1/requires
+++ b/DifferentialEquations/versions/0.1.1/requires
@@ -5,3 +5,4 @@ ChunkedArrays
 EllipsisNotation
 IterativeSolvers
 Plots
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.1.1/requires
+++ b/DifferentialEquations/versions/0.1.1/requires
@@ -6,3 +6,4 @@ EllipsisNotation
 IterativeSolvers
 Plots
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.2/requires
+++ b/DifferentialEquations/versions/0.1.2/requires
@@ -7,3 +7,4 @@ IterativeSolvers
 GenericSVD
 Plots
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.2/requires
+++ b/DifferentialEquations/versions/0.1.2/requires
@@ -6,3 +6,4 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.1.2/requires
+++ b/DifferentialEquations/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.5
 Parameters
 GrowableArrays
 ChunkedArrays
@@ -6,5 +6,3 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.3/requires
+++ b/DifferentialEquations/versions/0.1.3/requires
@@ -7,3 +7,4 @@ IterativeSolvers
 GenericSVD
 Plots
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.3/requires
+++ b/DifferentialEquations/versions/0.1.3/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.4
 Parameters
 GrowableArrays
 ChunkedArrays
@@ -6,5 +6,3 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.3/requires
+++ b/DifferentialEquations/versions/0.1.3/requires
@@ -6,3 +6,4 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.1.3/requires
+++ b/DifferentialEquations/versions/0.1.3/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 Parameters
 GrowableArrays
 ChunkedArrays

--- a/DifferentialEquations/versions/0.1.4/requires
+++ b/DifferentialEquations/versions/0.1.4/requires
@@ -8,3 +8,4 @@ IterativeSolvers
 GenericSVD
 Plots
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.4/requires
+++ b/DifferentialEquations/versions/0.1.4/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 Parameters
 ForwardDiff
 GrowableArrays

--- a/DifferentialEquations/versions/0.1.4/requires
+++ b/DifferentialEquations/versions/0.1.4/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.4
 Parameters
 ForwardDiff
 GrowableArrays
@@ -7,5 +7,3 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.1.4/requires
+++ b/DifferentialEquations/versions/0.1.4/requires
@@ -7,3 +7,4 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.2.0/requires
+++ b/DifferentialEquations/versions/0.2.0/requires
@@ -8,3 +8,4 @@ IterativeSolvers
 GenericSVD
 Plots
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.2.0/requires
+++ b/DifferentialEquations/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 Parameters
 ForwardDiff
 GrowableArrays

--- a/DifferentialEquations/versions/0.2.0/requires
+++ b/DifferentialEquations/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.4
 Parameters
 ForwardDiff
 GrowableArrays
@@ -7,5 +7,3 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.2.0/requires
+++ b/DifferentialEquations/versions/0.2.0/requires
@@ -7,3 +7,4 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.2.1/requires
+++ b/DifferentialEquations/versions/0.2.1/requires
@@ -8,3 +8,4 @@ IterativeSolvers
 GenericSVD
 Plots
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.2.1/requires
+++ b/DifferentialEquations/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 Parameters
 ForwardDiff
 GrowableArrays

--- a/DifferentialEquations/versions/0.2.1/requires
+++ b/DifferentialEquations/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.4
 Parameters
 ForwardDiff
 GrowableArrays
@@ -7,5 +7,3 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.2.1/requires
+++ b/DifferentialEquations/versions/0.2.1/requires
@@ -7,3 +7,4 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.3.0/requires
+++ b/DifferentialEquations/versions/0.3.0/requires
@@ -10,3 +10,4 @@ Compat
 Plots
 InplaceOps
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.3.0/requires
+++ b/DifferentialEquations/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.4
 Parameters
 ForwardDiff
 GrowableArrays
@@ -9,5 +9,3 @@ GenericSVD
 Compat
 Plots
 InplaceOps
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.3.0/requires
+++ b/DifferentialEquations/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.4 0.4
+julia 0.4 0.5
 Parameters
 ForwardDiff
 GrowableArrays

--- a/DifferentialEquations/versions/0.3.0/requires
+++ b/DifferentialEquations/versions/0.3.0/requires
@@ -9,3 +9,4 @@ GenericSVD
 Compat
 Plots
 InplaceOps
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.4.0/requires
+++ b/DifferentialEquations/versions/0.4.0/requires
@@ -8,5 +8,5 @@ Compat 0.8.8
 Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0
+OrdinaryDiffEq 0.0.0 1.2.0
+StochasticDiffEq 0.0.0 1.0.0

--- a/DifferentialEquations/versions/0.4.0/requires
+++ b/DifferentialEquations/versions/0.4.0/requires
@@ -8,3 +8,4 @@ Compat 0.8.8
 Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.4.0/requires
+++ b/DifferentialEquations/versions/0.4.0/requires
@@ -9,3 +9,4 @@ Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.4.1/requires
+++ b/DifferentialEquations/versions/0.4.1/requires
@@ -8,5 +8,5 @@ Compat 0.8.8
 Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0
+OrdinaryDiffEq 0.0.0 1.2.0
+StochasticDiffEq 0.0.0 1.0.0

--- a/DifferentialEquations/versions/0.4.1/requires
+++ b/DifferentialEquations/versions/0.4.1/requires
@@ -8,3 +8,4 @@ Compat 0.8.8
 Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.4.1/requires
+++ b/DifferentialEquations/versions/0.4.1/requires
@@ -9,3 +9,4 @@ Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.4.2/requires
+++ b/DifferentialEquations/versions/0.4.2/requires
@@ -8,5 +8,5 @@ Compat 0.8.8
 Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0
+OrdinaryDiffEq 0.0.0 1.2.0
+StochasticDiffEq 0.0.0 1.0.0

--- a/DifferentialEquations/versions/0.4.2/requires
+++ b/DifferentialEquations/versions/0.4.2/requires
@@ -8,3 +8,4 @@ Compat 0.8.8
 Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.4.2/requires
+++ b/DifferentialEquations/versions/0.4.2/requires
@@ -9,3 +9,4 @@ Plots 0.9.2
 InplaceOps 0.0.5
 SIUnits 0.0.6
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/0.5.0/requires
+++ b/DifferentialEquations/versions/0.5.0/requires
@@ -10,5 +10,5 @@ InplaceOps 0.0.5
 NLsolve 0.7.3
 Sundials 0.3.0
 Ranges 0.0.1
-OrdinaryDiffEq 0.0.0 1.1.0
-StochasticDiffEq 0.0.0 0.5.0
+OrdinaryDiffEq 0.0.0 1.2.0
+StochasticDiffEq 0.0.0 1.0.0

--- a/DifferentialEquations/versions/0.5.0/requires
+++ b/DifferentialEquations/versions/0.5.0/requires
@@ -10,3 +10,4 @@ InplaceOps 0.0.5
 NLsolve 0.7.3
 Sundials 0.3.0
 Ranges 0.0.1
+OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/0.5.0/requires
+++ b/DifferentialEquations/versions/0.5.0/requires
@@ -11,3 +11,4 @@ NLsolve 0.7.3
 Sundials 0.3.0
 Ranges 0.0.1
 OrdinaryDiffEq 0.0.0 1.1.0
+StochasticDiffEq 0.0.0 0.5.0

--- a/DifferentialEquations/versions/1.0.0/requires
+++ b/DifferentialEquations/versions/1.0.0/requires
@@ -4,7 +4,7 @@ DiffEqBase
 StochasticDiffEq
 FiniteElementDiffEq
 DiffEqDevTools
-OrdinaryDiffEq
+OrdinaryDiffEq 0.0.0 1.1.0
 AlgebraicDiffEq
 StokesDiffEq
 DiffEqParamEstim

--- a/DifferentialEquations/versions/1.0.0/requires
+++ b/DifferentialEquations/versions/1.0.0/requires
@@ -1,12 +1,12 @@
 julia 0.5
 Reexport
 DiffEqBase
-StochasticDiffEq 0.0.0 0.5.0
 FiniteElementDiffEq
 DiffEqDevTools
-OrdinaryDiffEq 0.0.0 1.1.0
 AlgebraicDiffEq
 StokesDiffEq
 DiffEqParamEstim
 DiffEqSensitivity
 Sundials
+OrdinaryDiffEq 0.0.0 1.2.0
+StochasticDiffEq 0.0.0 1.0.0

--- a/DifferentialEquations/versions/1.0.0/requires
+++ b/DifferentialEquations/versions/1.0.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Reexport
 DiffEqBase
-StochasticDiffEq
+StochasticDiffEq 0.0.0 0.5.0
 FiniteElementDiffEq
 DiffEqDevTools
 OrdinaryDiffEq 0.0.0 1.1.0

--- a/DifferentialEquations/versions/1.1.0/requires
+++ b/DifferentialEquations/versions/1.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.1.3
-StochasticDiffEq 0.0.5
+StochasticDiffEq 0.0.5 0.5.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.1.1
 OrdinaryDiffEq 0.1.1 1.1.0

--- a/DifferentialEquations/versions/1.1.0/requires
+++ b/DifferentialEquations/versions/1.1.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.1.3
-StochasticDiffEq 0.0.5 0.5.0
+StochasticDiffEq 0.0.5 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.1.1
-OrdinaryDiffEq 0.1.1 1.1.0
+OrdinaryDiffEq 0.1.1 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.1.0/requires
+++ b/DifferentialEquations/versions/1.1.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.1.3
 StochasticDiffEq 0.0.5
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.1.1
-OrdinaryDiffEq 0.1.1
+OrdinaryDiffEq 0.1.1 1.1.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.2.0/requires
+++ b/DifferentialEquations/versions/1.2.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.2.0
 StochasticDiffEq 0.1.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0
+OrdinaryDiffEq 0.2.0 1.1.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.2.0/requires
+++ b/DifferentialEquations/versions/1.2.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0 0.5.0
+StochasticDiffEq 0.1.0 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0 1.1.0
+OrdinaryDiffEq 0.2.0 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.2.0/requires
+++ b/DifferentialEquations/versions/1.2.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0
+StochasticDiffEq 0.1.0 0.5.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
 OrdinaryDiffEq 0.2.0 1.1.0

--- a/DifferentialEquations/versions/1.3.0/requires
+++ b/DifferentialEquations/versions/1.3.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.2.0
 StochasticDiffEq 0.1.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0
+OrdinaryDiffEq 0.2.0 1.1.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.3.0/requires
+++ b/DifferentialEquations/versions/1.3.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0 0.5.0
+StochasticDiffEq 0.1.0 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0 1.1.0
+OrdinaryDiffEq 0.2.0 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.3.0/requires
+++ b/DifferentialEquations/versions/1.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0
+StochasticDiffEq 0.1.0 0.5.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
 OrdinaryDiffEq 0.2.0 1.1.0

--- a/DifferentialEquations/versions/1.3.1/requires
+++ b/DifferentialEquations/versions/1.3.1/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.2.0
 StochasticDiffEq 0.1.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0
+OrdinaryDiffEq 0.2.0 1.1.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.3.1/requires
+++ b/DifferentialEquations/versions/1.3.1/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0 0.5.0
+StochasticDiffEq 0.1.0 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0 1.1.0
+OrdinaryDiffEq 0.2.0 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.3.1/requires
+++ b/DifferentialEquations/versions/1.3.1/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0
+StochasticDiffEq 0.1.0 0.5.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
 OrdinaryDiffEq 0.2.0 1.1.0

--- a/DifferentialEquations/versions/1.4.0/requires
+++ b/DifferentialEquations/versions/1.4.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.2.0
 StochasticDiffEq 0.1.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0
+OrdinaryDiffEq 0.2.0 1.1.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.4.0/requires
+++ b/DifferentialEquations/versions/1.4.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0 0.5.0
+StochasticDiffEq 0.1.0 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0 1.1.0
+OrdinaryDiffEq 0.2.0 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.4.0/requires
+++ b/DifferentialEquations/versions/1.4.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0
+StochasticDiffEq 0.1.0 0.5.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
 OrdinaryDiffEq 0.2.0 1.1.0

--- a/DifferentialEquations/versions/1.5.0/requires
+++ b/DifferentialEquations/versions/1.5.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.2.0
 StochasticDiffEq 0.1.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0
+OrdinaryDiffEq 0.2.0 1.1.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.5.0/requires
+++ b/DifferentialEquations/versions/1.5.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0 0.5.0
+StochasticDiffEq 0.1.0 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0 1.1.0
+OrdinaryDiffEq 0.2.0 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.5.0/requires
+++ b/DifferentialEquations/versions/1.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0
+StochasticDiffEq 0.1.0 0.5.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
 OrdinaryDiffEq 0.2.0 1.1.0

--- a/DifferentialEquations/versions/1.6.0/requires
+++ b/DifferentialEquations/versions/1.6.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.2.0
 StochasticDiffEq 0.1.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0
+OrdinaryDiffEq 0.2.0 1.1.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.6.0/requires
+++ b/DifferentialEquations/versions/1.6.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0 0.5.0
+StochasticDiffEq 0.1.0 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 0.2.0 1.1.0
+OrdinaryDiffEq 0.2.0 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.6.0/requires
+++ b/DifferentialEquations/versions/1.6.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Reexport 0.0.3
 DiffEqBase 0.2.0
-StochasticDiffEq 0.1.0
+StochasticDiffEq 0.1.0 0.5.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
 OrdinaryDiffEq 0.2.0 1.1.0

--- a/OrdinaryDiffEq/versions/0.0.1/requires
+++ b/OrdinaryDiffEq/versions/0.0.1/requires
@@ -8,3 +8,4 @@ NLsolve 0.7.3
 Sundials 0.3.0
 Ranges 0.0.1
 RecipesBase 0.1.0
+DiffEqBase 0.0.0 0.7.0

--- a/OrdinaryDiffEq/versions/0.0.2/requires
+++ b/OrdinaryDiffEq/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.0.3/requires
+++ b/OrdinaryDiffEq/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.0.4/requires
+++ b/OrdinaryDiffEq/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.0.5/requires
+++ b/OrdinaryDiffEq/versions/0.0.5/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.1.0/requires
+++ b/OrdinaryDiffEq/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase
+DiffEqBase 0.0.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.1.1/requires
+++ b/OrdinaryDiffEq/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.1.2
+DiffEqBase 0.1.2 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.2.0/requires
+++ b/OrdinaryDiffEq/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.2.1/requires
+++ b/OrdinaryDiffEq/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.3.0/requires
+++ b/OrdinaryDiffEq/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.3.1/requires
+++ b/OrdinaryDiffEq/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.4.0/requires
+++ b/OrdinaryDiffEq/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.4.1/requires
+++ b/OrdinaryDiffEq/versions/0.4.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.4.2/requires
+++ b/OrdinaryDiffEq/versions/0.4.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.5.0/requires
+++ b/OrdinaryDiffEq/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.2.0
+DiffEqBase 0.2.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/0.6.0/requires
+++ b/OrdinaryDiffEq/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.4.0
+DiffEqBase 0.4.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/1.0.0/requires
+++ b/OrdinaryDiffEq/versions/1.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.6.0
+DiffEqBase 0.6.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/1.0.0/requires
+++ b/OrdinaryDiffEq/versions/1.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.6.0 0.7.0
+DiffEqBase 0.6.0 0.8.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/1.0.1/requires
+++ b/OrdinaryDiffEq/versions/1.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.6.0
+DiffEqBase 0.6.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/1.0.1/requires
+++ b/OrdinaryDiffEq/versions/1.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.6.0 0.7.0
+DiffEqBase 0.6.0 0.8.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/1.0.2/requires
+++ b/OrdinaryDiffEq/versions/1.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.6.0
+DiffEqBase 0.6.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/1.0.2/requires
+++ b/OrdinaryDiffEq/versions/1.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.6.0 0.7.0
+DiffEqBase 0.6.0 0.8.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/1.1.0/requires
+++ b/OrdinaryDiffEq/versions/1.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.7.0
+DiffEqBase 0.7.0 0.7.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/1.1.0/requires
+++ b/OrdinaryDiffEq/versions/1.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.7.0 0.7.0
+DiffEqBase 0.7.0 0.8.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2

--- a/StochasticDiffEq/versions/0.0.1/requires
+++ b/StochasticDiffEq/versions/0.0.1/requires
@@ -2,4 +2,4 @@ julia 0.5
 ParameterizedFunctions 0.1.0
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.0.0 0.7.0
+DiffEqBase 0.0.0 0.8.0

--- a/StochasticDiffEq/versions/0.0.2/requires
+++ b/StochasticDiffEq/versions/0.0.2/requires
@@ -2,4 +2,4 @@ julia 0.5
 ParameterizedFunctions 0.1.0
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.0.0 0.7.0
+DiffEqBase 0.0.0 0.8.0

--- a/StochasticDiffEq/versions/0.0.3/requires
+++ b/StochasticDiffEq/versions/0.0.3/requires
@@ -2,4 +2,4 @@ julia 0.5
 ParameterizedFunctions 0.1.0
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.0.0 0.7.0
+DiffEqBase 0.0.0 0.8.0

--- a/StochasticDiffEq/versions/0.0.4/requires
+++ b/StochasticDiffEq/versions/0.0.4/requires
@@ -2,5 +2,5 @@ julia 0.5
 ParameterizedFunctions 0.1.0
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.0.0 0.7.0
+DiffEqBase 0.0.0 0.8.0
 RecursiveArrayTools

--- a/StochasticDiffEq/versions/0.0.5/requires
+++ b/StochasticDiffEq/versions/0.0.5/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.0.0 0.7.0
+DiffEqBase 0.0.0 0.8.0
 RecursiveArrayTools

--- a/StochasticDiffEq/versions/0.1.0/requires
+++ b/StochasticDiffEq/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.2.0 0.7.0
+DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.1.1/requires
+++ b/StochasticDiffEq/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.2.0 0.7.0
+DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.2.0/requires
+++ b/StochasticDiffEq/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.2.0 0.7.0
+DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.3.0/requires
+++ b/StochasticDiffEq/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.2.0 0.7.0
+DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2
 DataStructures
 ResettableStacks

--- a/StochasticDiffEq/versions/0.4.0/requires
+++ b/StochasticDiffEq/versions/0.4.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.4.0 0.7.0
+DiffEqBase 0.4.0 0.8.0
 RecursiveArrayTools 0.1.2
 DataStructures 0.4.6
 ResettableStacks 0.0.1

--- a/StochasticDiffEq/versions/0.5.0/requires
+++ b/StochasticDiffEq/versions/0.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Parameters 0.5.0
 ChunkedArrays 0.1.0
-DiffEqBase 0.4.0 0.7.0
+DiffEqBase 0.4.0 0.8.0
 RecursiveArrayTools 0.1.2
 DataStructures 0.4.6
 ResettableStacks 0.0.1


### PR DESCRIPTION
The following max versions are required:

- OrdinaryDiffEq.jl, StochasticDiffEq.jl, and DelayDiffEq.jl need to max version DiffEqBase.jl because the next version will allow for an improved interpolations API, which requires new arguments and will thus error on older versions.
- DelayDiffEq.jl needs to version match OrdinaryDiffEq.jl's updates because of its design of essentially bootstrapping off of it.
- DifferentialEquations.jl needs to max version OrdinaryDiffEq.jl and StochasticDiffEq.jl because their default algorithm choices changed to have some type parameters. This actually doesn't make a difference for usage (it'll work), but it's for the tests.