### PR TITLE
Add bounds to a LazyQuery dependency

### DIFF
--- a/LazyQuery/versions/0.0.1/requires
+++ b/LazyQuery/versions/0.0.1/requires
@@ -2,3 +2,4 @@ julia 0.5
 DataFrames
 MacroTools
 LazyContext 0.0.1 0.1.0
+Query 0.0.0 0.7.0

--- a/LazyQuery/versions/0.1.0/requires
+++ b/LazyQuery/versions/0.1.0/requires
@@ -2,6 +2,6 @@ julia 0.6
 LazyContext 0.1.1
 DataFrames
 MacroTools 0.3.3
-Query
+Query 0.0.1 0.7.0
 NamedTuples
 ChainRecursive 0.0.3

--- a/LazyQuery/versions/0.1.1/requires
+++ b/LazyQuery/versions/0.1.1/requires
@@ -2,7 +2,7 @@ julia 0.6
 LazyContext 0.1.2
 DataFrames
 MacroTools 0.3.2
-Query
+Query 0.0.1 0.7.0
 NamedTuples
 ChainRecursive 0.0.3
 LazyCall 0.1.1


### PR DESCRIPTION
Current LazyQuery.jl versions don't work with Query.jl v0.7.0, so this adds the appropriate bounds.

CC @bramtayl 