### PR TITLE
Update REQUIRE for Query

### DIFF
--- a/Query/versions/0.0.1/requires
+++ b/Query/versions/0.0.1/requires
@@ -2,6 +2,6 @@ julia 0.5-
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7

--- a/Query/versions/0.0.2/requires
+++ b/Query/versions/0.0.2/requires
@@ -2,6 +2,6 @@ julia 0.5-
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7

--- a/Query/versions/0.0.3/requires
+++ b/Query/versions/0.0.3/requires
@@ -2,6 +2,6 @@ julia 0.5-
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7

--- a/Query/versions/0.0.4/requires
+++ b/Query/versions/0.0.4/requires
@@ -2,6 +2,6 @@ julia 0.5
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7

--- a/Query/versions/0.1.0/requires
+++ b/Query/versions/0.1.0/requires
@@ -2,6 +2,6 @@ julia 0.5
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7

--- a/Query/versions/0.2.0/requires
+++ b/Query/versions/0.2.0/requires
@@ -2,6 +2,6 @@ julia 0.5
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7

--- a/Query/versions/0.2.1/requires
+++ b/Query/versions/0.2.1/requires
@@ -2,6 +2,6 @@ julia 0.5
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7

--- a/Query/versions/0.3.0/requires
+++ b/Query/versions/0.3.0/requires
@@ -2,6 +2,6 @@ julia 0.5
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7

--- a/Query/versions/0.3.1/requires
+++ b/Query/versions/0.3.1/requires
@@ -2,6 +2,6 @@ julia 0.5
 NamedTuples 1.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5
-Requires 0.3.0
+Requires 0.3.0 2.0.0
 Documenter 0.3.0
 NullableArrays 0.0.7


### PR DESCRIPTION
Not sure this is the recommended way to handle this, but NamedTuples v2.0.0 (just tagged in JuliaLang/METADATA.jl#8154) breaks Query, so my intention here is to set an upper limit.

I'll try to release a patch release of Query soon that will then work with NamedTuples v2.0.0, but that might take a couple of days and I don't want folks to be stuck with a non-working version until then.