### PR TITLE
ParticleFilters requires POMDPs below 0.6

### DIFF
--- a/ParticleFilters/versions/0.0.1/requires
+++ b/ParticleFilters/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
 StatsBase
-POMDPs 0.4
+POMDPs 0.4 0.6

--- a/ParticleFilters/versions/0.0.2/requires
+++ b/ParticleFilters/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5
 StatsBase
-POMDPs 0.4
+POMDPs 0.4 0.6

--- a/ParticleFilters/versions/0.0.3/requires
+++ b/ParticleFilters/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.5
 StatsBase
-POMDPs 0.4
+POMDPs 0.4 0.6


### PR DESCRIPTION
ParticleFilter now requires a version of POMDPs.jl < 0.6