### PR TITLE
Augmentor.jl: restrict upper version of ImageCore and StaticArrays

### DIFF
--- a/Augmentor/versions/0.0.1/requires
+++ b/Augmentor/versions/0.0.1/requires
@@ -1,11 +1,11 @@
 julia 0.5
-ImageCore 0.1.2
+ImageCore 0.1.2 0.5
 ImageTransformations 0.3.0
 ImageFiltering 0.1.4
 CoordinateTransformations 0.4.0
 Interpolations 0.6
 Rotations
-StaticArrays
+StaticArrays 0.0.0 0.6.5
 OffsetArrays
 IdentityRanges
 ColorTypes 0.4

--- a/Augmentor/versions/0.0.2/requires
+++ b/Augmentor/versions/0.0.2/requires
@@ -1,11 +1,11 @@
 julia 0.5
-ImageCore 0.1.2
+ImageCore 0.1.2 0.5
 ImageTransformations 0.3.0
 ImageFiltering 0.1.4
 CoordinateTransformations 0.4.0
 Interpolations 0.6
 Rotations
-StaticArrays
+StaticArrays 0.0.0 0.6.5
 OffsetArrays
 IdentityRanges
 ColorTypes 0.4

--- a/Augmentor/versions/0.1.0/requires
+++ b/Augmentor/versions/0.1.0/requires
@@ -1,11 +1,11 @@
 julia 0.5
-ImageCore 0.1.2
+ImageCore 0.1.2 0.5
 ImageTransformations 0.3.0
 ImageFiltering 0.1.4
 CoordinateTransformations 0.4.0
 Interpolations 0.6
 Rotations
-StaticArrays
+StaticArrays 0.0.0 0.6.5
 OffsetArrays
 IdentityRanges
 ColorTypes 0.4

--- a/Augmentor/versions/0.2.0/requires
+++ b/Augmentor/versions/0.2.0/requires
@@ -1,12 +1,12 @@
 julia 0.6
 MappedArrays 0.0.3
-ImageCore 0.1.2
+ImageCore 0.1.2 0.5
 ImageTransformations 0.3.0
 ImageFiltering 0.1.4
 CoordinateTransformations 0.4.0
 Interpolations 0.6
 Rotations
-StaticArrays
+StaticArrays 0.0.0 0.6.5
 OffsetArrays
 IdentityRanges
 ColorTypes 0.4

--- a/Augmentor/versions/0.3.0/requires
+++ b/Augmentor/versions/0.3.0/requires
@@ -1,12 +1,12 @@
 julia 0.6
 MappedArrays 0.0.3
-ImageCore 0.1.2
+ImageCore 0.1.2 0.5
 ImageTransformations 0.3.0
 ImageFiltering 0.1.4
 CoordinateTransformations 0.4.0
 Interpolations 0.6
 Rotations
-StaticArrays
+StaticArrays 0.0.0 0.6.5
 OffsetArrays
 IdentityRanges
 ColorTypes 0.4


### PR DESCRIPTION
The tagged versions of Augmentor rely on a function in ImageCore that was removed with ImageCore 0.5