### PR TITLE
Tag Graphs v0.8.0 [https://github.com/JuliaArchive/Graphs.jl]

### DIFF
--- a/Graphs/versions/0.8.0/requires
+++ b/Graphs/versions/0.8.0/requires
@@ -1,0 +1,3 @@
+julia 0.5
+DataStructures 0.5.0
+Compat 0.18

--- a/Graphs/versions/0.8.0/sha1
+++ b/Graphs/versions/0.8.0/sha1
@@ -1,0 +1,1 @@
+784d12602dd3eefa2f94824ae7daf2b42b8c6b6c


### PR DESCRIPTION
REDO of #11193 , but need minor version update for dropping Julia 0.4 support.

[Graphs.jl](https://github.com/JuliaArchive/Graphs.jl)
v0.7.1 -> [v0.8.0](https://github.com/JuliaArchive/Graphs.jl/releases/tag/v0.8.0)
[![Build Status](https://travis-ci.org/JuliaArchive/Graphs.jl.svg?branch=master)](https://travis-ci.org/JuliaArchive/Graphs.jl)
Diff vs v0.7.1: https://github.com/JuliaArchive/Graphs.jl/compare/0207655f5e3f51dde98e507b4e5f4ccf480390eb...784d12602dd3eefa2f94824ae7daf2b42b8c6b6c

REQUIRE
```
julia 0.5
DataStructures 0.5.0
Compat 0.18
```