### PR TITLE
Tag IncrementalInference v0.2.10

### DIFF
--- a/IncrementalInference/versions/0.2.10/requires
+++ b/IncrementalInference/versions/0.2.10/requires
@@ -1,0 +1,13 @@
+julia 0.5
+Graphs 0.8.0
+GraphViz
+Gadfly
+Colors
+NLsolve
+Optim
+Distributions
+KernelDensityEstimate 0.2.6
+HDF5 0.8.5
+JLD
+ProgressMeter
+Compat 0.18

--- a/IncrementalInference/versions/0.2.10/sha1
+++ b/IncrementalInference/versions/0.2.10/sha1
@@ -1,0 +1,1 @@
+ac625cd49afd57d82413d3d305f26adddb7a974b


### PR DESCRIPTION
[IncrementalInference.jl](https://github.com/dehann/IncrementalInference.jl)
v0.2.9 -> [v0.2.10](https://github.com/dehann/IncrementalInference.jl/releases/tag/v0.2.10)
[![Build Status](https://travis-ci.org/dehann/IncrementalInference.jl.svg?branch=master)](https://travis-ci.org/dehann/IncrementalInference.jl)
Diff vs v0.2.9: https://github.com/dehann/IncrementalInference.jl/compare/476212075512dfff85b371a8254824693d3e8fd0...ac625cd49afd57d82413d3d305f26adddb7a974b