### PR TITLE
Bump Compat dependency for GLMNet 0.3.0

### DIFF
--- a/GLMNet/versions/0.3.0/requires
+++ b/GLMNet/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Distributions
 StatsBase
-Compat 0.9.3
+Compat 0.27.0


### PR DESCRIPTION
Tagged with Compat too low. Ref https://github.com/JuliaStats/GLMNet.jl/pull/27