### PR TITLE
Allow BinDeps 0.7.0 on julia 0.5 and 0.6 on non-linux

### DIFF
--- a/BinDeps/versions/0.7.0/requires
+++ b/BinDeps/versions/0.7.0/requires
@@ -1,4 +1,5 @@
-julia 0.7.0-DEV.1287
+julia 0.5
+@linux julia 0.7.0-DEV.1287
 URIParser
 SHA
 Compat 0.17.0


### PR DESCRIPTION
the problem #10652 is avoiding is only an issue on linux
(and maybe freebsd)