### PR TITLE
Fix URLs for migrations

### DIFF
--- a/RecursiveArrayTools/url
+++ b/RecursiveArrayTools/url
@@ -1,1 +1,1 @@
-https://github.com/ChrisRackauckas/RecursiveArrayTools.jl.git
+https://github.com/JuliaDiffEq/RecursiveArrayTools.jl.git

--- a/ResettableStacks/url
+++ b/ResettableStacks/url
@@ -1,1 +1,1 @@
-git://github.com/ChrisRackauckas/ResettableStacks.jl.git
+git://github.com/JuliaDiffEq/ResettableStacks.jl.git


### PR DESCRIPTION
These two libraries were essentially helper libraries for JuliaDiffEq, and all of the work on them was spawned by JuliaDiffEq work. So for organizational and maitanance purposes, I migrated them to JuliaDiffEq.