### PR TITLE
Add upper bounds on NamedTuples in Query and IterableTables

### DIFF
--- a/IterableTables/versions/0.0.1/requires
+++ b/IterableTables/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
-NamedTuples 2.0.0
+NamedTuples 2.0.0 3.0.0
 Requires 0.3.0

--- a/IterableTables/versions/0.0.2/requires
+++ b/IterableTables/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5
-NamedTuples 2.0.0
+NamedTuples 2.0.0 3.0.0
 Requires 0.3.0

--- a/IterableTables/versions/0.1.0/requires
+++ b/IterableTables/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.6.0-rc1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 4.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/Query/versions/0.4.0/requires
+++ b/Query/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-NamedTuples 2.0.0
+NamedTuples 2.0.0 3.0.0
 DataStructures 0.4.5
 Requires 0.3.0
 Documenter 0.9.0

--- a/Query/versions/0.4.1/requires
+++ b/Query/versions/0.4.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-NamedTuples 2.0.0
+NamedTuples 2.0.0 3.0.0
 DataStructures 0.4.5
 Requires 0.3.0
 Documenter 0.9.0

--- a/Query/versions/0.5.0/requires
+++ b/Query/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 4.0.0
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0


### PR DESCRIPTION
I mark all the versions that don't work with julia 0.6- as such.

I also upper bound NamedTuples so that we can phase in the next breaking change in NamedTuples.