### PR TITLE
Remove upper bound on a Query requirement

### DIFF
--- a/Query/versions/0.5.0/requires
+++ b/Query/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
-NamedTuples 3.0.2 4.0.0
+NamedTuples 3.0.2
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0


### PR DESCRIPTION
This upper bound is unnecessary and just block things. I added it a while back ago after the original tag, but that was an error.