### PR TITLE
Tag Spectra v0.3.4 [https://github.com/charlesll/Spectra.jl]

### DIFF
--- a/Spectra/versions/0.3.4/requires
+++ b/Spectra/versions/0.3.4/requires
@@ -1,0 +1,12 @@
+julia 0.5
+IJulia
+PyPlot
+JuMP 0.13
+Ipopt
+StatsBase
+Dierckx
+Distributions
+JLD
+LsqFit
+PyCall
+NMF

--- a/Spectra/versions/0.3.4/sha1
+++ b/Spectra/versions/0.3.4/sha1
@@ -1,0 +1,1 @@
+d80b712b23fc20c7e8ff0cbf97de5d1b304ce6e1


### PR DESCRIPTION
- Drop FORTRAN compilation of GCVSPL.f: Import new gcvspline Python module; installation of gcvspline through pip in a build.jl script in deps.
- various tests added;
- various examples added;
- Support now seems OK for Julia 0.6;

Diff vs v0.3.3: https://github.com/charlesll/Spectra.jl/compare/8b3ffeb8e123ff8fd367cd4f79cfd060fbdc909f...d80b712b23fc20c7e8ff0cbf97de5d1b304ce6e1