### PR TITLE
Use 0.6.0-pre as julia lower bound for Atom 0.6.0 and Media 0.3.0

### DIFF
--- a/Atom/versions/0.6.0/requires
+++ b/Atom/versions/0.6.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Juno 0.2.6
 Lazy 0.11.3
 LNR

--- a/Media/versions/0.3.0/requires
+++ b/Media/versions/0.3.0/requires
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 MacroTools


### PR DESCRIPTION
both of these use syntax that wouldn't work in early dev versions

@MikeInnes come on.