### PR TITLE
Emit a better error message for misspecified repo URLs

### DIFF
--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -1,7 +1,11 @@
 const BUILD_DIR = ENV["BUILD_DIR"]
 
 function get_remote_tags(url)
-    ls = readchomp(`git ls-remote --tags -q $url`)
+    ls = try
+        readchomp(`git ls-remote --tags -q $url`)
+    catch
+        error("The specified URL does not correspond to a valid Git repository")
+    end
     lines = split(ls, "\n")
 
     filter!(lines) do line


### PR DESCRIPTION
With this change:
```julia
julia> get_remote_tags("https://github.com/ararslan/Jackknife.jl.git")
Dict{VersionNumber,AbstractString} with 2 entries:
  v"0.1.0" => "ef13817c52284adb704d122536769242a6eebfd1"
  v"0.2.0" => "864fdce2c82c4f113bdf760da9e4dd19a6484589"

julia> get_remote_tags("https://github.com/ararslan/HopesAndDreams.jl.git")
remote: Repository not found.
fatal: repository 'https://github.com/ararslan/HopesAndDreams.jl.git/' not found
ERROR: The specified URL does not correspond to a valid Git repository
Stacktrace:
 [1] get_remote_tags(::String) at ./REPL[6]:5
```
Ref https://github.com/JuliaLang/METADATA.jl/pull/8767#issuecomment-293369113 (cc @tkelman)