### PR TITLE
Upper bound julia versions for old Gallium

### DIFF
--- a/Gallium/versions/0.0.1/requires
+++ b/Gallium/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5- 0.6
 TerminalUI
 DWARF
 ELF

--- a/Gallium/versions/0.0.2/requires
+++ b/Gallium/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5- 0.6
 TerminalUI
 DWARF
 ObjFileBase

--- a/Gallium/versions/0.0.3/requires
+++ b/Gallium/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5- 0.6
 TerminalUI
 DWARF
 ObjFileBase

--- a/Gallium/versions/0.0.4/requires
+++ b/Gallium/versions/0.0.4/requires
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5- 0.6
 TerminalUI
 DWARF
 ObjFileBase


### PR DESCRIPTION
In preparation for tagging a new 0.6 Gallium that just re-exports ASTInterpreter2.