### PR TITLE
LowRankApprox v0.1.0

### DIFF
--- a/LowRankApprox/url
+++ b/LowRankApprox/url
@@ -1,1 +1,1 @@
-https://github.com/klho/LowRankApprox.jl.git
+https://github.com/JuliaMatrices/LowRankApprox.jl.git

--- a/LowRankApprox/versions/0.1.0/requires
+++ b/LowRankApprox/versions/0.1.0/requires
@@ -1,0 +1,3 @@
+julia 0.6
+Compat 0.18
+FFTW 0.0.4

--- a/LowRankApprox/versions/0.1.0/sha1
+++ b/LowRankApprox/versions/0.1.0/sha1
@@ -1,0 +1,1 @@
+d32fcad35d9ce39536b36e58421fbace2bb0ee73


### PR DESCRIPTION
This moves LowRankApprox to JuliaMatrices, and tags a new release that support v0.7-dev but drops v0.5.