### PR TITLE
add upper bounds for sugar + transpiler

### DIFF
--- a/GPUArrays/versions/0.1.0/requires
+++ b/GPUArrays/versions/0.1.0/requires
@@ -2,8 +2,8 @@ julia 0.6
 StaticArrays
 ColorTypes
 
-Transpiler 0.3
-Sugar 0.3
+Transpiler 0.3 0.4
+Sugar 0.3 0.4
 Matcha 0.0.2
 
 CUDAnative 0.4.1 # llvm codegen fix

--- a/Transpiler/versions/0.1.0/requires
+++ b/Transpiler/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 Compat 0.17.0
-Sugar 0.3.0
+Sugar 0.3 0.4
 Matcha
 StaticArrays 0.3.0
 DataStructures

--- a/Transpiler/versions/0.2.0/requires
+++ b/Transpiler/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 Compat 0.17.0
-Sugar 0.3.0
+Sugar 0.3 0.4
 Matcha
 StaticArrays 0.3.0
 DataStructures

--- a/Transpiler/versions/0.3.0/requires
+++ b/Transpiler/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 Compat 0.17.0
-Sugar 0.3.0
+Sugar 0.3 0.4
 Matcha
 StaticArrays 0.3.0
 DataStructures


### PR DESCRIPTION
I think this is how we can assure, that GPUArrays still works after tagging Sugar + Transpiler for the new changes!