### PR TITLE
Bound JSON on packages that used deprecated _print

### DIFF
--- a/Bokeh/versions/0.0.1/requires
+++ b/Bokeh/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 Mustache
-JSON
+JSON 0.0 0.9

--- a/Bokeh/versions/0.1.0/requires
+++ b/Bokeh/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Mustache
-JSON 0.4
+JSON 0.4 0.9
 Dates 0.3.2
 Compat

--- a/Bokeh/versions/0.2.0/requires
+++ b/Bokeh/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Mustache
-JSON 0.4
+JSON 0.4 0.9
 Dates 0.3.2
 Compat

--- a/Escher/versions/0.0.1/requires
+++ b/Escher/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 Compat
-JSON
+JSON 0.0 0.9
 Markdown
 Reactive
 Patchwork

--- a/Escher/versions/0.0.2/requires
+++ b/Escher/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Compat
-JSON
+JSON 0.0 0.9
 Requires
 Markdown
 Reactive

--- a/Escher/versions/0.0.3/requires
+++ b/Escher/versions/0.0.3/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Compat
-JSON
+JSON 0.0 0.9
 Requires
 Markdown
 Reactive

--- a/Escher/versions/0.1.0/requires
+++ b/Escher/versions/0.1.0/requires
@@ -2,7 +2,7 @@ julia 0.3
 ArgParse
 Color
 Compat
-JSON
+JSON 0.0 0.9
 Markdown
 Mux
 Reactive 0.2.2

--- a/Escher/versions/0.2.0/requires
+++ b/Escher/versions/0.2.0/requires
@@ -3,7 +3,7 @@ ArgParse
 Colors
 Compat
 Dates
-JSON
+JSON 0.0 0.9
 Markdown
 Mux 0.1.0
 Reactive 0.2.3

--- a/Escher/versions/0.2.1/requires
+++ b/Escher/versions/0.2.1/requires
@@ -3,7 +3,7 @@ ArgParse
 Colors
 Compat
 Dates
-JSON
+JSON 0.0 0.9
 Markdown
 Mux 0.1.0
 Reactive 0.2.3

--- a/Escher/versions/0.3.0/requires
+++ b/Escher/versions/0.3.0/requires
@@ -3,7 +3,7 @@ ArgParse
 Colors
 Compat
 Dates
-JSON
+JSON 0.0 0.9
 Markdown
 Mux 0.1.0
 Reactive 0.3.0

--- a/Escher/versions/0.3.1/requires
+++ b/Escher/versions/0.3.1/requires
@@ -3,7 +3,7 @@ ArgParse
 Colors
 Compat
 Dates
-JSON
+JSON 0.0 0.9
 Markdown
 Mux 0.1.0
 Reactive 0.3.0

--- a/Escher/versions/0.3.2/requires
+++ b/Escher/versions/0.3.2/requires
@@ -3,7 +3,7 @@ ArgParse
 Colors
 Compat
 Dates
-JSON
+JSON 0.0 0.9
 Markdown
 Mux 0.1.0
 Reactive 0.3.0

--- a/PlotlyJS/versions/0.3.0/requires
+++ b/PlotlyJS/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-JSON 0.6
+JSON 0.6 0.9
 Blink 0.3.3
 Colors
 Compat 0.7.16

--- a/PlotlyJS/versions/0.3.1/requires
+++ b/PlotlyJS/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-JSON
+JSON 0.6 0.9
 Blink 0.3.3
 Colors
 Compat 0.7.16

--- a/Plots/versions/0.0.1/requires
+++ b/Plots/versions/0.0.1/requires
@@ -2,3 +2,4 @@ julia 0.4-
 
 Colors
 FactCheck
+JSON 0.0 0.9

--- a/Plots/versions/0.0.2/requires
+++ b/Plots/versions/0.0.2/requires
@@ -2,3 +2,4 @@ julia 0.4-
 
 Colors
 FactCheck
+JSON 0.0 0.9

--- a/Plots/versions/0.1.0/requires
+++ b/Plots/versions/0.1.0/requires
@@ -2,3 +2,4 @@ julia 0.4-
 
 Colors
 FactCheck
+JSON 0.0 0.9

--- a/Plots/versions/0.1.1/requires
+++ b/Plots/versions/0.1.1/requires
@@ -1,3 +1,4 @@
 julia 0.4-
 
 Colors
+JSON 0.0 0.9

--- a/Plots/versions/0.1.2/requires
+++ b/Plots/versions/0.1.2/requires
@@ -1,3 +1,4 @@
 julia 0.4-
 
 Colors
+JSON 0.0 0.9

--- a/Plots/versions/0.1.3/requires
+++ b/Plots/versions/0.1.3/requires
@@ -1,3 +1,4 @@
 julia 0.4-
 
 Colors
+JSON 0.0 0.9

--- a/Plots/versions/0.2.0/requires
+++ b/Plots/versions/0.2.0/requires
@@ -2,3 +2,4 @@ julia 0.4-
 
 Colors
 Reexport
+JSON 0.0 0.9

--- a/Plots/versions/0.3.0/requires
+++ b/Plots/versions/0.3.0/requires
@@ -2,3 +2,4 @@ julia 0.4-
 
 Colors
 Reexport
+JSON 0.0 0.9

--- a/Plots/versions/0.4.0/requires
+++ b/Plots/versions/0.4.0/requires
@@ -3,3 +3,4 @@ julia 0.3
 Colors
 Reexport
 Compat
+JSON 0.0 0.9

--- a/Plots/versions/0.4.1/requires
+++ b/Plots/versions/0.4.1/requires
@@ -3,3 +3,4 @@ julia 0.3
 Colors
 Reexport
 Compat
+JSON 0.0 0.9

--- a/Plots/versions/0.4.2/requires
+++ b/Plots/versions/0.4.2/requires
@@ -3,3 +3,4 @@ julia 0.3
 Colors
 Reexport
 Compat
+JSON 0.0 0.9

--- a/Plots/versions/0.5.0/requires
+++ b/Plots/versions/0.5.0/requires
@@ -3,3 +3,4 @@ julia 0.4
 Colors
 Reexport
 Compat
+JSON 0.0 0.9

--- a/Plots/versions/0.5.1/requires
+++ b/Plots/versions/0.5.1/requires
@@ -3,3 +3,4 @@ julia 0.4
 Colors
 Reexport
 Compat
+JSON 0.0 0.9

--- a/Plots/versions/0.5.2/requires
+++ b/Plots/versions/0.5.2/requires
@@ -4,3 +4,4 @@ Colors
 Reexport
 Compat
 Requires
+JSON 0.0 0.9

--- a/Plots/versions/0.5.3/requires
+++ b/Plots/versions/0.5.3/requires
@@ -5,3 +5,4 @@ Reexport
 Compat
 Requires
 FixedSizeArrays
+JSON 0.0 0.9

--- a/Plots/versions/0.5.4/requires
+++ b/Plots/versions/0.5.4/requires
@@ -5,3 +5,4 @@ Reexport
 Compat
 Requires
 FixedSizeArrays
+JSON 0.0 0.9

--- a/Plots/versions/0.6.0/requires
+++ b/Plots/versions/0.6.0/requires
@@ -5,3 +5,4 @@ Reexport
 Compat
 Requires
 FixedSizeArrays
+JSON 0.0 0.9

--- a/Plots/versions/0.6.1/requires
+++ b/Plots/versions/0.6.1/requires
@@ -5,3 +5,4 @@ Reexport
 Compat
 Requires
 FixedSizeArrays
+JSON 0.0 0.9

--- a/Plots/versions/0.6.2/requires
+++ b/Plots/versions/0.6.2/requires
@@ -6,3 +6,4 @@ Reexport
 Compat
 Requires
 FixedSizeArrays
+JSON 0.0 0.9

--- a/Plots/versions/0.7.0/requires
+++ b/Plots/versions/0.7.0/requires
@@ -6,3 +6,4 @@ Reexport
 Compat
 FixedSizeArrays
 Measures
+JSON 0.0 0.9

--- a/Plots/versions/0.7.1/requires
+++ b/Plots/versions/0.7.1/requires
@@ -6,3 +6,4 @@ Reexport
 Compat
 FixedSizeArrays
 Measures
+JSON 0.0 0.9

--- a/Plots/versions/0.7.2/requires
+++ b/Plots/versions/0.7.2/requires
@@ -6,3 +6,4 @@ Reexport
 Compat
 FixedSizeArrays
 Measures
+JSON 0.0 0.9

--- a/Plots/versions/0.7.3/requires
+++ b/Plots/versions/0.7.3/requires
@@ -6,3 +6,4 @@ Reexport
 Compat
 FixedSizeArrays
 Measures
+JSON 0.0 0.9

--- a/Plots/versions/0.7.4/requires
+++ b/Plots/versions/0.7.4/requires
@@ -6,3 +6,4 @@ Reexport
 Compat
 FixedSizeArrays
 Measures
+JSON 0.0 0.9

--- a/Plots/versions/0.7.5/requires
+++ b/Plots/versions/0.7.5/requires
@@ -6,3 +6,4 @@ Reexport
 Compat
 FixedSizeArrays
 Measures
+JSON 0.0 0.9

--- a/Plots/versions/0.8.0/requires
+++ b/Plots/versions/0.8.0/requires
@@ -6,3 +6,4 @@ Reexport
 Compat
 FixedSizeArrays
 Measures
+JSON 0.0 0.9

--- a/Plots/versions/0.8.1/requires
+++ b/Plots/versions/0.8.1/requires
@@ -7,3 +7,4 @@ Compat
 FixedSizeArrays
 Measures
 Showoff
+JSON 0.0 0.9

--- a/Plots/versions/0.8.2/requires
+++ b/Plots/versions/0.8.2/requires
@@ -6,3 +6,4 @@ Compat
 FixedSizeArrays
 Measures
 Showoff
+JSON 0.0 0.9

--- a/Plots/versions/0.9.0/requires
+++ b/Plots/versions/0.9.0/requires
@@ -6,3 +6,4 @@ Compat
 FixedSizeArrays
 Measures
 Showoff
+JSON 0.0 0.9


### PR DESCRIPTION
See #8798.

I obtained the list of packages from https://github.com/JuliaIO/JSON.jl/issues/158. The maximum tag with the bound in each case is:

- Plots 0.9.0
- Escher 0.3.2
- Plotly 0.3.1 (note versions 0.2.0 are earlier were already bounded by 0.6.0)
- Bokeh 0.2.0 (note this is the latest tag; the problem is fixed on master but there has been no tag since for this unmaintained package)

Plots is special because it never depended on JSON; instead it used it through its conditional dependency Plotly. I think it is not harmful to add an unnecessary JSON dependency to old versions of Plots.