### PR TITLE
Bounds on old version of ConicNonlinearBridge

### DIFF
--- a/ConicNonlinearBridge/versions/0.0.1/requires
+++ b/ConicNonlinearBridge/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
-MathProgBase
+MathProgBase 0.4 0.6
 JuMP


### PR DESCRIPTION
Prevents accidental downgrading due to MathProgBase 0.7