### PR TITLE
Add Optim 0.7 upper bound to KernelDensity

### DIFF
--- a/KernelDensity/versions/0.0.1/requires
+++ b/KernelDensity/versions/0.0.1/requires
@@ -1,3 +1,3 @@
-julia 0.3-
+julia 0.3- 0.4
 StatsBase
 Distributions

--- a/KernelDensity/versions/0.0.2/requires
+++ b/KernelDensity/versions/0.0.2/requires
@@ -1,3 +1,3 @@
-julia 0.3-
+julia 0.3- 0.4
 StatsBase
 Distributions 0.4.6

--- a/KernelDensity/versions/0.1.1/requires
+++ b/KernelDensity/versions/0.1.1/requires
@@ -3,4 +3,4 @@ StatsBase
 Distributions 0.4.6
 Optim 0.0 0.5
 Grid
-Compat
+Compat 0.3.8

--- a/KernelDensity/versions/0.1.2/requires
+++ b/KernelDensity/versions/0.1.2/requires
@@ -3,4 +3,4 @@ StatsBase
 Distributions
 Optim 0.0 0.7
 Grid
-Compat
+Compat 0.7.0

--- a/KernelDensity/versions/0.1.2/requires
+++ b/KernelDensity/versions/0.1.2/requires
@@ -1,6 +1,6 @@
 julia 0.3
 StatsBase
 Distributions
-Optim
+Optim 0.0 0.7
 Grid
 Compat

--- a/KernelDensity/versions/0.2.0/requires
+++ b/KernelDensity/versions/0.2.0/requires
@@ -3,4 +3,4 @@ StatsBase
 Distributions
 Optim 0.0 0.7
 Grid
-Compat
+Compat 0.7.0

--- a/KernelDensity/versions/0.2.0/requires
+++ b/KernelDensity/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.3
 StatsBase
 Distributions
-Optim
+Optim 0.0 0.7
 Grid
 Compat

--- a/KernelDensity/versions/0.3.0/requires
+++ b/KernelDensity/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 StatsBase
 Distributions
-Optim
+Optim 0.0 0.7
 Interpolations
 Compat

--- a/KernelDensity/versions/0.3.0/requires
+++ b/KernelDensity/versions/0.3.0/requires
@@ -3,4 +3,4 @@ StatsBase
 Distributions
 Optim 0.0 0.7
 Interpolations
-Compat
+Compat 0.7.0

--- a/KernelDensity/versions/0.3.1/requires
+++ b/KernelDensity/versions/0.3.1/requires
@@ -3,4 +3,4 @@ StatsBase
 Distributions
 Optim
 Interpolations
-Compat
+Compat 0.7.0


### PR DESCRIPTION
earliest versions don't even load on julia 0.4