### PR TITLE
Add upper bounds of Celeste dependencies

### DIFF
--- a/Celeste/versions/0.3.0/requires
+++ b/Celeste/versions/0.3.0/requires
@@ -6,8 +6,8 @@ Distributions
 FITSIO 0.8.4
 DiffBase 0.0.3 0.3.0
 ForwardDiff 0.3.4 0.5
-ReverseDiff 0.1.1 0.2
+ReverseDiff 0.1.1 0.1.3
 JLD 0.6.0
 Optim 0.7.4
-StaticArrays 0.1.4
+StaticArrays 0.1.4 0.5.0
 WCS 0.1.3


### PR DESCRIPTION
cc @jeff-regier. Without this, the tagged version of Celeste doesn't load on 0.6.