### PR TITLE
Add bounds to BedgraphsFiles package

### DIFF
--- a/BedgraphFiles/versions/0.1.0/requires
+++ b/BedgraphFiles/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
-IterableTables 0.4.2
+IterableTables 0.4.2 0.5.0
 FileIO 0.5.1
 DataFrames 0.10.0


### PR DESCRIPTION
Missed this one when I did #10832.

@CiaranOMara Cool package! I'm in the process of moving the trait definition from IterableTables to TableTraits to get rid of some annoying Requires.jl dependency. This here will prevent things from breaking, and I'll open PRs against BedgraphFiles.jl to make this a smooth transition.