### PR TITLE
Add missing upper bounds on CategoricalArrays 0.3.0 to recent RCall releases

### DIFF
--- a/RCall/versions/0.7.5/requires
+++ b/RCall/versions/0.7.5/requires
@@ -2,7 +2,7 @@ julia 0.5
 DataStructures 0.5.0
 DataFrames 0.9
 NullableArrays 0.1.0
-CategoricalArrays 0.1.0
+CategoricalArrays 0.1.0 0.3.0
 AxisArrays 0.0.6
 NamedArrays 0.5.3
 Compat 0.17.0

--- a/RCall/versions/0.8.0/requires
+++ b/RCall/versions/0.8.0/requires
@@ -3,7 +3,7 @@ Nulls 0.1.0
 DataStructures 0.5.0
 DataFrames 0.10
 DataArrays 0.5.0
-CategoricalArrays 0.1.0
+CategoricalArrays 0.1.0 0.3.0
 NullableArrays 0.1.0
 AxisArrays 0.0.6
 NamedArrays 0.5.3

--- a/RCall/versions/0.8.1/requires
+++ b/RCall/versions/0.8.1/requires
@@ -3,7 +3,7 @@ Nulls 0.1.0
 DataStructures 0.5.0
 DataFrames 0.10
 DataArrays 0.5.0
-CategoricalArrays 0.1.0
+CategoricalArrays 0.1.0 0.3.0
 NullableArrays 0.1.0
 AxisArrays 0.0.6
 NamedArrays 0.5.3


### PR DESCRIPTION
These should have been included in #12039.

Cc: @randy3k 