### PR TITLE
Bound JSON to 0.9.0 on LanguageServer

### DIFF
--- a/LanguageServer/versions/0.0.1/requires
+++ b/LanguageServer/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
-JSON 0.8.0
+JSON 0.8.0 0.9.0
 Lint 0.2.5
 URIParser 0.1.6


### PR DESCRIPTION
cc @tkelman 

The only other package that used `_writejson`, from a GitHub search, is JSONStreams, which is unregistered.