### PR TITLE
update MathProgBase upper bounds

### DIFF
--- a/AmplNLWriter/versions/0.3.0/requires
+++ b/AmplNLWriter/versions/0.3.0/requires
@@ -1,2 +1,2 @@
 julia 0.5
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8

--- a/CPLEX/versions/0.2.8/requires
+++ b/CPLEX/versions/0.2.8/requires
@@ -1,3 +1,3 @@
 julia 0.5
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 Compat 0.18

--- a/Cbc/versions/0.3.2/requires
+++ b/Cbc/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
 BinDeps
-MathProgBase 0.5.5 0.7
+MathProgBase 0.5.5 0.8
 @osx Homebrew
 @windows WinRPM

--- a/Clp/versions/0.3.1/requires
+++ b/Clp/versions/0.3.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
 Cbc
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8

--- a/CoinOptServices/versions/0.2.0/requires
+++ b/CoinOptServices/versions/0.2.0/requires
@@ -4,6 +4,6 @@ Cbc
 Ipopt
 LightXML 0.2
 BinDeps
-MathProgBase 0.5.0 0.7
+MathProgBase 0.5.0 0.8
 @osx Homebrew
 @windows WinRPM

--- a/Convex/versions/0.5.0/requires
+++ b/Convex/versions/0.5.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 DataStructures

--- a/GLPKMathProgInterface/versions/0.3.4/requires
+++ b/GLPKMathProgInterface/versions/0.3.4/requires
@@ -1,4 +1,4 @@
 julia 0.5
 GLPK 0.2.8
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 Compat 0.17.0

--- a/Gurobi/versions/0.3.3/requires
+++ b/Gurobi/versions/0.3.3/requires
@@ -1,3 +1,3 @@
 julia 0.5
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 Compat 0.18

--- a/Ipopt/versions/0.2.6/requires
+++ b/Ipopt/versions/0.2.6/requires
@@ -1,6 +1,6 @@
 julia 0.4
 BinDeps
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 @osx Homebrew
 @windows WinRPM
 Compat 0.8.0

--- a/JuMP/versions/0.18.0/requires
+++ b/JuMP/versions/0.18.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-MathProgBase 0.6 0.7
+MathProgBase 0.6 0.8
 ReverseDiffSparse 0.8 0.9
 ForwardDiff 0.5 0.6
 Calculus

--- a/KNITRO/versions/0.3.1/requires
+++ b/KNITRO/versions/0.3.1/requires
@@ -1,2 +1,2 @@
 julia 0.5
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8

--- a/NLopt/versions/0.3.6/requires
+++ b/NLopt/versions/0.3.6/requires
@@ -1,5 +1,5 @@
 julia 0.4
 @osx Homebrew
 BinDeps
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 Compat 0.8

--- a/Pajarito/versions/0.5.0/requires
+++ b/Pajarito/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 JuMP 0.15
 ConicNonlinearBridge
 ConicBenchmarkUtilities

--- a/SCIP/versions/0.4.0/requires
+++ b/SCIP/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 BinDeps
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 Compat 0.8.6

--- a/SCS/versions/0.3.3/requires
+++ b/SCS/versions/0.3.3/requires
@@ -1,4 +1,4 @@
 julia 0.5
-MathProgBase 0.5 0.7
+MathProgBase 0.5 0.8
 BinDeps
 @osx Homebrew

--- a/Xpress/versions/0.5.0/requires
+++ b/Xpress/versions/0.5.0/requires
@@ -1,2 +1,2 @@
 julia 0.5
-MathProgBase 0.6 0.7
+MathProgBase 0.6 0.8


### PR DESCRIPTION
A "major" version bump for MathProgBase 0.7 was required as it dropped support for Julia 0.5, no changes otherwise.