### PR TITLE
Register CommunityDetection [ssh://git@github.com/JuliaGraphs/Communi…

### DIFF
--- a/CommunityDetection/url
+++ b/CommunityDetection/url
@@ -1,0 +1,1 @@
+ssh://git@github.com/JuliaGraphs/CommunityDetection.jl.git


### PR DESCRIPTION
…tyDetection.jl.git]

This package is a split from LightGraphsExtras.jl - LGE is failing due to other dependency issues and we're splitting the functionality up into smaller packages for ease of use / maintenance. CommunityDetection is the first of several.