### PR TITLE
Upper bounds on Parameters.jl

### DIFF
--- a/CMakeWrapper/versions/0.0.1/requires
+++ b/CMakeWrapper/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4
-Parameters 0.5
+Parameters 0.5 0.7.0

--- a/CMakeWrapper/versions/0.0.2/requires
+++ b/CMakeWrapper/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4
-Parameters 0.5
+Parameters 0.5 0.7.0

--- a/ScikitLearn/versions/0.0.1/requires
+++ b/ScikitLearn/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 PyCall 1.4.0
 SymDict 0.0.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 ScikitLearnBase 0.0.1

--- a/ScikitLearn/versions/0.0.2/requires
+++ b/ScikitLearn/versions/0.0.2/requires
@@ -1,7 +1,7 @@
 julia 0.4
 PyCall 1.4.0
 SymDict 0.0.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 ScikitLearnBase 0.0.1

--- a/ScikitLearn/versions/0.0.3/requires
+++ b/ScikitLearn/versions/0.0.3/requires
@@ -1,7 +1,7 @@
 julia 0.4
 PyCall 1.4.0
 SymDict 0.0.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0

--- a/ScikitLearn/versions/0.0.4/requires
+++ b/ScikitLearn/versions/0.0.4/requires
@@ -1,7 +1,7 @@
 julia 0.4
 PyCall 1.4.0
 SymDict 0.0.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0

--- a/ScikitLearn/versions/0.1.0/requires
+++ b/ScikitLearn/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 PyCall 1.6.2
 SymDict 0.0.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0

--- a/ScikitLearn/versions/0.1.1/requires
+++ b/ScikitLearn/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.4
 PyCall 1.6.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0

--- a/ScikitLearn/versions/0.2.0/requires
+++ b/ScikitLearn/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 PyCall 1.6.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0

--- a/ScikitLearn/versions/0.2.1/requires
+++ b/ScikitLearn/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.4
 PyCall 1.6.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0

--- a/ScikitLearn/versions/0.2.2/requires
+++ b/ScikitLearn/versions/0.2.2/requires
@@ -1,6 +1,6 @@
 julia 0.4
 PyCall 1.6.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0

--- a/ScikitLearn/versions/0.2.3/requires
+++ b/ScikitLearn/versions/0.2.3/requires
@@ -1,6 +1,6 @@
 julia 0.4
 PyCall 1.6.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0

--- a/ScikitLearn/versions/0.2.4/requires
+++ b/ScikitLearn/versions/0.2.4/requires
@@ -1,6 +1,6 @@
 julia 0.4
 PyCall 1.6.2
-Parameters 0.3.0
+Parameters 0.3.0 0.7.0
 MacroTools 0.3.0
 Conda
 Requires 0.2.0


### PR DESCRIPTION
Due to escaping issues in Parameters.jl, these packages fail to precompile after `Pkg.update()`. See https://discourse.julialang.org/t/nested-macros-bypass-package-dependencies/2683/4

@rdeits
@cstjean