### PR TITLE
Upper bound IntervalArithmetic and ValidatedNumerics' dependencies on StaticArrays to < 0.5

### DIFF
--- a/IntervalArithmetic/versions/0.9.0/requires
+++ b/IntervalArithmetic/versions/0.9.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 CRlibm 0.5
-StaticArrays 0.3
+StaticArrays 0.3 0.5
 ForwardDiff 0.2
 RecipesBase

--- a/ValidatedNumerics/versions/0.8.0/requires
+++ b/ValidatedNumerics/versions/0.8.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 CRlibm 0.5
 Compat 0.7.11
-StaticArrays 0.3
+StaticArrays 0.3 0.5
 ForwardDiff 0.2
 RecipesBase


### PR DESCRIPTION
ref https://github.com/JuliaLang/METADATA.jl/pull/8999#issuecomment-297960883

since prior versions of ValidatedNumerics did not depend on StaticArrays,
this could result in downgrading ValidatedNumerics to 0.7.0 in order to
upgrade StaticArrays to 0.5

that would be fixed by releasing a new StaticArrays-0.5-compatible version
cc @dpsanders