### PR TITLE
Upper bound IterativeSolvers to < 0.3 for GeostatInversion and RobustLeastSquares

### DIFF
--- a/GeostatInversion/versions/0.1.0/requires
+++ b/GeostatInversion/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
-IterativeSolvers
+IterativeSolvers 0.0- 0.3
 RobustPmap
 Grid

--- a/GeostatInversion/versions/0.1.1/requires
+++ b/GeostatInversion/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
-IterativeSolvers
+IterativeSolvers 0.0- 0.3
 RobustPmap
 Grid

--- a/GeostatInversion/versions/0.1.2/requires
+++ b/GeostatInversion/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
-IterativeSolvers
+IterativeSolvers 0.0- 0.3
 RobustPmap
 Grid

--- a/GeostatInversion/versions/0.1.3/requires
+++ b/GeostatInversion/versions/0.1.3/requires
@@ -1,4 +1,4 @@
 julia 0.5
-IterativeSolvers
+IterativeSolvers 0.0- 0.3
 RobustPmap
 Grid

--- a/GeostatInversion/versions/0.1.4/requires
+++ b/GeostatInversion/versions/0.1.4/requires
@@ -1,4 +1,4 @@
 julia 0.5
-IterativeSolvers
+IterativeSolvers 0.0- 0.3
 RobustPmap
 Grid

--- a/GeostatInversion/versions/0.1.5/requires
+++ b/GeostatInversion/versions/0.1.5/requires
@@ -1,4 +1,4 @@
 julia 0.5
-IterativeSolvers
+IterativeSolvers 0.0- 0.3
 RobustPmap
 Grid

--- a/GeostatInversion/versions/0.2.0/requires
+++ b/GeostatInversion/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
-IterativeSolvers
+IterativeSolvers 0.0- 0.3
 RobustPmap
 Grid

--- a/RobustLeastSquares/versions/0.0.1/requires
+++ b/RobustLeastSquares/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 StatsBase
-IterativeSolvers
+IterativeSolvers 0.0- 0.3
 Logging


### PR DESCRIPTION
ref https://github.com/JuliaLang/METADATA.jl/pull/9190#issuecomment-301363799
cc @lopezm94 @montyvesselinov @andyferris 

if this turns out to be fixable in an IterativeSolvers 0.3.1, we can revert this then. for now this will downgrade IterativeSolvers to 0.2.x if either of these other packages are installed.