### PR TITLE
Insert julia version upper bound for Rmath

### DIFF
--- a/Rmath/versions/0.1.0/requires
+++ b/Rmath/versions/0.1.0/requires
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.4 0.7-
 BinDeps

--- a/Rmath/versions/0.1.1/requires
+++ b/Rmath/versions/0.1.1/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 BinDeps
 Compat 0.8.4

--- a/Rmath/versions/0.1.2/requires
+++ b/Rmath/versions/0.1.2/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 BinDeps
 Compat 0.8.4

--- a/Rmath/versions/0.1.3/requires
+++ b/Rmath/versions/0.1.3/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 BinDeps
 Compat 0.9.1

--- a/Rmath/versions/0.1.4/requires
+++ b/Rmath/versions/0.1.4/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 BinDeps
 Compat 0.9.1

--- a/Rmath/versions/0.1.5/requires
+++ b/Rmath/versions/0.1.5/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 BinDeps
 Compat 0.9.1

--- a/Rmath/versions/0.1.6/requires
+++ b/Rmath/versions/0.1.6/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 BinDeps
 Compat 0.9.1

--- a/Rmath/versions/0.1.7/requires
+++ b/Rmath/versions/0.1.7/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 BinDeps
 Compat 0.9.1


### PR DESCRIPTION
Older versions will break after JuliaLang/julia#19980 is merged.

Should only be merged after #10601.