### PR TITLE
Upper bound DelayDiffEq

### DIFF
--- a/DelayDiffEq/versions/0.10.0/requires
+++ b/DelayDiffEq/versions/0.10.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DiffEqBase 1.21.0
-OrdinaryDiffEq 2.17.0
+OrdinaryDiffEq 2.17.0 2.18.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics

--- a/DelayDiffEq/versions/0.9.0/requires
+++ b/DelayDiffEq/versions/0.9.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DiffEqBase 1.16.0
-OrdinaryDiffEq 2.15.0
+OrdinaryDiffEq 2.15.0 2.18.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics

--- a/DelayDiffEq/versions/0.9.1/requires
+++ b/DelayDiffEq/versions/0.9.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DiffEqBase 1.16.0
-OrdinaryDiffEq 2.15.0
+OrdinaryDiffEq 2.15.0 2.18.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics


### PR DESCRIPTION
This PR adds upper bounds to `DelayDiffEq` versions since there was a breaking change in `OrdinaryDiffEq`, see https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/36 for more information.