### PR TITLE
Fix bounds on DiffEqDiffTools

### DIFF
--- a/DiffEqDiffTools/versions/0.0.1/requires
+++ b/DiffEqDiffTools/versions/0.0.1/requires
@@ -1,1 +1,1 @@
-julia 0.6
+julia 0.5

--- a/OrdinaryDiffEq/versions/0.0.1/requires
+++ b/OrdinaryDiffEq/versions/0.0.1/requires
@@ -9,3 +9,4 @@ Sundials 0.3.0
 Ranges 0.0.1
 RecipesBase 0.1.0
 DiffEqBase 0.0.0 0.7.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.0.2/requires
+++ b/OrdinaryDiffEq/versions/0.0.2/requires
@@ -10,3 +10,4 @@ Sundials 0.3.0
 Ranges 0.0.1
 RecipesBase 0.1.0
 ParameterizedFunctions 0.1.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.0.3/requires
+++ b/OrdinaryDiffEq/versions/0.0.3/requires
@@ -10,3 +10,4 @@ Sundials 0.3.0
 Ranges 0.0.1
 RecipesBase 0.1.0
 ParameterizedFunctions 0.1.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.0.4/requires
+++ b/OrdinaryDiffEq/versions/0.0.4/requires
@@ -10,3 +10,4 @@ Sundials 0.3.0
 Ranges 0.0.1
 RecipesBase 0.1.0
 RecursiveArrayTools
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.0.5/requires
+++ b/OrdinaryDiffEq/versions/0.0.5/requires
@@ -10,3 +10,4 @@ Sundials 0.3.0
 Ranges 0.0.1
 RecipesBase 0.1.0
 RecursiveArrayTools
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.1.0/requires
+++ b/OrdinaryDiffEq/versions/0.1.0/requires
@@ -10,3 +10,4 @@ Ranges 0.0.1
 RecipesBase 0.1.0
 RecursiveArrayTools
 Juno
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.1.1/requires
+++ b/OrdinaryDiffEq/versions/0.1.1/requires
@@ -10,3 +10,4 @@ Ranges 0.0.1
 RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.2.0/requires
+++ b/OrdinaryDiffEq/versions/0.2.0/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.2.1/requires
+++ b/OrdinaryDiffEq/versions/0.2.1/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.3.0/requires
+++ b/OrdinaryDiffEq/versions/0.3.0/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.3.1/requires
+++ b/OrdinaryDiffEq/versions/0.3.1/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.4.0/requires
+++ b/OrdinaryDiffEq/versions/0.4.0/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.4.1/requires
+++ b/OrdinaryDiffEq/versions/0.4.1/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.4.2/requires
+++ b/OrdinaryDiffEq/versions/0.4.2/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.5.0/requires
+++ b/OrdinaryDiffEq/versions/0.5.0/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/0.6.0/requires
+++ b/OrdinaryDiffEq/versions/0.6.0/requires
@@ -11,3 +11,4 @@ RecipesBase 0.1.0
 RecursiveArrayTools 0.0.2
 Juno 0.2.5
 Calculus 0.1.15
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.0.0/requires
+++ b/OrdinaryDiffEq/versions/1.0.0/requires
@@ -11,3 +11,4 @@ Juno 0.2.5
 Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.0.1/requires
+++ b/OrdinaryDiffEq/versions/1.0.1/requires
@@ -11,3 +11,4 @@ Juno 0.2.5
 Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.0.2/requires
+++ b/OrdinaryDiffEq/versions/1.0.2/requires
@@ -11,3 +11,4 @@ Juno 0.2.5
 Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.1.0/requires
+++ b/OrdinaryDiffEq/versions/1.1.0/requires
@@ -12,3 +12,4 @@ Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
 Iterators
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.2.0/requires
+++ b/OrdinaryDiffEq/versions/1.2.0/requires
@@ -12,3 +12,4 @@ Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
 Iterators
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.3.0/requires
+++ b/OrdinaryDiffEq/versions/1.3.0/requires
@@ -12,3 +12,4 @@ Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
 Iterators
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.3.1/requires
+++ b/OrdinaryDiffEq/versions/1.3.1/requires
@@ -12,3 +12,4 @@ Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
 Iterators
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.4.0/requires
+++ b/OrdinaryDiffEq/versions/1.4.0/requires
@@ -12,3 +12,4 @@ Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
 Iterators
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.4.1/requires
+++ b/OrdinaryDiffEq/versions/1.4.1/requires
@@ -12,3 +12,4 @@ Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
 Iterators
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.5.0/requires
+++ b/OrdinaryDiffEq/versions/1.5.0/requires
@@ -13,3 +13,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.17.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.6.0/requires
+++ b/OrdinaryDiffEq/versions/1.6.0/requires
@@ -13,3 +13,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.17.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.6.1/requires
+++ b/OrdinaryDiffEq/versions/1.6.1/requires
@@ -13,3 +13,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.17.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.7.0/requires
+++ b/OrdinaryDiffEq/versions/1.7.0/requires
@@ -13,3 +13,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.17.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/1.8.0/requires
+++ b/OrdinaryDiffEq/versions/1.8.0/requires
@@ -13,3 +13,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.17.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.0.0/requires
+++ b/OrdinaryDiffEq/versions/2.0.0/requires
@@ -13,3 +13,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.17.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.0.1/requires
+++ b/OrdinaryDiffEq/versions/2.0.1/requires
@@ -13,3 +13,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.17.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.0.2/requires
+++ b/OrdinaryDiffEq/versions/2.0.2/requires
@@ -12,3 +12,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.18.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.0.3/requires
+++ b/OrdinaryDiffEq/versions/2.0.3/requires
@@ -12,3 +12,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.18.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.1.0/requires
+++ b/OrdinaryDiffEq/versions/2.1.0/requires
@@ -12,3 +12,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.18.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.2.0/requires
+++ b/OrdinaryDiffEq/versions/2.2.0/requires
@@ -12,3 +12,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.18.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.2.1/requires
+++ b/OrdinaryDiffEq/versions/2.2.1/requires
@@ -12,3 +12,4 @@ Roots 0.2.1
 DataStructures 0.4.6
 Iterators
 Compat 0.18.0
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.3.1/requires
+++ b/OrdinaryDiffEq/versions/2.3.1/requires
@@ -13,3 +13,4 @@ DataStructures 0.4.6
 Iterators
 Compat 0.18.0
 StaticArrays
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.3.2/requires
+++ b/OrdinaryDiffEq/versions/2.3.2/requires
@@ -12,3 +12,4 @@ DataStructures 0.4.6
 Iterators
 Compat 0.18.0
 StaticArrays
+DiffEqDiffTools 0.0.0 0.1.0

--- a/OrdinaryDiffEq/versions/2.4.0/requires
+++ b/OrdinaryDiffEq/versions/2.4.0/requires
@@ -12,3 +12,4 @@ DataStructures 0.4.6
 Iterators
 Compat 0.18.0
 StaticArrays
+DiffEqDiffTools 0.0.0 0.1.0


### PR DESCRIPTION
This stops the downgrading problems without causing versioning issues on v0.5