### PR TITLE
add version bounds to *diffeq for `@muladd` removal

### DIFF
--- a/OrdinaryDiffEq/versions/2.10.0/requires
+++ b/OrdinaryDiffEq/versions/2.10.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 1.15.0
+DiffEqBase 1.15.0 1.16.0
 Parameters 0.5.0
 ForwardDiff 0.5.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.11.0/requires
+++ b/OrdinaryDiffEq/versions/2.11.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 1.15.0
+DiffEqBase 1.15.0 1.16.0
 Parameters 0.5.0
 ForwardDiff 0.5.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.11.1/requires
+++ b/OrdinaryDiffEq/versions/2.11.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 1.15.0
+DiffEqBase 1.15.0 1.16.0
 Parameters 0.5.0
 ForwardDiff 0.5.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.11.2/requires
+++ b/OrdinaryDiffEq/versions/2.11.2/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 1.15.0
+DiffEqBase 1.15.0 1.16.0
 Parameters 0.5.0
 ForwardDiff 0.5.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.11.3/requires
+++ b/OrdinaryDiffEq/versions/2.11.3/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 1.15.0
+DiffEqBase 1.15.0 1.16.0
 Parameters 0.5.0
 ForwardDiff 0.5.0
 GenericSVD 0.0.2

--- a/StochasticDiffEq/versions/2.8.0/requires
+++ b/StochasticDiffEq/versions/2.8.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 1.15.0
+DiffEqBase 1.15.0 1.16.0
 RecursiveArrayTools 0.8.0
 DataStructures 0.4.6
 Juno 0.2.5

--- a/StochasticDiffEq/versions/2.9.0/requires
+++ b/StochasticDiffEq/versions/2.9.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 1.15.0
+DiffEqBase 1.15.0 1.16.0
 RecursiveArrayTools 0.8.0
 DataStructures 0.4.6
 Juno 0.2.5

--- a/StochasticDiffEq/versions/2.9.1/requires
+++ b/StochasticDiffEq/versions/2.9.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 1.15.0
+DiffEqBase 1.15.0 1.16.0
 RecursiveArrayTools 0.8.0
 DataStructures 0.4.6
 Juno 0.2.5


### PR DESCRIPTION
`@muladd` will be removed from DiffEqBase.jl into its own package MuladdMacro.jl and so this places version bounds for that transition.