### PR TITLE
Change URL following the move to the GenericMappingTools organization

### DIFF
--- a/GMT/url
+++ b/GMT/url
@@ -1,1 +1,1 @@
-git://github.com/joa-quim/GMT.jl.git
+git://github.com/GenericMappingTools/GMT.jl.git

--- a/GMT/url
+++ b/GMT/url
@@ -1,1 +1,1 @@
-git://github.com/GenericMappingTools/GMT.jl.git
+git://github.com/joa-quim/GMT.jl.git


### PR DESCRIPTION
GMT.jl is now hosted under the https://github.com/GenericMappingTools organization