### PR TITLE
New URL and release of ROOT.jl

### DIFF
--- a/ROOT/url
+++ b/ROOT/url
@@ -1,1 +1,1 @@
-git://github.com/jpata/ROOT.jl.git
+git://github.com/JuliaHEP/ROOT.jl.git


### PR DESCRIPTION
* Changes the URL of ROOT.jl - ROOT.jl has moved to the JuliaHEP organization. 
* New release, Cxx.jl-based, ROOT-6 and Julia v0.6 compatible.

Both changes are in agreement with the original author, Joosep Pata (who's a co-owner of JuliaHEP).