### PR TITLE
Tag ODEInterface v0.2.0 [https://github.com/luchr/ODEInterface.jl]

### DIFF
--- a/ODEInterface/versions/0.2.0/requires
+++ b/ODEInterface/versions/0.2.0/requires
@@ -1,0 +1,1 @@
+julia 0.7-DEV

--- a/ODEInterface/versions/0.2.0/sha1
+++ b/ODEInterface/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+e2bf5c3f013b2759d7c289bab2cebd5373fcf54c


### PR DESCRIPTION
Attemt:
Splitting `ODEInterface` in two different branches, depending on the julia version:
* Branch `julia_v0.4-v0.6`: `ODEInterface` for 0.4 ≤ julia ≤ 0.6 with future `ODEInterface`-versions: v0.1.5, v0.1.6, etc.
* Branch `master`: `ODEInterface` for julia ≥ 0.7 with `ODEInterface`-versions: v0.2.0 and fugure versions.

So Version v0.2.0 has the same features as v0.1.4, but written in julia-v0.7 style (`struct`, `mutable struct`, spaces around binary operators like `≥`, compatibility code/macros deleted, etc.).

Picture:
```
   v0.1.4          v0.2.0 (for julia ≥ 0.7)
─────┴──┬────────────┴───────── branch: master
        │
        └────┬───────────────── branch: julia_v0.4-v0.6
           v0.1.5  ... v0.1.*  (for 0.4 ≤ julia ≤ 0.6)
```

I hope the contents of `REQUIRE` and `requires` is right for the current v0.7/nightly build.