### PR TITLE
Tag a new version of StructIO

### DIFF
--- a/COFF/versions/0.0.1/requires
+++ b/COFF/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5-
-ObjFileBase
-StructIO
-DWARF
+ObjFileBase 0.0.2 0.0.3
+StructIO 0.0.1 0.1.0
+DWARF 0.0.2 0.0.3

--- a/COFF/versions/0.0.2/requires
+++ b/COFF/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.5-
-ObjFileBase
-StructIO
-DWARF
+ObjFileBase 0.0.4 0.1.0
+StructIO 0.0.2 0.1.0
+DWARF 0.1.0 0.2.0

--- a/DWARF/versions/0.0.0/requires
+++ b/DWARF/versions/0.0.0/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.5
 ELF
 StrPack

--- a/DWARF/versions/0.0.1/requires
+++ b/DWARF/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5-
-StructIO
+StructIO 0.0.1 0.1.0
 ObjFileBase
 AbstractTrees

--- a/DWARF/versions/0.0.2/requires
+++ b/DWARF/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.5-
-StructIO
+StructIO 0.0.1 0.1.0
 ObjFileBase
 AbstractTrees

--- a/DWARF/versions/0.0.3/requires
+++ b/DWARF/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.5-
-StructIO
+StructIO 0.0.1 0.1.0
 ObjFileBase
 AbstractTrees

--- a/DWARF/versions/0.1.0/requires
+++ b/DWARF/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5-
-StructIO
+StructIO 0.0.1 0.1.0
 ObjFileBase
 AbstractTrees

--- a/ELF/versions/0.0.0/requires
+++ b/ELF/versions/0.0.0/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.5
 StrPack

--- a/ELF/versions/0.0.1/requires
+++ b/ELF/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5-
-StructIO
-DWARF
-ObjFileBase
+StructIO 0.0.1 0.0.2
+DWARF 0.0.1 0.0.2
+ObjFileBase 0.0.1 0.0.2
 FileIO

--- a/ELF/versions/0.0.2/requires
+++ b/ELF/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.5-
-StructIO
-DWARF
-ObjFileBase
+StructIO 0.0.1 0.0.2
+DWARF 0.0.2 0.0.3
+ObjFileBase 0.0.2 0.0.3
 FileIO

--- a/ELF/versions/0.0.3/requires
+++ b/ELF/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.5-
-StructIO
-DWARF
-ObjFileBase
+StructIO 0.0.1 0.1.0
+DWARF 0.0.3 0.1.0
+ObjFileBase 0.0.3 0.1.0
 FileIO

--- a/ELF/versions/0.1.0/requires
+++ b/ELF/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5-
-StructIO
-DWARF
-ObjFileBase
+StructIO 0.0.1 0.1.0
+DWARF 0.1.0 0.2.0
+ObjFileBase 0.0.4 0.1.0
 FileIO

--- a/Gallium/versions/0.0.1/requires
+++ b/Gallium/versions/0.0.1/requires
@@ -1,7 +1,7 @@
 julia 0.5-
 TerminalUI
-DWARF
-ELF
-MachO
+DWARF 0.0.1 0.0.2
+ELF 0.0.1 0.0.2
+MachO 0.0.1 0.0.2
 ASTInterpreter
 AbstractTrees

--- a/Gallium/versions/0.0.2/requires
+++ b/Gallium/versions/0.0.2/requires
@@ -1,8 +1,8 @@
 julia 0.5-
 TerminalUI
-DWARF
+DWARF 0.0.2 0.0.3
 ObjFileBase
-ELF
-MachO
+ELF 0.0.2 0.0.3
+MachO 0.0.2 0.0.3
 ASTInterpreter
 AbstractTrees

--- a/Gallium/versions/0.0.3/requires
+++ b/Gallium/versions/0.0.3/requires
@@ -1,10 +1,10 @@
 julia 0.5-
 TerminalUI
-DWARF
+DWARF 0.0.3 0.2.0
 ObjFileBase
-ELF
-MachO
+ELF 0.0.3 0.1.0
+MachO 0.0.3 0.0.4
 ASTInterpreter
 AbstractTrees
-COFF
+COFF 0.0.2 0.1.0
 CRC

--- a/Gallium/versions/0.0.4/requires
+++ b/Gallium/versions/0.0.4/requires
@@ -1,10 +1,10 @@
 julia 0.5-
 TerminalUI
-DWARF
+DWARF 0.1.0 0.2.0
 ObjFileBase
-ELF
-MachO
+ELF 0.1.0 0.2.0
+MachO 0.0.4 0.1.0
 ASTInterpreter
 AbstractTrees
-COFF
+COFF 0.0.2 0.1.0
 CRC

--- a/MachO/versions/0.0.1/requires
+++ b/MachO/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5-
-ObjFileBase
-StructIO
+ObjFileBase 0.0.1 0.0.2
+StructIO 0.0.1 0.1.0

--- a/MachO/versions/0.0.2/requires
+++ b/MachO/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5-
-ObjFileBase
-StructIO
+ObjFileBase 0.0.2 0.0.3
+StructIO 0.0.1 0.0.2

--- a/MachO/versions/0.0.3/requires
+++ b/MachO/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.5-
-ObjFileBase
-StructIO
+ObjFileBase 0.0.3 0.0.4
+StructIO 0.0.2 0.1.0

--- a/MachO/versions/0.0.4/requires
+++ b/MachO/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.5-
-ObjFileBase
-StructIO
+ObjFileBase 0.0.4 0.1.0
+StructIO 0.0.2 0.1.0

--- a/StructIO/versions/0.1.0/requires
+++ b/StructIO/versions/0.1.0/requires
@@ -1,0 +1,2 @@
+julia 0.5
+Compat 0.17.0

--- a/StructIO/versions/0.1.0/sha1
+++ b/StructIO/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+98eed1e536452d5fc922bf13ac5ca9e7cbbfa8fe


### PR DESCRIPTION
Renames the `@struct` macro to `@io` since struct is now a keyword on 0.6. All users need to get upper bounds to keep working. I've tagged all the ones that I have. Don't think there's anybody else.