### PR TITLE
Deprecate ControlCore

### DIFF
--- a/ControlCore/versions/0.0.1/requires
+++ b/ControlCore/versions/0.0.1/requires
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.4 0.7
 Polynomials


### PR DESCRIPTION
Deprecated [`ControlCore`](https://github.com/KTH-AC/ControlCore.jl) in favour of [`LTISystems`](https://github.com/JuliaSystems/LTISystems.jl).

Related to #11014 and #11015.