### PR TITLE
Update URL after move GenericSVD

### DIFF
--- a/GenericSVD/url
+++ b/GenericSVD/url
@@ -1,1 +1,1 @@
-git://github.com/simonbyrne/GenericSVD.jl.git
+https://github.com/JuliaMath/GenericSVD.jl.git


### PR DESCRIPTION
The repository was moved to JuliaMath. This needs to be updated to trigger AttoBot.