### PR TITLE
Tag Mongo v0.3.0 [https://github.com/pzion/Mongo.jl]

### DIFF
--- a/Mongo/versions/0.3.0/requires
+++ b/Mongo/versions/0.3.0/requires
@@ -1,0 +1,5 @@
+julia 0.5
+LibBSON 0.3
+BinDeps 0.4
+Compat 0.9
+@osx Homebrew

--- a/Mongo/versions/0.3.0/sha1
+++ b/Mongo/versions/0.3.0/sha1
@@ -1,0 +1,1 @@
+e85a9a4c8e78f9ed11740a8abc5decd4d615514b


### PR DESCRIPTION
Diff vs v0.2.3: https://github.com/pzion/Mongo.jl/compare/ea46eab8e3e1c6fcaddc178b96c000e138f57573...e85a9a4c8e78f9ed11740a8abc5decd4d615514b

Note that this drops support for Julia v0.4