### PR TITLE
Fix link to manual in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is the official METADATA repo for the Julia package manager. See [manual section](http://docs.julialang.org/en/latest/manual/packages/) on packages for how to use the package manager to install and develop packages.
+This is the official METADATA repo for the Julia package manager. See [manual section](http://docs.julialang.org/en/latest/manual/packages) on packages for how to use the package manager to install and develop packages.
 
 
 Please note our current policies for accepting entries into METADATA.jl:


### PR DESCRIPTION
The link to the Julia's manual section about packages doesn't work with the trailing slash. I tried in both Firefox and MS Edge and had the same issue. Removing the trailing slash fixed the problem in both.