### PR TITLE
Upper bound ImageProjectiveGeometry's Images dependency to 0.11

### DIFF
--- a/ImageProjectiveGeometry/versions/0.1.0/requires
+++ b/ImageProjectiveGeometry/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia      0.4
-Images     0.5
+Images     0.5 0.11
 PyPlot     2.0

--- a/ImageProjectiveGeometry/versions/0.1.1/requires
+++ b/ImageProjectiveGeometry/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia      0.4
-Images     0.5
+Images     0.5 0.11
 PyPlot     2.0

--- a/ImageProjectiveGeometry/versions/0.1.2/requires
+++ b/ImageProjectiveGeometry/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia      0.4
-Images     0.5
+Images     0.5 0.11
 PyPlot     2.0
 Interpolations 
 Compat 0.8.7


### PR DESCRIPTION
gaussian2d was deprecated and now removed, cc @peterkovesi 

ref https://github.com/JuliaLang/METADATA.jl/pull/10251#issuecomment-315360576