### PR TITLE
Redirect deprecated package urls, according to discussion in #11200

### DIFF
--- a/Arduino/url
+++ b/Arduino/url
@@ -1,1 +1,1 @@
-git://github.com/rennis250/Arduino.jl.git
+git://github.com/JuliaPackageMirrors/Arduino.jl.git

--- a/GLUT/url
+++ b/GLUT/url
@@ -1,1 +1,1 @@
-git://github.com/rennis250/GLUT.jl.git
+git://github.com/JuliaPackageMirrors/GLUT.jl.git

--- a/GetC/url
+++ b/GetC/url
@@ -1,1 +1,1 @@
-git://github.com/rennis250/GetC.jl.git
+git://github.com/JuliaPackageMirrors/GetC.jl.git

--- a/OpenGL/url
+++ b/OpenGL/url
@@ -1,1 +1,1 @@
-git://github.com/rennis250/OpenGL.jl.git
+git://github.com/JuliaPackageMirrors/OpenGL.jl.git

--- a/Processing/url
+++ b/Processing/url
@@ -1,1 +1,1 @@
-git://github.com/rennis250/Processing.jl.git
+git://github.com/JuliaPackageMirrors/Processing.jl.git

--- a/SDL/url
+++ b/SDL/url
@@ -1,1 +1,1 @@
-git://github.com/rennis250/SDL.jl.git
+git://github.com/JuliaPackageMirrors/SDL.jl.git

--- a/Sparrow/url
+++ b/Sparrow/url
@@ -1,1 +1,1 @@
-git://github.com/rennis250/Sparrow.jl.git
+git://github.com/JuliaPackageMirrors/Sparrow.jl.git


### PR DESCRIPTION
I no longer maintain any of these packages and would like to remove them from my account. According to the discussion in #11200, it is acceptable if I redirect the urls to the JuliaPackageMirrors versions.