### PR TITLE
new package: HCubature

### DIFF
--- a/HCubature/url
+++ b/HCubature/url
@@ -1,0 +1,1 @@
+https://github.com/stevengj/HCubature.jl.git

--- a/HCubature/versions/1.0.0/requires
+++ b/HCubature/versions/1.0.0/requires
@@ -1,0 +1,6 @@
+julia 0.6
+Compat
+StaticArrays
+Combinatorics
+DataStructures
+QuadGK

--- a/HCubature/versions/1.0.0/sha1
+++ b/HCubature/versions/1.0.0/sha1
@@ -1,0 +1,1 @@
+d5bef9c5bd6055985b1efcb2f1cbfa4d41baa777


### PR DESCRIPTION
This package provides a pure-Julia alternative to the Cubature.jl and Cuba.jl packages (both of which rely on C libraries, and e.g. are not type-generic), complementing the pure-Julia QuadGK.jl (1d integrals).

(Closes stevengj/HCubature.jl#1)

cc @ararslan