### PR TITLE
Add julia 0.5 upper bound on early JLD versions

### DIFF
--- a/JLD/versions/0.5.0/requires
+++ b/JLD/versions/0.5.0/requires
@@ -1,3 +1,3 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat

--- a/JLD/versions/0.5.1/requires
+++ b/JLD/versions/0.5.1/requires
@@ -1,3 +1,3 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat

--- a/JLD/versions/0.5.2/requires
+++ b/JLD/versions/0.5.2/requires
@@ -1,3 +1,3 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat

--- a/JLD/versions/0.5.3/requires
+++ b/JLD/versions/0.5.3/requires
@@ -1,3 +1,3 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat

--- a/JLD/versions/0.5.4/requires
+++ b/JLD/versions/0.5.4/requires
@@ -1,3 +1,3 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat

--- a/JLD/versions/0.5.5/requires
+++ b/JLD/versions/0.5.5/requires
@@ -1,3 +1,3 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat 0.7.3

--- a/JLD/versions/0.5.6/requires
+++ b/JLD/versions/0.5.6/requires
@@ -1,4 +1,4 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat 0.7.3
 FileIO

--- a/JLD/versions/0.5.7/requires
+++ b/JLD/versions/0.5.7/requires
@@ -1,4 +1,4 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat 0.7.3
 FileIO

--- a/JLD/versions/0.5.8/requires
+++ b/JLD/versions/0.5.8/requires
@@ -1,4 +1,4 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat 0.7.3
 FileIO

--- a/JLD/versions/0.5.9/requires
+++ b/JLD/versions/0.5.9/requires
@@ -1,4 +1,4 @@
-julia 0.3.4
+julia 0.3.4 0.5
 HDF5
 Compat 0.7.3
 FileIO

--- a/JLD/versions/0.6.0/requires
+++ b/JLD/versions/0.6.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.5
 HDF5
 Compat 0.7.3
 FileIO

--- a/JLD/versions/0.6.1/requires
+++ b/JLD/versions/0.6.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.5
 HDF5
 Compat 0.8.0
 FileIO

--- a/JLD/versions/0.6.2/requires
+++ b/JLD/versions/0.6.2/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.5
 HDF5
 Compat 0.8.0
 FileIO


### PR DESCRIPTION
these used Union(...) or UTF16String so do not load on 0.5

this should help with some of the current resolution failures people are seeing