### PR TITLE
Add upper bound on a Feather dependency

### DIFF
--- a/Feather/versions/0.2.5/requires
+++ b/Feather/versions/0.2.5/requires
@@ -1,5 +1,5 @@
 julia 0.5
-FlatBuffers 0.2.0
+FlatBuffers 0.2.0 0.2.1
 NullableArrays 0.0.8
 CategoricalArrays 0.0.6 0.2.0
 DataFrames


### PR DESCRIPTION
This should be approved by someone from the JuliaData organization, ideally @quinnj.

It is a short-term fix for https://github.com/JuliaData/Feather.jl/issues/58, which is a real issue for all the downstream packages because it breaks all the tests.