### PR TITLE
Update minimum version of FileIO for CSVFiles, ExcelFiles, StatFiles

### DIFF
--- a/CSVFiles/versions/0.0.1/requires
+++ b/CSVFiles/versions/0.0.1/requires
@@ -3,4 +3,4 @@ TextParse 0.1.6
 IterableTables 0.2.0
 DataValues 0.1.0
 DataTables 0.0.3
-FileIO 0.3.1
+FileIO 0.4.0

--- a/ExcelFiles/versions/0.0.1/requires
+++ b/ExcelFiles/versions/0.0.1/requires
@@ -3,5 +3,5 @@ ExcelReaders 0.7.0
 IterableTables 0.2.0
 DataValues 0.1.0
 DataTables 0.0.3
-FileIO 0.3.1
+FileIO 0.4.0
 DataFrames 0.9.0

--- a/StatFiles/versions/0.0.1/requires
+++ b/StatFiles/versions/0.0.1/requires
@@ -3,4 +3,4 @@ ReadStat 0.1.1
 IterableTables 0.2.0
 DataValues 0.1.0
 DataFrames 0.10.0
-FileIO 0.3.1
+FileIO 0.4.0


### PR DESCRIPTION
This finishes the registration of these packages. They don't work with an older version of ``FileIO``, but when we originally registered them, FileIO v0.4.0 was not yet tagged.