### PR TITLE
tighten lower bound of BinDeps 0.7.0

### DIFF
--- a/BinDeps/versions/0.7.0/requires
+++ b/BinDeps/versions/0.7.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.7.0-DEV.1287
 URIParser
 SHA
 Compat 0.17.0


### PR DESCRIPTION
so it doesn't get used on versions of Julia susceptible to
https://github.com/JuliaLang/julia/pull/22886

ref https://github.com/JuliaStats/Rmath.jl/issues/38