### PR TITLE
change url for EMIRT.jl

### DIFF
--- a/EMIRT/url
+++ b/EMIRT/url
@@ -1,1 +1,1 @@
-git://github.com/JuliaPackageMirrors/EMIRT.jl.git
+git://github.com/seung-lab/EMIRT.jl.git


### PR DESCRIPTION
this repo was private previously and the url was moved to PackageMirror