### PR TITLE
Add upper bounds on IterableTables dependencies

### DIFF
--- a/CSVFiles/versions/0.0.1/requires
+++ b/CSVFiles/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 TextParse 0.1.6
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0

--- a/CSVFiles/versions/0.1.0/requires
+++ b/CSVFiles/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 TextParse 0.1.6
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0

--- a/CSVFiles/versions/0.1.1/requires
+++ b/CSVFiles/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 TextParse 0.1.6
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0

--- a/CSVFiles/versions/0.2.0/requires
+++ b/CSVFiles/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 TextParse 0.1.6
-IterableTables 0.4.0
+IterableTables 0.4.0 0.5.0
 DataValues 0.1.0
 FileIO 0.4.0
 HTTP 0.4.2

--- a/ExcelFiles/versions/0.0.1/requires
+++ b/ExcelFiles/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 ExcelReaders 0.7.0
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0

--- a/ExcelFiles/versions/0.1.0/requires
+++ b/ExcelFiles/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 ExcelReaders 0.7.0
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0

--- a/FeatherFiles/versions/0.0.1/requires
+++ b/FeatherFiles/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 Feather 0.2.4
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0

--- a/FeatherFiles/versions/0.0.2/requires
+++ b/FeatherFiles/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 Feather 0.2.4
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0

--- a/Query/versions/0.4.1/requires
+++ b/Query/versions/0.4.1/requires
@@ -3,4 +3,4 @@ NamedTuples 2.0.0 3.0.0
 DataStructures 0.4.5
 Requires 0.3.0
 Documenter 0.9.0
-IterableTables 0.0.1
+IterableTables 0.0.1 0.5.0

--- a/Query/versions/0.5.0/requires
+++ b/Query/versions/0.5.0/requires
@@ -3,5 +3,5 @@ NamedTuples 3.0.2
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0
-IterableTables 0.1.0
+IterableTables 0.1.0 0.5.0
 DataValues 0.0.2

--- a/Query/versions/0.6.0/requires
+++ b/Query/versions/0.6.0/requires
@@ -3,5 +3,5 @@ NamedTuples 3.0.2
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0
-IterableTables 0.1.0
+IterableTables 0.1.0 0.5.0
 DataValues 0.0.2

--- a/StatFiles/versions/0.0.1/requires
+++ b/StatFiles/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 ReadStat 0.1.1
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataFrames 0.10.0
 FileIO 0.4.0

--- a/StatFiles/versions/0.0.2/requires
+++ b/StatFiles/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 ReadStat 0.1.1
-IterableTables 0.2.0
+IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataFrames 0.10.0
 FileIO 0.4.0


### PR DESCRIPTION
IterableTables v0.5.0 will be breaking, so this bounds all existing packages that depend on it. I'll tag IterableTables v0.5.0 once this tag here is merged, and then will also tag new versions of all the packages that depend on IterableTables.