### PR TITLE
Add bounds to LanguageServer.jl requirements

### DIFF
--- a/LanguageServer/versions/0.1.0/requires
+++ b/LanguageServer/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
 JSON 0.8.1
 URIParser 0.1.8
-CSTParser
+CSTParser 0.0.2 0.2.0
 Tokenize

--- a/LanguageServer/versions/0.1.1/requires
+++ b/LanguageServer/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
 JSON 0.8.1
 URIParser 0.1.8
-CSTParser
+CSTParser 0.0.2 0.2.0
 Tokenize

--- a/LanguageServer/versions/0.1.2/requires
+++ b/LanguageServer/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
 JSON 0.8.1
 URIParser 0.1.8
-CSTParser
+CSTParser 0.0.2 0.2.0
 Tokenize

--- a/LanguageServer/versions/0.1.3/requires
+++ b/LanguageServer/versions/0.1.3/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
 JSON 0.8.1
 URIParser 0.1.8
-CSTParser
+CSTParser 0.0.2 0.2.0
 Tokenize

--- a/LanguageServer/versions/0.1.4/requires
+++ b/LanguageServer/versions/0.1.4/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
 JSON 0.8.1
 URIParser 0.1.8
-CSTParser
+CSTParser 0.0.2 0.2.0
 Tokenize

--- a/LanguageServer/versions/0.1.5/requires
+++ b/LanguageServer/versions/0.1.5/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
 JSON 0.8.1
 URIParser 0.1.8
-CSTParser
+CSTParser 0.0.2 0.2.0
 Tokenize


### PR DESCRIPTION
I also had to add lower bounds, and I just picked the first version of CSTParser.jl that was registered in METADATA.jl. I'm almost certain that those lower bounds are not right, but the main purpose of this PR is to get the upper bounds in place.