### PR TITLE
add upper bounds on RigidBodyTreeInspector's dependency on RigidBodyDynamics

### DIFF
--- a/RigidBodyTreeInspector/versions/0.0.1/requires
+++ b/RigidBodyTreeInspector/versions/0.0.1/requires
@@ -10,5 +10,5 @@ Interact 0.3.5
 Interpolations 0.3.6
 LightXML 0.4.0
 MeshIO 0.0.6
-RigidBodyDynamics 0.0.2
+RigidBodyDynamics 0.0.2 0.1.0
 StaticArrays 0.0.4

--- a/RigidBodyTreeInspector/versions/0.1.0/requires
+++ b/RigidBodyTreeInspector/versions/0.1.0/requires
@@ -11,5 +11,5 @@ Interact 0.3.5
 Interpolations 0.3.6
 LightXML 0.4.0
 MeshIO 0.0.6
-RigidBodyDynamics 0.0.5
+RigidBodyDynamics 0.0.5 0.1.0
 StaticArrays 0.0.4


### PR DESCRIPTION
ref #8431, breaks due to 'TreeDataStructure not defined'

cc @rdeits @tkoolen