### PR TITLE
Tag ODEInterface v0.4.0 [https://github.com/luchr/ODEInterface.jl]

### DIFF
--- a/ODEInterface/versions/0.4.0/requires
+++ b/ODEInterface/versions/0.4.0/requires
@@ -1,0 +1,1 @@
+julia 0.7-DEV

--- a/ODEInterface/versions/0.4.0/sha1
+++ b/ODEInterface/versions/0.4.0/sha1
@@ -1,0 +1,1 @@
+140bfaf1ddab8f4bc7226e7ea630cd2e0fd1fd6d


### PR DESCRIPTION
Attempt: 
Splitting ODEInterface in two (later perhaps more) different branches, depending on the julia version:

Here is an explanation of the version number idea/attempt:
https://github.com/luchr/ODEInterface.jl/blob/master/VERSIONS.md

I've read [tkelman's comment for Pull-Request 10415](https://github.com/JuliaLang/METADATA.jl/pull/10415#issuecomment-318437015) several times, and I think all the requirements and suggestions are satisfied [OK, except attobot]:

>  And if you drop support for a specific minor version of Julia, that's considered a form of breaking change even if the package code doesn't actually change significantly, so worth a new package minor version.

OK. This is case for the above scheme (after `v0.1.a` support for julia v0.4 is dropped and the new version (in time) is `v0.2.0`; bug fixes (for the old version) goes to `v0.1.a+1`, etc)

> Having version numbers that increase quickly or leave gaps isn't a problem

OK. With this Pull requeust there will be a huge gap: `v0.1.4` to `v0.4.0`.

> (though I didn't realize PkgDev would complain)

I've found the optional (undocumented) `force`-flag in `PkgDev.tag`.

> if you end up needing to go back and make backport bugfix releases in the future it's useful to have space to put them in case they need to be distinguished.

I don't understand (completely) the part with the "distinguished"-thing, but I hope that this comment is about the versions `v0.1.(a+1)`, `v0.2.(b+1)` in my above version description.
