### PR TITLE
JavaCall v0.5.0 does not support julia v0.4

### DIFF
--- a/JavaCall/versions/0.5.0/requires
+++ b/JavaCall/versions/0.5.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 Compat 0.9.5
 DataStructures
 @windows WinReg


### PR DESCRIPTION
Retroactively change the supported Julia version for JavaCall. 

JavaCall 0.5.0 was tagged stating support for julia 0.4. However, that is incorrect, it should have had julia 0.5 as the minimum supported version.  This PR makes that change in the existing tag. After this, JavaCall 0.4.4 should be the maximum supported version in Julia 0.4

Tony, is this acceptable? 

