### PR TITLE
Use 0.6.0-pre as minimum version for a number of 0.6-only packages

### DIFF
--- a/BlockArrays/versions/0.1.0/requires
+++ b/BlockArrays/versions/0.1.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/BlockArrays/versions/0.1.1/requires
+++ b/BlockArrays/versions/0.1.1/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/CUDAnative/versions/0.1.1/requires
+++ b/CUDAnative/versions/0.1.1/requires
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 CUDAdrv 0.2
 LLVM 0.2

--- a/CUDAnative/versions/0.1.2/requires
+++ b/CUDAnative/versions/0.1.2/requires
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 CUDAdrv 0.2
 LLVM 0.2

--- a/CUDAnative/versions/0.1.3/requires
+++ b/CUDAnative/versions/0.1.3/requires
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 CUDAdrv 0.2
 LLVM 0.2

--- a/CUDAnative/versions/0.2.0/requires
+++ b/CUDAnative/versions/0.2.0/requires
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 CUDAdrv 0.2
 LLVM 0.2

--- a/ControlSystems/versions/0.3.0/requires
+++ b/ControlSystems/versions/0.3.0/requires
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 Plots 0.7.4
 Polynomials

--- a/Crayons/versions/0.3.0/requires
+++ b/Crayons/versions/0.3.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/DataArrays/versions/0.4.0/requires
+++ b/DataArrays/versions/0.4.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Compat 0.8.6
 StatsBase 0.3
 Reexport

--- a/DataArrays/versions/0.5.0/requires
+++ b/DataArrays/versions/0.5.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Compat 0.8.6
 StatsBase 0.14.0
 Reexport

--- a/DataArrays/versions/0.5.1/requires
+++ b/DataArrays/versions/0.5.1/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Compat 0.8.6
 StatsBase 0.14.0
 Reexport

--- a/DataFlow/versions/0.2.0/requires
+++ b/DataFlow/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Lazy
 MacroTools 0.3.6
 Juno

--- a/DataValues/versions/0.0.1/requires
+++ b/DataValues/versions/0.0.1/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/DataValues/versions/0.0.2/requires
+++ b/DataValues/versions/0.0.2/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/DataValues/versions/0.0.3/requires
+++ b/DataValues/versions/0.0.3/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/DeepDiffs/versions/1.0.0/requires
+++ b/DeepDiffs/versions/1.0.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/DiffBase/versions/0.2.0/requires
+++ b/DiffBase/versions/0.2.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/DiffEqCallbacks/versions/0.2.0/requires
+++ b/DiffEqCallbacks/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 DiffEqBase 0.6.0
 NLsolve
 ForwardDiff 0.5.0

--- a/Divergences/versions/0.1.0/requires
+++ b/Divergences/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 ArrayViews
 Distances
 StatsFuns

--- a/Flux/versions/0.2.0/requires
+++ b/Flux/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 00.6-
+julia 0.6.0-pre
 Iterators
 DataFlow
 Juno

--- a/Flux/versions/0.2.1/requires
+++ b/Flux/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Iterators
 DataFlow
 Juno

--- a/ForwardDiff/versions/0.5.0/requires
+++ b/ForwardDiff/versions/0.5.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StaticArrays 0.5.0
 DiffBase 0.2.0 0.3.0
 NaNMath 0.2.2

--- a/GracePlot/versions/0.2.0/requires
+++ b/GracePlot/versions/0.2.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/GraphIO/versions/0.0.1/requires
+++ b/GraphIO/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 LightGraphs 0.8.0
 GZip 0.2.20
 EzXML 0.3.0

--- a/IOIndents/versions/0.1.0/requires
+++ b/IOIndents/versions/0.1.0/requires
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 TestSetExtensions

--- a/InspectDR/versions/0.2.0/requires
+++ b/InspectDR/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Colors
 Gtk
 Graphics

--- a/LibPSF/versions/0.2.0/requires
+++ b/LibPSF/versions/0.2.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/LightGraphs/versions/0.8.0/requires
+++ b/LightGraphs/versions/0.8.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 GZip 0.2.20
 EzXML 0.3.0
 ParserCombinator 1.7.11

--- a/LightGraphs/versions/0.9.0/requires
+++ b/LightGraphs/versions/0.9.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 GZip 0.2.20
 StatsBase 0.9.0
 DataStructures 0.5.0

--- a/LombScargle/versions/0.3.0/requires
+++ b/LombScargle/versions/0.3.0/requires
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 Measurements 0.2.0

--- a/LossFunctions/versions/0.1.0/requires
+++ b/LossFunctions/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase 0.8.0
 LearnBase 0.1.3 0.2.0
 RecipesBase

--- a/MLLabelUtils/versions/0.1.0/requires
+++ b/MLLabelUtils/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase 0.13
 LearnBase 0.1.3 0.2.0
 MappedArrays 0.0.6

--- a/MLLabelUtils/versions/0.1.1/requires
+++ b/MLLabelUtils/versions/0.1.1/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase 0.13
 LearnBase 0.1.5 0.2.0
 MappedArrays 0.0.6

--- a/MLLabelUtils/versions/0.1.2/requires
+++ b/MLLabelUtils/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase 0.13
 LearnBase 0.1.5 0.2.0
 MappedArrays 0.0.6

--- a/MLLabelUtils/versions/0.1.3/requires
+++ b/MLLabelUtils/versions/0.1.3/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase 0.13
 LearnBase 0.1.5 0.2.0
 MappedArrays 0.0.6

--- a/MP3/versions/1.0.0/requires
+++ b/MP3/versions/1.0.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 BinDeps
 FileIO
 FixedPointNumbers

--- a/Measurements/versions/0.4.0/requires
+++ b/Measurements/versions/0.4.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Calculus 0.1.5
 SpecialFunctions 0.1.0
 QuadGK 0.1.1

--- a/NamedTuples/versions/3.0.2/requires
+++ b/NamedTuples/versions/3.0.2/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/NearestNeighbors/versions/0.3.0/requires
+++ b/NearestNeighbors/versions/0.3.0/requires
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 Distances 0.4
 StaticArrays 0.0.4

--- a/NumericIO/versions/0.2.0/requires
+++ b/NumericIO/versions/0.2.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/OnlineStats/versions/0.8.0/requires
+++ b/OnlineStats/versions/0.8.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase
 LearnBase
 Distributions

--- a/OrdinaryDiffEq/versions/2.5.0/requires
+++ b/OrdinaryDiffEq/versions/2.5.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 DiffEqBase 1.5.0
 Parameters 0.5.0
 ForwardDiff 0.5.0

--- a/PGFPlotsX/versions/0.1.1/requires
+++ b/PGFPlotsX/versions/0.1.1/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 MacroTools
 DataStructures
 Requires

--- a/PGFPlotsX/versions/0.1.2/requires
+++ b/PGFPlotsX/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 MacroTools
 DataStructures
 Requires

--- a/PGFPlotsX/versions/0.1.3/requires
+++ b/PGFPlotsX/versions/0.1.3/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 MacroTools
 DataStructures
 Requires

--- a/PenaltyFunctions/versions/0.0.1/requires
+++ b/PenaltyFunctions/versions/0.0.1/requires
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 LearnBase 0.1.3 0.2.0
 RecipesBase

--- a/PooledArrays/versions/0.1.0/requires
+++ b/PooledArrays/versions/0.1.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/PortAudio/versions/1.0.0/requires
+++ b/PortAudio/versions/1.0.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-dev.2746
 BinDeps
 SampledSignals 0.3.0
 RingBuffers 1.0.0

--- a/QuartzImageIO/versions/0.3.0/requires
+++ b/QuartzImageIO/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-dev.2782
 FileIO 0.0.4
 Images 0.6
 ColorTypes 0.3

--- a/RandomNumbers/versions/0.1.0/requires
+++ b/RandomNumbers/versions/0.1.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/RingBuffers/versions/1.1.0/requires
+++ b/RingBuffers/versions/1.1.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/RingBuffers/versions/1.1.1/requires
+++ b/RingBuffers/versions/1.1.1/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/Rotations/versions/0.4.0/requires
+++ b/Rotations/versions/0.4.0/requires
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 StaticArrays 0.4.0 0.5-

--- a/Rotations/versions/0.5.0/requires
+++ b/Rotations/versions/0.5.0/requires
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 StaticArrays 0.5

--- a/SampledSignals/versions/1.0.0/requires
+++ b/SampledSignals/versions/1.0.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 SIUnits
 FixedPointNumbers
 DSP

--- a/SpiceData/versions/0.2.0/requires
+++ b/SpiceData/versions/0.2.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/StandardizedMatrices/versions/0.2.0/requires
+++ b/StandardizedMatrices/versions/0.2.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/StaticArrays/versions/0.4.0/requires
+++ b/StaticArrays/versions/0.4.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/StaticArrays/versions/0.5.0/requires
+++ b/StaticArrays/versions/0.5.0/requires
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/StochasticDiffEq/versions/2.3.0/requires
+++ b/StochasticDiffEq/versions/2.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Parameters 0.5.0
 DiffEqBase 1.2.0
 RecursiveArrayTools 0.8.0

--- a/TestSetExtensions/versions/1.0.0/requires
+++ b/TestSetExtensions/versions/1.0.0/requires
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 DeepDiffs

--- a/TrafficAssignment/versions/0.4.0/requires
+++ b/TrafficAssignment/versions/0.4.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 LightGraphs 0.8
 Optim 0.7
 BinDeps

--- a/TrafficAssignment/versions/0.4.1/requires
+++ b/TrafficAssignment/versions/0.4.1/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 LightGraphs 0.8
 Optim 0.7
 BinDeps


### PR DESCRIPTION
that use syntax that wouldn't work in early 0.6.0-dev versions