### PR TITLE
Upper bound DriftDiffusionPoissonSystems v0.0.1 dependency on EllipticFEM

### DIFF
--- a/DriftDiffusionPoissonSystems/versions/0.0.1/requires
+++ b/DriftDiffusionPoissonSystems/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
 PyPlot
-EllipticFEM
+EllipticFEM 0.0- 0.0.2


### PR DESCRIPTION
EllipticFem 0.0.2 deleted the Mesh type, DriftDiffusionPoissonSystems v0.0.1 was using it
ref https://github.com/JuliaLang/METADATA.jl/pull/7985#issuecomment-280923138

cc @Stivanification @gerhardtulzer what this will mean is if you have DDPS installed on Julia 0.4, EllipticFEM will get downgraded to version 0.0.1 so DDPS can work correctly. You can avoid that by tagging a Julia-0.4-compatible version of DDPS that works with the latest versions of EllipticFEM (or avoids depending on it).