### PR TITLE
Fix missing dependency of SingularIntegralEquations on Plots

### DIFF
--- a/SingularIntegralEquations/versions/0.1.1/requires
+++ b/SingularIntegralEquations/versions/0.1.1/requires
@@ -1,3 +1,4 @@
 julia 0.4 0.5
 ApproxFun 0.2 0.3-
 Compat 0.8.4
+Plots

--- a/SingularIntegralEquations/versions/0.1.2/requires
+++ b/SingularIntegralEquations/versions/0.1.2/requires
@@ -1,3 +1,4 @@
 julia 0.4 0.5
 ApproxFun 0.2.1 0.3-
 Compat 0.8.4
+Plots

--- a/SingularIntegralEquations/versions/0.1.3/requires
+++ b/SingularIntegralEquations/versions/0.1.3/requires
@@ -1,3 +1,4 @@
 julia 0.4 0.5
 ApproxFun 0.3 0.3.1-
 Compat 0.8.4
+Plots

--- a/SingularIntegralEquations/versions/0.1.4/requires
+++ b/SingularIntegralEquations/versions/0.1.4/requires
@@ -1,3 +1,4 @@
 julia 0.4 0.5
 ApproxFun 0.3.1 0.4-
 Compat 0.8.4
+Plots

--- a/SingularIntegralEquations/versions/0.1.5/requires
+++ b/SingularIntegralEquations/versions/0.1.5/requires
@@ -1,3 +1,4 @@
 julia 0.4 0.5
 ApproxFun 0.3.2 0.4-
 Compat 0.8.4
+Plots

--- a/SingularIntegralEquations/versions/0.2.0/requires
+++ b/SingularIntegralEquations/versions/0.2.0/requires
@@ -3,3 +3,4 @@ ApproxFun 0.4 0.4.1
 BandedMatrices 0.1.2
 Compat 0.8.4
 DualNumbers 0.2.3
+Plots

--- a/SingularIntegralEquations/versions/0.2.1/requires
+++ b/SingularIntegralEquations/versions/0.2.1/requires
@@ -3,3 +3,4 @@ ApproxFun 0.4.1
 BandedMatrices 0.1.2
 Compat 0.9.5
 DualNumbers 0.2.3
+Plots


### PR DESCRIPTION
cc @dlfivefifty @MikaelSlevinsky since ApproxFun 0.5 came out this has been failing due to an undeclared dependency http://pkg.julialang.org/detail/SingularIntegralEquations.html