### PR TITLE
Tag Spectra v0.3.3 [https://github.com/charlesll/Spectra.jl]

### DIFF
--- a/Spectra/versions/0.3.3/requires
+++ b/Spectra/versions/0.3.3/requires
@@ -1,0 +1,12 @@
+julia 0.5
+IJulia
+PyPlot
+JuMP 0.13
+Ipopt
+StatsBase
+Dierckx
+Distributions
+JLD
+LsqFit
+PyCall
+NMF

--- a/Spectra/versions/0.3.3/sha1
+++ b/Spectra/versions/0.3.3/sha1
@@ -1,0 +1,1 @@
+8b3ffeb8e123ff8fd367cd4f79cfd060fbdc909f


### PR DESCRIPTION
A fix in the peakhw (renamed peakmeas) function + related doc update.

Diff vs v0.3.2: https://github.com/charlesll/Spectra.jl/compare/8194b1310093efd47502fed301c5b3e7a9410d7f...8b3ffeb8e123ff8fd367cd4f79cfd060fbdc909f