### PR TITLE
preempt possible precompile bug

### DIFF
--- a/ReverseDiffSparse/versions/0.7.2/requires
+++ b/ReverseDiffSparse/versions/0.7.2/requires
@@ -1,5 +1,6 @@
 julia 0.5
 Calculus
+Lazy
 DataStructures
 MathProgBase
 NaNMath 0.2.1


### PR DESCRIPTION
We should keep this dependency around until the next time JuMP gets a version bump that triggers precompilation, following discussion with @tkelman.