### PR TITLE
Widen MathProgBase requirement on Convex.jl

### DIFF
--- a/Convex/versions/0.4.0/requires
+++ b/Convex/versions/0.4.0/requires
@@ -1,3 +1,3 @@
 julia 0.4
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 DataStructures


### PR DESCRIPTION
Until https://github.com/JuliaLang/METADATA.jl/pull/8080 goes through, this will let the latest releases of JuMP and Convex.jl coexist.

CC @madeleineudell 