### PR TITLE
Upper bound SingularIntegralEquations 0.2.0 and 0.2.1 to Julia < 0.6

### DIFF
--- a/SingularIntegralEquations/versions/0.2.0/requires
+++ b/SingularIntegralEquations/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.6
 ApproxFun 0.4 0.4.1
 BandedMatrices 0.1.2
 Compat 0.8.4

--- a/SingularIntegralEquations/versions/0.2.1/requires
+++ b/SingularIntegralEquations/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.6
 ApproxFun 0.4.1 0.5
 BandedMatrices 0.1.2
 Compat 0.9.5


### PR DESCRIPTION
since ApproxFun 0.4.x has that julia upper bound

cc @dlfivefifty these go with https://github.com/JuliaLang/METADATA.jl/pull/7584