### PR TITLE
use 0.6.0-rc1 on metadata travis

### DIFF
--- a/.test/ci.sh
+++ b/.test/ci.sh
@@ -16,8 +16,6 @@ for ver in 0.4 0.5 0.6 nightly; do
   if [ $ver = "nightly" ]; then
     url="julianightlies/bin/linux/x64/julia-latest-linux64"
     ver=0.7
-  elif [ $ver = "0.6" ]; then # delete this case once rc1 is available
-    url="julianightlies/bin/linux/x64/0.6/julia-0.6.0-609b3d12c7-linux64"
   else
     url="julialang/bin/linux/x64/$ver/julia-$ver-latest-linux-x86_64"
   fi


### PR DESCRIPTION
reverts a temporary workaround that was needed to deal with Pkg resolver problems