### PR TITLE
Update DoubleDouble URL to JuliaMath org

### DIFF
--- a/DoubleDouble/url
+++ b/DoubleDouble/url
@@ -1,1 +1,1 @@
-git://github.com/simonbyrne/DoubleDouble.jl.git
+git://github.com/JuliaMath/DoubleDouble.jl.git


### PR DESCRIPTION
DoubleDouble moved to JuliaMath.

cc @simonbyrne 