### PR TITLE
Register PyCallJLD.jl [https://github.com/JuliaPy/PyCallJLD.git]

### DIFF
--- a/PyCallJLD.jl/url
+++ b/PyCallJLD.jl/url
@@ -1,0 +1,1 @@
+https://github.com/JuliaPy/PyCallJLD.git


### PR DESCRIPTION
I called `PkgDev.register("PyCallJLD.jl")`, but it seems to have latched onto `PyCallJLD.git` even though I renamed that repo to `PyCallJLD.jl`. Is that an issue?

Also, I would have loved to use attobot for this, but I don't seem to have the proper JuliaPy permissions?

Hopefully this module can be merged into PyCall once we have conditional modules.