### PR TITLE
upper bound ForwardDiff at 0.5.0 for downstream packages

### DIFF
--- a/FiniteElementDiffEq/versions/0.0.1/requires
+++ b/FiniteElementDiffEq/versions/0.0.1/requires
@@ -5,7 +5,7 @@ Parameters 0.5.0
 Plots 0.9.2
 RecipesBase 0.1.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/FiniteElementDiffEq/versions/0.0.2/requires
+++ b/FiniteElementDiffEq/versions/0.0.2/requires
@@ -5,7 +5,7 @@ Parameters 0.5.0
 Plots 0.9.2
 RecipesBase 0.1.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/FiniteElementDiffEq/versions/0.0.3/requires
+++ b/FiniteElementDiffEq/versions/0.0.3/requires
@@ -5,7 +5,7 @@ Parameters 0.5.0
 Plots 0.9.2
 RecipesBase 0.1.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/FiniteElementDiffEq/versions/0.0.4/requires
+++ b/FiniteElementDiffEq/versions/0.0.4/requires
@@ -4,7 +4,7 @@ IterativeSolvers 0.2.2
 Parameters 0.5.0
 RecipesBase 0.1.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/FiniteElementDiffEq/versions/0.0.5/requires
+++ b/FiniteElementDiffEq/versions/0.0.5/requires
@@ -4,7 +4,7 @@ IterativeSolvers 0.2.2
 Parameters 0.5.0
 RecipesBase 0.1.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/FiniteElementDiffEq/versions/0.1.0/requires
+++ b/FiniteElementDiffEq/versions/0.1.0/requires
@@ -4,7 +4,7 @@ IterativeSolvers 0.2.2
 Parameters 0.5.0
 RecipesBase 0.1.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/FiniteElementDiffEq/versions/0.2.0/requires
+++ b/FiniteElementDiffEq/versions/0.2.0/requires
@@ -4,7 +4,7 @@ IterativeSolvers 0.2.2
 Parameters 0.5.0
 RecipesBase 0.1.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/FiniteElementDiffEq/versions/0.2.1/requires
+++ b/FiniteElementDiffEq/versions/0.2.1/requires
@@ -4,7 +4,7 @@ DiffEqPDEBase
 IterativeSolvers 0.2.2
 Parameters 0.5.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/FiniteElementDiffEq/versions/0.3.0/requires
+++ b/FiniteElementDiffEq/versions/0.3.0/requires
@@ -4,7 +4,7 @@ DiffEqPDEBase
 IterativeSolvers 0.2.2
 Parameters 0.5.0
 GenericSVD 0.0.2
-ForwardDiff 0.2.4
+ForwardDiff 0.2.4 0.5.0
 NLsolve 0.7.3
 ChunkedArrays 0.1.0
 VectorizedRoutines 0.0.2

--- a/ReverseDiff/versions/0.0.1/requires
+++ b/ReverseDiff/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 DiffBase 0.0.2
-ForwardDiff 0.3.2
+ForwardDiff 0.3.2 0.5.0
 Calculus 0.1.15

--- a/ReverseDiff/versions/0.0.2/requires
+++ b/ReverseDiff/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 DiffBase 0.0.2
-ForwardDiff 0.3.2
+ForwardDiff 0.3.2 0.5.0
 Calculus 0.1.15

--- a/ReverseDiff/versions/0.0.3/requires
+++ b/ReverseDiff/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.5
 DiffBase 0.0.3
-ForwardDiff 0.3.4
+ForwardDiff 0.3.4 0.5.0
 Calculus 0.2.0

--- a/ReverseDiff/versions/0.0.4/requires
+++ b/ReverseDiff/versions/0.0.4/requires
@@ -1,4 +1,4 @@
 julia 0.5
 DiffBase 0.0.3
-ForwardDiff 0.3.4
+ForwardDiff 0.3.4 0.5.0
 Calculus 0.2.0

--- a/ReverseDiff/versions/0.1.0/requires
+++ b/ReverseDiff/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 DiffBase 0.0.3
-ForwardDiff 0.3.4
+ForwardDiff 0.3.4 0.5.0
 Calculus 0.2.0
 Compat 0.19.0

--- a/ReverseDiff/versions/0.1.1/requires
+++ b/ReverseDiff/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 DiffBase 0.0.3
-ForwardDiff 0.3.4
+ForwardDiff 0.3.4 0.5.0
 Calculus 0.2.0
 Compat 0.19.0

--- a/ReverseDiff/versions/0.1.2/requires
+++ b/ReverseDiff/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
 DiffBase 0.0.3
-ForwardDiff 0.3.4
+ForwardDiff 0.3.4 0.5.0
 Calculus 0.2.0
 Compat 0.19.0

--- a/StochasticDiffEq/versions/2.0.0/requires
+++ b/StochasticDiffEq/versions/2.0.0/requires
@@ -9,4 +9,4 @@ Iterators
 Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve
-ForwardDiff
+ForwardDiff 0.0.1 0.5.0

--- a/StochasticDiffEq/versions/2.0.1/requires
+++ b/StochasticDiffEq/versions/2.0.1/requires
@@ -9,4 +9,4 @@ Iterators
 Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve
-ForwardDiff
+ForwardDiff 0.0.1 0.5.0

--- a/StochasticDiffEq/versions/2.0.2/requires
+++ b/StochasticDiffEq/versions/2.0.2/requires
@@ -9,4 +9,4 @@ Iterators
 Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve
-ForwardDiff
+ForwardDiff 0.0.1 0.5.0

--- a/StochasticDiffEq/versions/2.0.3/requires
+++ b/StochasticDiffEq/versions/2.0.3/requires
@@ -9,4 +9,4 @@ Iterators
 Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve
-ForwardDiff
+ForwardDiff 0.0.1 0.5.0

--- a/StochasticDiffEq/versions/2.0.4/requires
+++ b/StochasticDiffEq/versions/2.0.4/requires
@@ -9,4 +9,4 @@ Iterators
 Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve
-ForwardDiff
+ForwardDiff 0.0.1 0.5.0

--- a/StochasticDiffEq/versions/2.1.0/requires
+++ b/StochasticDiffEq/versions/2.1.0/requires
@@ -9,4 +9,4 @@ Iterators
 Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve
-ForwardDiff
+ForwardDiff 0.0.1 0.5.0

--- a/StochasticDiffEq/versions/2.2.0/requires
+++ b/StochasticDiffEq/versions/2.2.0/requires
@@ -9,5 +9,5 @@ Iterators
 Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve
-ForwardDiff
+ForwardDiff 0.0.1 0.5.0
 StaticArrays

--- a/StochasticDiffEq/versions/2.2.1/requires
+++ b/StochasticDiffEq/versions/2.2.1/requires
@@ -9,5 +9,5 @@ Iterators
 Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve
-ForwardDiff
+ForwardDiff 0.0.1 0.5.0
 StaticArrays


### PR DESCRIPTION
I've placed upper bounds on ForwardDiff for the packages [marked by JuliaCIBot](http://juliarun-ci.s3.amazonaws.com/3a284f317fad06108bbef2fd7e5475743ce4a6f0/ForwardDiff_reverse_dependency_tests.html) in #9407.

ref #9416 

cc @ChrisRackauckas 