### PR TITLE
change links to have JuliaDynamics instead of Datseris

### DIFF
--- a/DynamicalBilliards/url
+++ b/DynamicalBilliards/url
@@ -1,1 +1,1 @@
-https://github.com/Datseris/DynamicalBilliards.jl.git
+https://github.com/JuliaDynamics/DynamicalBilliards.jl.git

--- a/DynamicalSystems/url
+++ b/DynamicalSystems/url
@@ -1,1 +1,1 @@
-https://github.com/Datseris/DynamicalSystems.jl.git
+https://github.com/JuliaDynamics/DynamicalSystems.jl.git


### PR DESCRIPTION
Due to the creation of the github organization.