### PR TITLE
upper bound Juno 0.2.6 to prevent its installation on Julia 0.6-dev

### DIFF
--- a/Juno/versions/0.2.6/requires
+++ b/Juno/versions/0.2.6/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6-
 MacroTools
 Hiccup
 Media


### PR DESCRIPTION
LambdaInfo not defined

cc @andreasnoack ref https://github.com/JuliaLang/METADATA.jl/pull/7945#issuecomment-279883202