### PR TITLE
Upper bounds on Parameters.jl in DiffEq

### DIFF
--- a/AlgebraicDiffEq/versions/0.0.1/requires
+++ b/AlgebraicDiffEq/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 Sundials 0.3.0
 DiffEqBase

--- a/AlgebraicDiffEq/versions/0.0.2/requires
+++ b/AlgebraicDiffEq/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 Sundials 0.3.0
 DiffEqBase

--- a/AlgebraicDiffEq/versions/0.1.0/requires
+++ b/AlgebraicDiffEq/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 DiffEqBase 0.2.0

--- a/DiffEqBase/versions/0.0.1/requires
+++ b/DiffEqBase/versions/0.0.1/requires
@@ -1,2 +1,3 @@
 julia 0.5
 RecipesBase 0.1.0
+Parameters 0.0.0 0.7.0

--- a/DiffEqBase/versions/0.0.2/requires
+++ b/DiffEqBase/versions/0.0.2/requires
@@ -1,3 +1,4 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
+Parameters 0.0.0 0.7.0

--- a/DiffEqBase/versions/0.0.3/requires
+++ b/DiffEqBase/versions/0.0.3/requires
@@ -1,3 +1,4 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
+Parameters 0.0.0 0.7.0

--- a/DiffEqBase/versions/0.0.4/requires
+++ b/DiffEqBase/versions/0.0.4/requires
@@ -1,3 +1,4 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
+Parameters 0.0.0 0.7.0

--- a/DiffEqBase/versions/0.1.0/requires
+++ b/DiffEqBase/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters
+Parameters 0.0.0 0.7.0
 RecursiveArrayTools

--- a/DiffEqBase/versions/0.1.1/requires
+++ b/DiffEqBase/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters
+Parameters 0.0.0 0.7.0
 RecursiveArrayTools

--- a/DiffEqBase/versions/0.1.2/requires
+++ b/DiffEqBase/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2

--- a/DiffEqBase/versions/0.1.3/requires
+++ b/DiffEqBase/versions/0.1.3/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2

--- a/DiffEqBase/versions/0.10.0/requires
+++ b/DiffEqBase/versions/0.10.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.2.0
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.11.0/requires
+++ b/DiffEqBase/versions/0.11.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.2.0
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.2.0/requires
+++ b/DiffEqBase/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2

--- a/DiffEqBase/versions/0.3.0/requires
+++ b/DiffEqBase/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.3.1/requires
+++ b/DiffEqBase/versions/0.3.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.3.2/requires
+++ b/DiffEqBase/versions/0.3.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.4.0/requires
+++ b/DiffEqBase/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.4.1/requires
+++ b/DiffEqBase/versions/0.4.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.5.0/requires
+++ b/DiffEqBase/versions/0.5.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.6.0/requires
+++ b/DiffEqBase/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.7.0/requires
+++ b/DiffEqBase/versions/0.7.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.0.2
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.8.0/requires
+++ b/DiffEqBase/versions/0.8.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.2.0
 SimpleTraits 0.1.1

--- a/DiffEqBase/versions/0.9.0/requires
+++ b/DiffEqBase/versions/0.9.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 RecipesBase 0.1.0
 Ranges 0.0.1
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecursiveArrayTools 0.2.0
 SimpleTraits 0.1.1

--- a/FiniteElementDiffEq/versions/0.0.1/requires
+++ b/FiniteElementDiffEq/versions/0.0.1/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DiffEqBase
 IterativeSolvers 0.2.2
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 Plots 0.9.2
 RecipesBase 0.1.0
 GenericSVD 0.0.2

--- a/FiniteElementDiffEq/versions/0.0.2/requires
+++ b/FiniteElementDiffEq/versions/0.0.2/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DiffEqBase
 IterativeSolvers 0.2.2
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 Plots 0.9.2
 RecipesBase 0.1.0
 GenericSVD 0.0.2

--- a/FiniteElementDiffEq/versions/0.0.3/requires
+++ b/FiniteElementDiffEq/versions/0.0.3/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DiffEqBase
 IterativeSolvers 0.2.2
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 Plots 0.9.2
 RecipesBase 0.1.0
 GenericSVD 0.0.2

--- a/FiniteElementDiffEq/versions/0.0.4/requires
+++ b/FiniteElementDiffEq/versions/0.0.4/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DiffEqBase
 IterativeSolvers 0.2.2
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecipesBase 0.1.0
 GenericSVD 0.0.2
 ForwardDiff 0.2.4

--- a/FiniteElementDiffEq/versions/0.0.5/requires
+++ b/FiniteElementDiffEq/versions/0.0.5/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DiffEqBase 0.1.1
 IterativeSolvers 0.2.2
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecipesBase 0.1.0
 GenericSVD 0.0.2
 ForwardDiff 0.2.4

--- a/FiniteElementDiffEq/versions/0.1.0/requires
+++ b/FiniteElementDiffEq/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DiffEqBase 0.4.0
 IterativeSolvers 0.2.2
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecipesBase 0.1.0
 GenericSVD 0.0.2
 ForwardDiff 0.2.4

--- a/FiniteElementDiffEq/versions/0.2.0/requires
+++ b/FiniteElementDiffEq/versions/0.2.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DiffEqBase 0.4.0
 IterativeSolvers 0.2.2
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 RecipesBase 0.1.0
 GenericSVD 0.0.2
 ForwardDiff 0.2.4

--- a/FiniteElementDiffEq/versions/0.2.1/requires
+++ b/FiniteElementDiffEq/versions/0.2.1/requires
@@ -2,7 +2,7 @@ julia 0.5
 DiffEqBase 0.4.0
 DiffEqPDEBase
 IterativeSolvers 0.2.2
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 GenericSVD 0.0.2
 ForwardDiff 0.2.4
 NLsolve 0.7.3

--- a/LSODA/versions/0.0.1/requires
+++ b/LSODA/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.9.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 DiffEqBase

--- a/OrdinaryDiffEq/versions/0.0.1/requires
+++ b/OrdinaryDiffEq/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.0.2/requires
+++ b/OrdinaryDiffEq/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.0.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.0.3/requires
+++ b/OrdinaryDiffEq/versions/0.0.3/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.0.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.0.4/requires
+++ b/OrdinaryDiffEq/versions/0.0.4/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.0.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.0.5/requires
+++ b/OrdinaryDiffEq/versions/0.0.5/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.0.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.1.0/requires
+++ b/OrdinaryDiffEq/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.0.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.1.1/requires
+++ b/OrdinaryDiffEq/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.1.2 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.2.0/requires
+++ b/OrdinaryDiffEq/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.2.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.2.1/requires
+++ b/OrdinaryDiffEq/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.2.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.3.0/requires
+++ b/OrdinaryDiffEq/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.2.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.3.1/requires
+++ b/OrdinaryDiffEq/versions/0.3.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.2.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.4.0/requires
+++ b/OrdinaryDiffEq/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.2.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.4.1/requires
+++ b/OrdinaryDiffEq/versions/0.4.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.2.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.4.2/requires
+++ b/OrdinaryDiffEq/versions/0.4.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.2.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.5.0/requires
+++ b/OrdinaryDiffEq/versions/0.5.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.2.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/0.6.0/requires
+++ b/OrdinaryDiffEq/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.4.0 0.7.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.0.0/requires
+++ b/OrdinaryDiffEq/versions/1.0.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.6.0 0.8.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.0.1/requires
+++ b/OrdinaryDiffEq/versions/1.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.6.0 0.8.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.0.2/requires
+++ b/OrdinaryDiffEq/versions/1.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.6.0 0.8.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.1.0/requires
+++ b/OrdinaryDiffEq/versions/1.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.7.0 0.8.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.2.0/requires
+++ b/OrdinaryDiffEq/versions/1.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.8.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.3.0/requires
+++ b/OrdinaryDiffEq/versions/1.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.8.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.3.1/requires
+++ b/OrdinaryDiffEq/versions/1.3.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.8.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.4.0/requires
+++ b/OrdinaryDiffEq/versions/1.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.11.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/OrdinaryDiffEq/versions/1.4.1/requires
+++ b/OrdinaryDiffEq/versions/1.4.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DiffEqBase 0.11.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
 Compat 0.8.8

--- a/StochasticDiffEq/versions/0.0.1/requires
+++ b/StochasticDiffEq/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ParameterizedFunctions 0.1.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0

--- a/StochasticDiffEq/versions/0.0.2/requires
+++ b/StochasticDiffEq/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ParameterizedFunctions 0.1.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0

--- a/StochasticDiffEq/versions/0.0.3/requires
+++ b/StochasticDiffEq/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ParameterizedFunctions 0.1.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0

--- a/StochasticDiffEq/versions/0.0.4/requires
+++ b/StochasticDiffEq/versions/0.0.4/requires
@@ -1,6 +1,6 @@
 julia 0.5
 ParameterizedFunctions 0.1.0
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0
 RecursiveArrayTools

--- a/StochasticDiffEq/versions/0.0.5/requires
+++ b/StochasticDiffEq/versions/0.0.5/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0
 RecursiveArrayTools

--- a/StochasticDiffEq/versions/0.1.0/requires
+++ b/StochasticDiffEq/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.1.1/requires
+++ b/StochasticDiffEq/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.2.0/requires
+++ b/StochasticDiffEq/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.3.0/requires
+++ b/StochasticDiffEq/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2

--- a/StochasticDiffEq/versions/0.4.0/requires
+++ b/StochasticDiffEq/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.4.0 0.8.0
 RecursiveArrayTools 0.1.2

--- a/StochasticDiffEq/versions/0.5.0/requires
+++ b/StochasticDiffEq/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 ChunkedArrays 0.1.0
 DiffEqBase 0.4.0 0.8.0
 RecursiveArrayTools 0.1.2

--- a/StochasticDiffEq/versions/1.0.0/requires
+++ b/StochasticDiffEq/versions/1.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 DiffEqBase 0.8.0
 RecursiveArrayTools 0.2.0
 DataStructures 0.4.6

--- a/StochasticDiffEq/versions/1.0.1/requires
+++ b/StochasticDiffEq/versions/1.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 DiffEqBase 0.8.0
 RecursiveArrayTools 0.2.0
 DataStructures 0.4.6

--- a/StochasticDiffEq/versions/1.0.2/requires
+++ b/StochasticDiffEq/versions/1.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 DiffEqBase 0.8.0
 RecursiveArrayTools 0.2.0
 DataStructures 0.4.6

--- a/StochasticDiffEq/versions/1.1.0/requires
+++ b/StochasticDiffEq/versions/1.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-Parameters 0.5.0
+Parameters 0.5.0 0.7.0
 DiffEqBase 0.11.0
 RecursiveArrayTools 0.2.0
 DataStructures 0.4.6


### PR DESCRIPTION
Avoiding 0.7.0 due to escaping issues. See https://discourse.julialang.org/t/nested-macros-bypass-package-dependencies/2683/4