### PR TITLE
Remove upper bound on OptimBase

### DIFF
--- a/OptimBase/versions/0.1.0/requires
+++ b/OptimBase/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Reexport
-NLSolversBase 2.0 3.0
+NLSolversBase 2.0
 Compat 0.18


### PR DESCRIPTION
It seems that this was not necessary, and is currently making LsqFit downgrade NLSolversBase, Optim and NLsolve and LsqFit ends up not working as a result.