### PR TITLE
Correctly bound DelayDiffEq

### DIFF
--- a/DelayDiffEq/versions/0.10.0/requires
+++ b/DelayDiffEq/versions/0.10.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DiffEqBase 1.21.0
-OrdinaryDiffEq 2.17.0 2.18.0
+OrdinaryDiffEq 2.17.0 2.19.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics

--- a/DelayDiffEq/versions/0.9.0/requires
+++ b/DelayDiffEq/versions/0.9.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DiffEqBase 1.16.0
-OrdinaryDiffEq 2.15.0 2.18.0
+OrdinaryDiffEq 2.15.0 2.19.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics

--- a/DelayDiffEq/versions/0.9.1/requires
+++ b/DelayDiffEq/versions/0.9.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DiffEqBase 1.16.0
-OrdinaryDiffEq 2.15.0 2.18.0
+OrdinaryDiffEq 2.15.0 2.19.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics


### PR DESCRIPTION
This corrects https://github.com/JuliaLang/METADATA.jl/pull/11095. Sorry, I wrongly assumed upper bounds are inclusive.