### PR TITLE
Upper bound early JuMP versions to 0.6.0-pre

### DIFF
--- a/JuMP/versions/0.1.1/requires
+++ b/JuMP/versions/0.1.1/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-

--- a/JuMP/versions/0.1.2/requires
+++ b/JuMP/versions/0.1.2/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-

--- a/JuMP/versions/0.10.0/requires
+++ b/JuMP/versions/0.10.0/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.10.1/requires
+++ b/JuMP/versions/0.10.1/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.10.2/requires
+++ b/JuMP/versions/0.10.2/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.10.3/requires
+++ b/JuMP/versions/0.10.3/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.11.0/requires
+++ b/JuMP/versions/0.11.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.0 0.5.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.11.1/requires
+++ b/JuMP/versions/0.11.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.0 0.5.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.11.2/requires
+++ b/JuMP/versions/0.11.2/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.0 0.5.0-
 ReverseDiffSparse 0.3 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.11.3/requires
+++ b/JuMP/versions/0.11.3/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.0 0.5.0-
 ReverseDiffSparse 0.3 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.12.0/requires
+++ b/JuMP/versions/0.12.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.0 0.5.0-
 ReverseDiffSparse 0.5.3 0.6
 ForwardDiff 0.1 0.2

--- a/JuMP/versions/0.12.1/requires
+++ b/JuMP/versions/0.12.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.0 0.5.0-
 ReverseDiffSparse 0.5.3 0.6
 ForwardDiff 0.1 0.2

--- a/JuMP/versions/0.12.2/requires
+++ b/JuMP/versions/0.12.2/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.0 0.5.0-
 ReverseDiffSparse 0.5.3 0.6
 ForwardDiff 0.1 0.2

--- a/JuMP/versions/0.13.0/requires
+++ b/JuMP/versions/0.13.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.3 0.5.0-
 ReverseDiffSparse 0.5.3 0.6
 ForwardDiff 0.1 0.2

--- a/JuMP/versions/0.13.1/requires
+++ b/JuMP/versions/0.13.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 MathProgBase 0.4.3 0.5.0-
 ReverseDiffSparse 0.5.3 0.6
 ForwardDiff 0.1 0.2

--- a/JuMP/versions/0.2.0/requires
+++ b/JuMP/versions/0.2.0/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-

--- a/JuMP/versions/0.3.0/requires
+++ b/JuMP/versions/0.3.0/requires
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.2- 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-

--- a/JuMP/versions/0.3.1/requires
+++ b/JuMP/versions/0.3.1/requires
@@ -1,2 +1,2 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-

--- a/JuMP/versions/0.3.2/requires
+++ b/JuMP/versions/0.3.2/requires
@@ -1,2 +1,2 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-

--- a/JuMP/versions/0.4.0/requires
+++ b/JuMP/versions/0.4.0/requires
@@ -1,2 +1,2 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-

--- a/JuMP/versions/0.4.1/requires
+++ b/JuMP/versions/0.4.1/requires
@@ -1,2 +1,2 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-

--- a/JuMP/versions/0.5.0/requires
+++ b/JuMP/versions/0.5.0/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.1/requires
+++ b/JuMP/versions/0.5.1/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.2/requires
+++ b/JuMP/versions/0.5.2/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.3/requires
+++ b/JuMP/versions/0.5.3/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.4/requires
+++ b/JuMP/versions/0.5.4/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.5/requires
+++ b/JuMP/versions/0.5.5/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.0.0 0.3.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.6/requires
+++ b/JuMP/versions/0.5.6/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.3.0- 0.4.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.7/requires
+++ b/JuMP/versions/0.5.7/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.3.0- 0.4.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.5.8/requires
+++ b/JuMP/versions/0.5.8/requires
@@ -1,3 +1,3 @@
-julia 0.2
+julia 0.2 0.6.0-pre
 MathProgBase 0.3.0- 0.4.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.6.0/requires
+++ b/JuMP/versions/0.6.0/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.0- 0.4.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.6.1/requires
+++ b/JuMP/versions/0.6.1/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.0- 0.4.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.6.2/requires
+++ b/JuMP/versions/0.6.2/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.1 0.4.0-
 ReverseDiffSparse 0.1 0.4

--- a/JuMP/versions/0.6.3/requires
+++ b/JuMP/versions/0.6.3/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.1 0.4.0-
 ReverseDiffSparse 0.1 0.4
 ArrayViews

--- a/JuMP/versions/0.7.0/requires
+++ b/JuMP/versions/0.7.0/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.1 0.4
 ArrayViews

--- a/JuMP/versions/0.7.1/requires
+++ b/JuMP/versions/0.7.1/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.1 0.4
 ArrayViews

--- a/JuMP/versions/0.7.2/requires
+++ b/JuMP/versions/0.7.2/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.1 0.4
 ArrayViews

--- a/JuMP/versions/0.7.3/requires
+++ b/JuMP/versions/0.7.3/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.1 0.4
 ArrayViews

--- a/JuMP/versions/0.7.4/requires
+++ b/JuMP/versions/0.7.4/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.1.11-
 ArrayViews

--- a/JuMP/versions/0.8.0/requires
+++ b/JuMP/versions/0.8.0/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.1
 ArrayViews

--- a/JuMP/versions/0.9.0/requires
+++ b/JuMP/versions/0.9.0/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews

--- a/JuMP/versions/0.9.1/requires
+++ b/JuMP/versions/0.9.1/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.9.2/requires
+++ b/JuMP/versions/0.9.2/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMP/versions/0.9.3/requires
+++ b/JuMP/versions/0.9.3/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 MathProgBase 0.3.8 0.4.0-
 ReverseDiffSparse 0.2.2 0.4
 ArrayViews 0.4.12

--- a/JuMPeR/versions/0.1.0/requires
+++ b/JuMPeR/versions/0.1.0/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 JuMP 0.8 0.9

--- a/JuMPeR/versions/0.1.1/requires
+++ b/JuMPeR/versions/0.1.1/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 JuMP 0.9 0.10

--- a/JuMPeR/versions/0.1.2/requires
+++ b/JuMPeR/versions/0.1.2/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 JuMP 0.9 0.10
 Compat

--- a/JuMPeR/versions/0.2.0/requires
+++ b/JuMPeR/versions/0.2.0/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 JuMP 0.10 0.11
 Compat

--- a/JuMPeR/versions/0.2.1/requires
+++ b/JuMPeR/versions/0.2.1/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.6.0-pre
 JuMP 0.10.2 0.11
 Compat

--- a/JuMPeR/versions/0.3.0/requires
+++ b/JuMPeR/versions/0.3.0/requires
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 JuMP 0.11.1 0.12

--- a/JuMPeR/versions/0.3.1/requires
+++ b/JuMPeR/versions/0.3.1/requires
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.4 0.6.0-pre
 JuMP 0.12.0 0.13


### PR DESCRIPTION
these all used lower-case `symbol()` which no longer exists

ref https://github.com/JuliaLang/METADATA.jl/pull/9512#issuecomment-304057632, cc @mlubin @joehuchette, the existence of ForwardDiff 0.5.0 is causing issues since the only JuMP versions that don't have ForwardDiff upper bounds are the old ones that don't depend on ForwardDiff at all.