### PR TITLE
Update URLs for moved packages

### DIFF
--- a/Bokeh/url
+++ b/Bokeh/url
@@ -1,1 +1,1 @@
-git://github.com/bokeh/Bokeh.jl.git
+git://github.com/samuelcolvin/Bokeh.jl.git

--- a/ColorSchemes/url
+++ b/ColorSchemes/url
@@ -1,1 +1,1 @@
-git://github.com/cormullion/ColorSchemes.jl.git
+git://github.com/JuliaGraphics/ColorSchemes.jl.git

--- a/GeneralizedSchurAlgorithm/url
+++ b/GeneralizedSchurAlgorithm/url
@@ -1,1 +1,1 @@
-https://github.com/KTH-AC/GeneralizedSchurAlgorithm.jl.git
+https://github.com/neveritt/GeneralizedSchurAlgorithm.jl.git

--- a/RayTraceEllipsoid/url
+++ b/RayTraceEllipsoid/url
@@ -1,1 +1,1 @@
-https://github.com/yakir12/RayTraceEllipsoid.jl.git
+https://github.com/JuliaGeometry/RayTraceEllipsoid.jl.git


### PR DESCRIPTION
Bokeh, ColorSchemes, GeneralizedSchurAlgorithm, and RayTraceEllipsoid were all redirects, update urls here

cc @samuelcolvin @cormullion @neveritt and @yakir12 - make sure all CI services are re-enabled at the new locations