### PR TITLE
Update urls for moved packages

### DIFF
--- a/ConfParser/url
+++ b/ConfParser/url
@@ -1,1 +1,1 @@
-git://github.com/brandonkmiller/ConfParser.jl.git
+git://github.com/furface/ConfParser.jl.git

--- a/FilePaths/url
+++ b/FilePaths/url
@@ -1,1 +1,1 @@
-git://github.com/Rory-Finnegan/FilePaths.jl.git
+git://github.com/rofinn/FilePaths.jl.git

--- a/HexEdit/url
+++ b/HexEdit/url
@@ -1,1 +1,1 @@
-git://github.com/brandonkmiller/HexEdit.jl.git
+git://github.com/furface/HexEdit.jl.git

--- a/Interfaces/url
+++ b/Interfaces/url
@@ -1,1 +1,1 @@
-git://github.com/Rory-Finnegan/Interfaces.jl.git
+git://github.com/rofinn/Interfaces.jl.git

--- a/NMEA/url
+++ b/NMEA/url
@@ -1,1 +1,1 @@
-git://github.com/brandonkmiller/NMEA.jl.git
+git://github.com/furface/NMEA.jl.git

--- a/Pcap/url
+++ b/Pcap/url
@@ -1,1 +1,1 @@
-git://github.com/brandonkmiller/Pcap.jl.git
+git://github.com/furface/Pcap.jl.git

--- a/Playground/url
+++ b/Playground/url
@@ -1,1 +1,1 @@
-git://github.com/Rory-Finnegan/Playground.jl.git
+git://github.com/rofinn/Playground.jl.git


### PR DESCRIPTION
Update urls for @rofinn (formerly @Rory-Finnegan) and @furface (formerly @brandonkmiller)'s packages. Github redirects should handle these, but if you plan on keeping these new names permanently, best to have the urls be accurate.