### PR TITLE
Script to populate and save test dependencies of registered packages

### DIFF
--- a/.test/testdeps.jl
+++ b/.test/testdeps.jl
@@ -1,0 +1,124 @@
+#!/usr/bin/env julia
+# script to populate test dependencies of registered packages
+# in the same format as metadata-v2
+
+using ProgressMeter
+cd(Pkg.dir("METADATA")) do
+    old_branch = readchomp(`git rev-parse --abbrev-ref HEAD`)
+    old_upstream = readchomp(ignorestatus(`git config --get remote.upstream.url`))
+    try
+        old_upstream == "" || run(`git remote rm upstream`)
+        run(`git remote add -f upstream https://github.com/JuliaLang/METADATA.jl`)
+        sha_upstream = readchomp(`git rev-parse upstream/metadata-v2`)
+        startpoint = strip(readchomp(ignorestatus(`git log -1 --format=%B testdeps --`)))
+        run(`git checkout upstream/metadata-v2`)
+        newtags = cd(Pkg.dir()) do
+            Pkg.Read.available()
+        end
+        urls = Dict{String, String}()
+        for pkg in keys(newtags) # need to pre-populate this for newly registered pkg urls
+            urls[pkg] = Pkg.Read.url(pkg)
+        end
+        if startpoint == ""
+            run(`git checkout --orphan testdeps`)
+        else
+            changedfiles = chomp.(readlines(`git diff --name-only $startpoint HEAD`))
+            for pkg in keys(newtags)
+                anyverschanged = false
+                vers = newtags[pkg]
+                for ver in keys(vers)
+                    if "$pkg/versions/$ver/sha1" in changedfiles
+                        anyverschanged = true
+                    else
+                        delete!(vers, ver)
+                    end
+                end
+                if !anyverschanged
+                    delete!(newtags, pkg)
+                end
+            end
+            run(`git checkout testdeps`)
+        end
+        @showprogress for pkg in keys(newtags)
+            url = urls[pkg]
+            vers = newtags[pkg]
+            filestoadd = [$pkg/url]
+            if !isfile("$pkg/url") || readchomp("$pkg/url") != url
+                run(`mkdir -p $pkg`)
+                open("$pkg/url", "w") do f
+                    println(f, url)
+                end
+            end
+            for ver in keys(vers)
+                tagsha = vers[ver].sha1
+                sha1file = "$pkg/versions/$ver/sha1"
+                push!(filestoadd, sha1file)
+                if !isfile(sha1file) || readchomp(sha1file) != tagsha
+                    run(`mkdir -p $pkg/versions/$ver`)
+                    open(sha1file, "w") do f
+                        println(f, tagsha)
+                    end
+                end
+            end
+            if !ismatch(Pkg.Cache.GITHUB_REGEX, url)
+                # non-github package, do the hard way with an actual clone
+                run(`git clone -q $url $pkg-tmp`)
+                cd("$pkg-tmp") do
+                    for ver in keys(vers)
+                        tagsha = vers[ver].sha1
+                        run(`git checkout -q $tagsha`)
+                        reqfile = "$pkg/versions/$ver/requires"
+                        hasREQUIRE = isfile("../$reqfile")
+                        if isfile("test/REQUIRE")
+                            cp("test/REQUIRE", "../$reqfile")
+                            if !hasREQUIRE && startpoint == ""
+                                println()
+                                warn("$pkg v$ver has a test/REQUIRE but no REQUIRE")
+                            end
+                        elseif hasREQUIRE
+                            rm(reqfile)
+                        end
+                    end
+                end
+                rm("$pkg-tmp", recursive=true)
+                continue
+            end
+            url = Pkg.Cache.normalize_url(url)
+            if endswith(url, ".git")
+                url = url[1:end-4]
+            end
+            @sync for ver in keys(vers)
+                tagsha = vers[ver].sha1
+                @async begin
+                    # check if tagged sha's exist - only github counterexample
+                    # so far is ProjectiveDictionaryPairLearning v0.2.2
+                    #status = readstring(`curl -s -o /dev/null -I -L -w "%{http_code}" $url/tree/$tagsha`)
+                    #if status != "200"
+                    #    println()
+                    #    warn("Status $status returned for $pkg v$ver at $url/tree/$tagsha")
+                    #end
+                    reqfile = "$pkg/versions/$ver/requires"
+                    hasREQUIRE = isfile(reqfile)
+                    status = readstring(`curl -s -o $reqfile -L $url/raw/$tagsha/test/REQUIRE`)
+                    if readchomp(reqfile) == "Not Found"
+                        rm(reqfile)
+                    elseif !hasREQUIRE
+                        if startpoint == ""
+                            println()
+                            warn("$pkg v$ver has a test/REQUIRE but no REQUIRE")
+                        end
+                        push!(filestoadd, reqfile) # is this safe?
+                    end
+                end
+            end
+            for reqfile in filestoadd
+                run(`git add $reqfile`)
+            end
+        end
+        isempty(newtags) || run(`git commit -a -m "$sha_upstream"`)
+    finally
+        run(`git checkout $old_branch`)
+        run(`git remote rm upstream`)
+        old_upstream == "" || run(`git remote add upstream $old_upstream`)
+    end
+end

--- a/.test/testdeps.jl
+++ b/.test/testdeps.jl
@@ -1,124 +1,106 @@
 #!/usr/bin/env julia
 # script to populate test dependencies of registered packages
-# in the same format as metadata-v2
 
-using ProgressMeter
+using JLD
+
+stdreqs = cd(Pkg.dir()) do
+    Pkg.Read.available()
+end
+
 cd(Pkg.dir("METADATA")) do
-    old_branch = readchomp(`git rev-parse --abbrev-ref HEAD`)
-    old_upstream = readchomp(ignorestatus(`git config --get remote.upstream.url`))
-    try
-        old_upstream == "" || run(`git remote rm upstream`)
-        run(`git remote add -f upstream https://github.com/JuliaLang/METADATA.jl`)
-        sha_upstream = readchomp(`git rev-parse upstream/metadata-v2`)
-        startpoint = strip(readchomp(ignorestatus(`git log -1 --format=%B testdeps --`)))
-        run(`git checkout upstream/metadata-v2`)
-        newtags = cd(Pkg.dir()) do
-            Pkg.Read.available()
-        end
-        urls = Dict{String, String}()
-        for pkg in keys(newtags) # need to pre-populate this for newly registered pkg urls
-            urls[pkg] = Pkg.Read.url(pkg)
-        end
-        if startpoint == ""
-            run(`git checkout --orphan testdeps`)
+    empty_pkg() = Dict{VersionNumber, Pkg.Types.Available}()
+    empty_version(sha) = Pkg.Types.Available(sha, Dict{String, Pkg.Types.VersionSet}())
+
+    if isfile(".test/testreqs.jld")
+        # load testreqs and metadata_sha_old from existing saved jld file, if any
+        testreqs, metadata_sha_old = load(".test/testreqs.jld", "testreqs", "metadata_sha")
+    else
+        testreqs = Dict{String, Dict{VersionNumber, Pkg.Types.Available}}()
+        metadata_sha_old = ""
+    end
+    metadata_sha = readchomp(`git rev-parse HEAD`)
+
+    ghpkgs = String[]
+    nonghpkgs = String[]
+    for pkg in keys(stdreqs)
+        haskey(testreqs, pkg) || (testreqs[pkg] = empty_pkg())
+        if ismatch(Pkg.Cache.GITHUB_REGEX, Pkg.Read.url(pkg))
+            push!(ghpkgs, pkg)
         else
-            changedfiles = chomp.(readlines(`git diff --name-only $startpoint HEAD`))
-            for pkg in keys(newtags)
-                anyverschanged = false
-                vers = newtags[pkg]
-                for ver in keys(vers)
-                    if "$pkg/versions/$ver/sha1" in changedfiles
-                        anyverschanged = true
-                    else
-                        delete!(vers, ver)
-                    end
-                end
-                if !anyverschanged
-                    delete!(newtags, pkg)
-                end
-            end
-            run(`git checkout testdeps`)
+            push!(nonghpkgs, pkg)
         end
-        @showprogress for pkg in keys(newtags)
-            url = urls[pkg]
-            vers = newtags[pkg]
-            filestoadd = [$pkg/url]
-            if !isfile("$pkg/url") || readchomp("$pkg/url") != url
-                run(`mkdir -p $pkg`)
-                open("$pkg/url", "w") do f
-                    println(f, url)
-                end
+    end
+
+    asyncmap((pkg, ver) for pkg in ghpkgs for ver in keys(stdreqs[pkg])) do pv
+        # use curl for github packages
+        pkg, ver = pv
+        url = Pkg.Cache.normalize_url(Pkg.Read.url(pkg)) # normalize to https
+        if endswith(url, ".git")
+            url = url[1:end-4]
+        end
+        tagsha = stdreqs[pkg][ver].sha1
+        @assert tagsha != ""
+        testvers = testreqs[pkg]
+        if get(testvers, ver, empty_version("")).sha1 == tagsha
+            # no change in sha since saved version
+            return
+        end
+        # else, new tag or changed sha, update test reqs
+        # check if tagged sha's exist - only github counterexample
+        # so far is ProjectiveDictionaryPairLearning v0.2.2
+        #status = readstring(`curl -s -o /dev/null -I -L -w "%{http_code}" $url/tree/$tagsha`)
+        #if status != "200"
+        #    warn("$pkg v$ver at $url/tree/$tagsha returned status $status")
+        #end
+        content = readlines(`curl -s -L $url/raw/$tagsha/test/REQUIRE`)
+        if length(content) != 1 || chomp(content[1]) != "Not Found"
+            parsedreqs = Pkg.Reqs.parse(content)
+            testvers[ver] = Pkg.Types.Available(tagsha, parsedreqs)
+            if !isempty(parsedreqs) && isempty(stdreqs[pkg][ver].requires)
+                warn("$pkg v$ver has a test/REQUIRE but no REQUIRE")
             end
-            for ver in keys(vers)
-                tagsha = vers[ver].sha1
-                sha1file = "$pkg/versions/$ver/sha1"
-                push!(filestoadd, sha1file)
-                if !isfile(sha1file) || readchomp(sha1file) != tagsha
-                    run(`mkdir -p $pkg/versions/$ver`)
-                    open(sha1file, "w") do f
-                        println(f, tagsha)
-                    end
-                end
+        else
+            if !isempty(get(testvers, ver, empty_version("")).requires)
+                warn("$pkg v$ver previously had a nonempty test/REQUIRE but sha changed?")
             end
-            if !ismatch(Pkg.Cache.GITHUB_REGEX, url)
-                # non-github package, do the hard way with an actual clone
-                run(`git clone -q $url $pkg-tmp`)
-                cd("$pkg-tmp") do
-                    for ver in keys(vers)
-                        tagsha = vers[ver].sha1
-                        run(`git checkout -q $tagsha`)
-                        reqfile = "$pkg/versions/$ver/requires"
-                        hasREQUIRE = isfile("../$reqfile")
-                        if isfile("test/REQUIRE")
-                            cp("test/REQUIRE", "../$reqfile")
-                            if !hasREQUIRE && startpoint == ""
-                                println()
-                                warn("$pkg v$ver has a test/REQUIRE but no REQUIRE")
-                            end
-                        elseif hasREQUIRE
-                            rm(reqfile)
-                        end
-                    end
-                end
-                rm("$pkg-tmp", recursive=true)
+            testvers[ver] = empty_version(tagsha)
+        end
+    end
+
+    # for non-github packages, do the hard way with an actual clone
+    for pkg in nonghpkgs
+        url = Pkg.Read.url(pkg)
+        stdvers = stdreqs[pkg]
+        testvers = testreqs[pkg]
+        for ver in keys(stdvers)
+            tagsha = stdvers[ver].sha1
+            @assert tagsha != ""
+            if get(testvers, ver, empty_version("")).sha1 == tagsha
+                # no change in sha since saved version
                 continue
             end
-            url = Pkg.Cache.normalize_url(url)
-            if endswith(url, ".git")
-                url = url[1:end-4]
-            end
-            @sync for ver in keys(vers)
-                tagsha = vers[ver].sha1
-                @async begin
-                    # check if tagged sha's exist - only github counterexample
-                    # so far is ProjectiveDictionaryPairLearning v0.2.2
-                    #status = readstring(`curl -s -o /dev/null -I -L -w "%{http_code}" $url/tree/$tagsha`)
-                    #if status != "200"
-                    #    println()
-                    #    warn("Status $status returned for $pkg v$ver at $url/tree/$tagsha")
-                    #end
-                    reqfile = "$pkg/versions/$ver/requires"
-                    hasREQUIRE = isfile(reqfile)
-                    status = readstring(`curl -s -o $reqfile -L $url/raw/$tagsha/test/REQUIRE`)
-                    if readchomp(reqfile) == "Not Found"
-                        rm(reqfile)
-                    elseif !hasREQUIRE
-                        if startpoint == ""
-                            println()
-                            warn("$pkg v$ver has a test/REQUIRE but no REQUIRE")
-                        end
-                        push!(filestoadd, reqfile) # is this safe?
+            # else, new tag or changed sha, update test reqs
+            isdir("$pkg-tmp") || run(`git clone $url $pkg-tmp`)
+            cd("$pkg-tmp") do
+                run(`git checkout -q $tagsha`)
+                if isfile("test/REQUIRE")
+                    parsedreqs = Pkg.Reqs.parse("test/REQUIRE")
+                    testvers[ver] = Pkg.Types.Available(tagsha, parsedreqs)
+                    if !isempty(parsedreqs) && isempty(stdvers[ver].requires)
+                        warn("$pkg v$ver has a test/REQUIRE but no REQUIRE")
                     end
+                else
+                    if !isempty(get(testvers, ver, empty_version("")).requires)
+                        warn("$pkg v$ver previously had a nonempty test/REQUIRE but sha changed?")
+                    end
+                    testvers[ver] = empty_version(tagsha)
                 end
             end
-            for reqfile in filestoadd
-                run(`git add $reqfile`)
-            end
         end
-        isempty(newtags) || run(`git commit -a -m "$sha_upstream"`)
-    finally
-        run(`git checkout $old_branch`)
-        run(`git remote rm upstream`)
-        old_upstream == "" || run(`git remote add upstream $old_upstream`)
+        isdir("$pkg-tmp") && rm("$pkg-tmp", recursive=true)
     end
+
+    # save testreqs and metadata_sha to jld file
+    save(".test/testreqs.jld", "testreqs", testreqs, "metadata_sha", metadata_sha)
+    return stdreqs, testreqs
 end

--- a/.test/testdeps.jl
+++ b/.test/testdeps.jl
@@ -55,9 +55,7 @@ allreqs = cd(Pkg.dir("METADATA")) do
         end
     end
 
-    ntasks = haskey(ENV, "CI") ? 20 : 100
-    asyncmap((pkg, ver) for pkg in ghpkgs
-            for ver in readdir(joinpath(pkg, "versions")), ntasks=ntasks) do pv
+    asyncmap((pkg, ver) for pkg in ghpkgs for ver in readdir(joinpath(pkg, "versions"))) do pv
         # use curl for github packages
         pkg, ver = pv
         ismatch(Base.VERSION_REGEX, ver) || return
@@ -84,7 +82,7 @@ allreqs = cd(Pkg.dir("METADATA")) do
         #if status != "200"
         #    warn("$pkg v$ver at $url/tree/$tagsha returned status $status")
         #end
-        testrequires = readstring(`curl -s -L $url/raw/$tagsha/test/REQUIRE`)
+        testrequires = readstring(`curl -s --retry 4 -L $url/raw/$tagsha/test/REQUIRE`)
         if !startswith(testrequires, "Not Found")
             if !isempty(testrequires) && isempty(requires)
                 warn("$pkg v$ver has a test/REQUIRE but no REQUIRE")


### PR DESCRIPTION
Since the contents of `test/REQUIRE` aren't saved in METADATA or any other central location, I wrote this script to collect and save them all. Turns out for the nested dictionary here, JLD is slower and takes much more space than saving the data as a round-trippable Julia syntax string. Using the Julia serializer would be faster than parsing the string representation, but take a few times more space and be much worse to track in version control (being binary).

At least running on Linux with a good connection, the script takes a little under a minute to run the first time, and the saved data is just under a megabyte. Updating a previously saved copy takes just a few seconds, since it only needs to check newly-tagged versions.

I plan on using this data for some automated reverse-dependency testing for proposed new tags, and it'll be good to include test-only reverse dependencies as well as standard dependencies. Since the data is a little large, not needed for normal usage of Pkg, and it would be a fair amount of git noise to continuously track it on the metadata-v2 branch that everyone uses, I'll probably set up a separate branch on my personal METADATA and a Travis cron job to update it nightly. Will see how that goes. It might make things slightly easier if the script itself is committed here though. It's not that long and hopefully once things are up and running I won't have to change it much (at least until Pkg3, but this makes for a pretty good reason to save test dependencies within the Pkg3 registry format anyway).
