### PR TITLE
StatprofilerHTML: bump julia version

### DIFF
--- a/StatProfilerHTML/versions/0.1.1/requires
+++ b/StatProfilerHTML/versions/0.1.1/requires
@@ -1,1 +1,1 @@
-julia 0.5
+julia 0.5+


### PR DESCRIPTION
Tested to work with julia 0.6-rc2; no reason to suspect it doesn't work in every current 0.5+.