### PR TITLE
Tag Reduce v0.0.2

### DIFF
--- a/Reduce/versions/0.0.2/requires
+++ b/Reduce/versions/0.0.2/requires
@@ -1,0 +1,2 @@
+julia 0.5
+Compat 0.9.5

--- a/Reduce/versions/0.0.2/sha1
+++ b/Reduce/versions/0.0.2/sha1
@@ -1,0 +1,1 @@
+fed2933c4800ac9f1c0be1af19f7f6655cbbbf9c


### PR DESCRIPTION
Diff vs v0.0.1: https://github.com/chakravala/Reduce.jl/compare/a1f1d3a3ad81422582fff42a285c07aeb9f76988...fed2933c4800ac9f1c0be1af19f7f6655cbbbf9c

Added `build` support for Linux and Unix. The linux build works very well and quickly with precompiled binaries. The general unix build from source depends on what kind of build tools are present.

The OSX automated build may or may not be working yet, I don't have my own system to test it on:
https://travis-ci.org/chakravala/Reduce.jl/builds/234067763
https://travis-ci.org/chakravala/Reduce.jl/builds/234080918

Windows build is not yet supported

Also, fixed an `IJulia` display bug with LaTeX

Finally, the build directory has been changed to a relative directory.