### PR TITLE
Tag RationalFunctions

### DIFF
--- a/RationalFunctions/versions/0.0.4/requires
+++ b/RationalFunctions/versions/0.0.4/requires
@@ -1,0 +1,4 @@
+julia 0.4
+Compat 0.8.0
+Polynomials 0.1.2
+RecipesBase

--- a/RationalFunctions/versions/0.0.4/sha1
+++ b/RationalFunctions/versions/0.0.4/sha1
@@ -1,0 +1,1 @@
+9bd8db28913b77c2e34dbb3eccc621ccdafab7a5


### PR DESCRIPTION
Tagging [v0.0.4](https://github.com/aytekinar/RationalFunctions.jl) with the following cosmetic changes:

- [x] switch from `Var` and `Conj` value types to `Val` value type for compatibility,
- [x] drop the deprecated `typealias`, and use `const ...` notation, instead,
- [x] drop the deprecated `is`, and use `===`, instead, and,
- [x] put minimum version requirements for `Plots` and `GR` in `test/REQUIRE`.