### PR TITLE
Upper bound Polynomials to 0.1.4 for ControlCore, PolynomialFactors, …

### DIFF
--- a/ControlCore/versions/0.0.1/requires
+++ b/ControlCore/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.4
-Polynomials
+Polynomials 0.0- 0.1.4

--- a/PolynomialFactors/versions/0.0.1/requires
+++ b/PolynomialFactors/versions/0.0.1/requires
@@ -3,3 +3,4 @@ Compat 0.7.15
 Iterators 0.1.0
 Combinatorics 0.2.1
 Primes 0.1.1
+Polynomials 0.0- 0.1.4

--- a/PolynomialFactors/versions/0.0.2/requires
+++ b/PolynomialFactors/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Polynomials 0.1.1
+Polynomials 0.1.1 0.1.4
 Iterators 0.1.0
 Compat 0.7.15
 Combinatorics 0.2.1

--- a/PolynomialFactors/versions/0.0.3/requires
+++ b/PolynomialFactors/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Polynomials 0.1.1
+Polynomials 0.1.1 0.1.4
 Iterators 0.1.0
 Compat 0.7.15
 Combinatorics 0.2.1

--- a/PolynomialMatrices/versions/0.1.0/requires
+++ b/PolynomialMatrices/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
 DataStructures 0.5.1
-Polynomials 0.1.2
+Polynomials 0.1.2 0.1.4
 Compat 0.19.0

--- a/RationalFunctions/versions/0.0.1/requires
+++ b/RationalFunctions/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Compat 0.8.0
-Polynomials 0.1.1
+Polynomials 0.1.1 0.1.4

--- a/RationalFunctions/versions/0.0.2/requires
+++ b/RationalFunctions/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Compat 0.8.0
-Polynomials 0.1.2
+Polynomials 0.1.2 0.1.4
 RecipesBase

--- a/RationalFunctions/versions/0.0.3/requires
+++ b/RationalFunctions/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Compat 0.8.0
-Polynomials 0.1.2
+Polynomials 0.1.2 0.1.4
 RecipesBase

--- a/RationalFunctions/versions/0.0.4/requires
+++ b/RationalFunctions/versions/0.0.4/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Compat 0.8.0
-Polynomials 0.1.2
+Polynomials 0.1.2 0.1.4
 RecipesBase

--- a/Roots/versions/0.1.10/requires
+++ b/Roots/versions/0.1.10/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 ForwardDiff 0.0 0.2

--- a/Roots/versions/0.1.11/requires
+++ b/Roots/versions/0.1.11/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 ForwardDiff 0.0 0.2

--- a/Roots/versions/0.1.12/requires
+++ b/Roots/versions/0.1.12/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 ForwardDiff 0.0 0.2

--- a/Roots/versions/0.1.13/requires
+++ b/Roots/versions/0.1.13/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 ForwardDiff 0.0 0.2

--- a/Roots/versions/0.1.14/requires
+++ b/Roots/versions/0.1.14/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.15/requires
+++ b/Roots/versions/0.1.15/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.16/requires
+++ b/Roots/versions/0.1.16/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.17/requires
+++ b/Roots/versions/0.1.17/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.18/requires
+++ b/Roots/versions/0.1.18/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1.11
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.19/requires
+++ b/Roots/versions/0.1.19/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 ForwardDiff 0.0 0.2
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.20/requires
+++ b/Roots/versions/0.1.20/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 ForwardDiff 0.0 0.2
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.21/requires
+++ b/Roots/versions/0.1.21/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 ForwardDiff 0.0 0.2
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.22/requires
+++ b/Roots/versions/0.1.22/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 ForwardDiff 0.0 0.2
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.23/requires
+++ b/Roots/versions/0.1.23/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.5
+Polynomials 0.0.5 0.1.4
 ForwardDiff 0.0 0.2
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.24/requires
+++ b/Roots/versions/0.1.24/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.5
+Polynomials 0.0.5 0.1.4
 ForwardDiff 0.0 0.2
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.25/requires
+++ b/Roots/versions/0.1.25/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.5
+Polynomials 0.0.5 0.1.4
 ForwardDiff 0.0 0.2
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.26/requires
+++ b/Roots/versions/0.1.26/requires
@@ -1,5 +1,5 @@
 julia 0.3
-Polynomials 0.0.5
+Polynomials 0.0.5 0.1.4
 ForwardDiff 0.0 0.2
 Docile 0.4
 Compat 0.4

--- a/Roots/versions/0.1.9/requires
+++ b/Roots/versions/0.1.9/requires
@@ -1,4 +1,4 @@
 julia 0.3
-Polynomials 0.0.3
+Polynomials 0.0.3 0.1.4
 PowerSeries 0.1
 ForwardDiff 0.0 0.2

--- a/Roots/versions/0.2.0/requires
+++ b/Roots/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Polynomials 0.0.5
+Polynomials 0.0.5 0.1.4
 ForwardDiff 0.2.0
 Docile 0.4
 Primes

--- a/Roots/versions/0.2.1/requires
+++ b/Roots/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-Polynomials 0.0.5
+Polynomials 0.0.5 0.1.4
 ForwardDiff 0.2.0
 Primes
 Compat 0.4

--- a/Roots/versions/0.3.0/requires
+++ b/Roots/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 ForwardDiff 0.2.0
-Polynomials 0.0.5
+Polynomials 0.0.5 0.1.4
 PolynomialFactors 0.0.3
 Compat 0.8.0


### PR DESCRIPTION
…PolynomialMatrices, RationalFunctions, and Roots

There was a change in `eltype`, ref https://github.com/JuliaLang/METADATA.jl/pull/8528#issuecomment-290297570.

cc @jverzani @aytekinar @neveritt 

Having ControlCore, PolynomialMatrices, RationalFunctions, or Roots installed will hold Polynomials back to 0.1.3 until you tag a new version that works with Polynomials 0.1.4 (this was already done for PolynomialFactors, so the upper bound is only applied to the older versions of that package).