### PR TITLE
Tag GLPK v0.4.1 [https://github.com/JuliaOpt/GLPK.jl]

### DIFF
--- a/GLPK/versions/0.4.1/requires
+++ b/GLPK/versions/0.4.1/requires
@@ -1,0 +1,4 @@
+julia 0.5
+BinDeps
+@osx Homebrew
+Compat 0.18

--- a/GLPK/versions/0.4.1/sha1
+++ b/GLPK/versions/0.4.1/sha1
@@ -1,0 +1,1 @@
+bb10dd6b5163f64a3b10ac49160a2b396d6ccbcc


### PR DESCRIPTION
Fix deprecation warnings on julia 0.6.