### PR TITLE
Tag RoME v0.0.4 [https://github.com/dehann/RoME.jl]

### DIFF
--- a/RoME/versions/0.0.4/requires
+++ b/RoME/versions/0.0.4/requires
@@ -1,0 +1,11 @@
+julia 0.5
+IncrementalInference 0.2.5
+Graphs 0.7.1
+TransformUtils 0.0.5
+KernelDensityEstimate 0.2.3
+Distributions
+Colors
+Gadfly
+JLD
+HDF5
+Optim

--- a/RoME/versions/0.0.4/sha1
+++ b/RoME/versions/0.0.4/sha1
@@ -1,0 +1,1 @@
+6bb6b52d8baff9ce95620060dbc42f6fe4cfeb1a


### PR DESCRIPTION
Redo of #8153 , was missing Optim.jl requirement for testing.

[RoME.jl](https://github.com/dehann/RoME.jl)
v0.0.3 -> [v0.0.4](https://github.com/dehann/RoME.jl/releases/tag/v0.0.4)
[![Build Status](https://travis-ci.org/dehann/RoME.jl.svg?branch=master)](https://travis-ci.org/dehann/RoME.jl)
diff: [vs v0.0.3](https://github.com/dehann/RoME.jl/compare/0f105f4...6bb6b52d)

REQUIRE
```
julia 0.5
IncrementalInference 0.2.5
Graphs 0.7.1
TransformUtils 0.0.5
KernelDensityEstimate 0.2.3
Distributions
Colors
Gadfly
JLD
HDF5
Optim
```