### PR TITLE
move OffsetArrays to JuliaArrays

### DIFF
--- a/OffsetArrays/url
+++ b/OffsetArrays/url
@@ -1,1 +1,1 @@
-git://github.com/alsam/OffsetArrays.jl.git
+git://github.com/JuliaArrays/OffsetArrays.jl.git


### PR DESCRIPTION
https://github.com/JuliaArrays/OffsetArrays.jl

This needs confirmation from @timholy @alsam, because I noted that this wasn't a transfer per se, more of a "manual" fork, so the original repository is still at alsam/OffsetArrays.jl. (was this on purpose?) Anyway, this means that there is no automatic forwarding to the the new home at JuliaArrays, and the link in METADATA has to be replaced for the move to take effect

ref: https://github.com/alsam/OffsetArrays.jl/pull/26#issuecomment-294231805



