### PR TITLE
prepare for MathProgBase 0.6 release

### DIFF
--- a/AmplNLWriter/versions/0.3.0/requires
+++ b/AmplNLWriter/versions/0.3.0/requires
@@ -1,2 +1,2 @@
 julia 0.5
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7

--- a/CPLEX/versions/0.2.0/requires
+++ b/CPLEX/versions/0.2.0/requires
@@ -1,2 +1,2 @@
 julia 0.5
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7

--- a/Cbc/versions/0.3.0/requires
+++ b/Cbc/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 BinDeps
-MathProgBase 0.5.5 0.6
+MathProgBase 0.5.5 0.7
 @osx Homebrew
 @windows WinRPM

--- a/Clp/versions/0.3.0/requires
+++ b/Clp/versions/0.3.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
 Cbc
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7

--- a/CoinOptServices/versions/0.1.2/requires
+++ b/CoinOptServices/versions/0.1.2/requires
@@ -4,6 +4,6 @@ Cbc
 Ipopt
 LightXML 0.2
 BinDeps
-MathProgBase 0.5.0 0.6.0-
+MathProgBase 0.5.0 0.7
 @osx Homebrew
 @windows WinRPM

--- a/ECOS/versions/0.7.0/requires
+++ b/ECOS/versions/0.7.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 @osx Homebrew

--- a/GLPKMathProgInterface/versions/0.2.3/requires
+++ b/GLPKMathProgInterface/versions/0.2.3/requires
@@ -1,3 +1,3 @@
 julia 0.4
 GLPK 0.2.8
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7

--- a/Gurobi/versions/0.3.0/requires
+++ b/Gurobi/versions/0.3.0/requires
@@ -1,2 +1,2 @@
 julia 0.5
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7

--- a/Ipopt/versions/0.2.6/requires
+++ b/Ipopt/versions/0.2.6/requires
@@ -1,6 +1,6 @@
 julia 0.4
 BinDeps
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 @osx Homebrew
 @windows WinRPM
 Compat 0.8.0

--- a/KNITRO/versions/0.2.0/requires
+++ b/KNITRO/versions/0.2.0/requires
@@ -1,2 +1,2 @@
 julia 0.4
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7

--- a/Mosek/versions/0.6.1/requires
+++ b/Mosek/versions/0.6.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
-MathProgBase 0.5.1 0.6
+MathProgBase 0.5.1 0.7
 

--- a/NLopt/versions/0.3.3/requires
+++ b/NLopt/versions/0.3.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
 @osx Homebrew
 BinDeps
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 Compat 0.8

--- a/SCS/versions/0.2.7/requires
+++ b/SCS/versions/0.2.7/requires
@@ -1,5 +1,5 @@
 julia 0.4.0
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 BinDeps
 Compat 0.8.6
 @osx Homebrew

--- a/Xpress/versions/0.1.0/requires
+++ b/Xpress/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.4
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 Compat 0.8.6


### PR DESCRIPTION
MPB 0.6 is [coming soon](https://github.com/JuliaLang/METADATA.jl/pull/7838). We dropped support for Julia 0.4 and removed functionality for default solvers, so it warranted a new minor release. Nevertheless most solver interfaces will not be affected.