### PR TITLE
METADATA Tests: Tag/SHA mismatch

### DIFF
--- a/Example/versions/0.2.1/requires
+++ b/Example/versions/0.2.1/requires
@@ -1,0 +1,6 @@
+# This file lists the packages and version ranges required by this package.
+# It is used by the yet-to-be-written package metadata generator to automatically determine metadata for this package in the registry of Julia packages, and when a package is in an attached head state, determines what the requirements of the package are considered to be.
+# The format of the file is that ignore comments and blank lines, each line must have the form "pkg v1 v2..." where the zero or more version numbers in semantic version format [http://semver.org/] determine what intervals of versions of each package are required.
+# If no REQUIRE file is present, it means there are no requirements.
+# See README.md for more details.
+julia 0.2-

--- a/Example/versions/0.2.1/sha1
+++ b/Example/versions/0.2.1/sha1
@@ -1,0 +1,1 @@
+c62dcad13ca2ef40d59f4e1f8e1a452f0b604dd4


### PR DESCRIPTION
Using a parent SHA of v0.2.1.

Testing changes in #8548