### PR TITLE
Tag Knet v0.8.2 [https://github.com/denizyuret/Knet.jl]

### DIFF
--- a/Knet/versions/0.8.2/requires
+++ b/Knet/versions/0.8.2/requires
@@ -1,0 +1,9 @@
+julia 0.4
+AutoGrad 0.0.5
+Compat 0.16.0   # for @views
+# We need these for some examples. They get automatically installed when needed.
+# ArgParse
+# JLD
+# GZip    # for mnist
+# Images  # for vgg
+# MAT     # for vgg

--- a/Knet/versions/0.8.2/sha1
+++ b/Knet/versions/0.8.2/sha1
@@ -1,0 +1,1 @@
+acd16e604d1342f35d1473bb4ec5ae816c6c7ebb


### PR DESCRIPTION
Replaced "relase" with "0.5" in .travis.yml and removed the Base.min/max definitions from src.