### PR TITLE
Add bounds to OrdinaryDiffEq.jl

### DIFF
--- a/OrdinaryDiffEq/versions/2.12.0/requires
+++ b/OrdinaryDiffEq/versions/2.12.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 1.16.0
+DiffEqBase 1.16.0 1.19.0
 Parameters 0.5.0
 ForwardDiff 0.5.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.13.0/requires
+++ b/OrdinaryDiffEq/versions/2.13.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 1.16.0
+DiffEqBase 1.16.0 1.19.0
 Parameters 0.5.0
 ForwardDiff 0.5.0
 GenericSVD 0.0.2


### PR DESCRIPTION
There is an impending change to the symplectic methods definitions which will break tests in OrdinaryDiffEq.jl.