### PR TITLE
Tag DataFrames 0.11.0

### DIFF
--- a/Augur/versions/0.0.1/requires
+++ b/Augur/versions/0.0.1/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Distributions
 Dates
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 HDF5
 Gadfly

--- a/Augur/versions/0.0.2/requires
+++ b/Augur/versions/0.0.2/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Distributions
 Dates
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 HDF5
 Gadfly

--- a/Augur/versions/0.0.3/requires
+++ b/Augur/versions/0.0.3/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Distributions
 Dates
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 HDF5
 Gadfly

--- a/Augur/versions/0.1.0/requires
+++ b/Augur/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Distributions
 Dates
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 HDF5
 Gadfly

--- a/Augur/versions/0.1.1/requires
+++ b/Augur/versions/0.1.1/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Distributions
 Dates
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 HDF5
 Gadfly

--- a/BIGUQ/versions/0.1.0/requires
+++ b/BIGUQ/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.4-
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lora 0.4.4
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.1/requires
+++ b/BIGUQ/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lora 0.4.4
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.10/requires
+++ b/BIGUQ/versions/0.1.10/requires
@@ -2,7 +2,7 @@ julia 0.4
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BIGUQ/versions/0.1.2/requires
+++ b/BIGUQ/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lora 0.4.4
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.3/requires
+++ b/BIGUQ/versions/0.1.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lora 0.4.4
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.4/requires
+++ b/BIGUQ/versions/0.1.4/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lora 0.4.4
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.5/requires
+++ b/BIGUQ/versions/0.1.5/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lora 0.4.4
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.6/requires
+++ b/BIGUQ/versions/0.1.6/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lora
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.7/requires
+++ b/BIGUQ/versions/0.1.7/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Klara 0.6
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.8/requires
+++ b/BIGUQ/versions/0.1.8/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Klara 0.6
 ForwardDiff
 BlackBoxOptim

--- a/BIGUQ/versions/0.1.9/requires
+++ b/BIGUQ/versions/0.1.9/requires
@@ -2,7 +2,7 @@ julia 0.4
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BIGUQ/versions/0.2.0/requires
+++ b/BIGUQ/versions/0.2.0/requires
@@ -2,7 +2,7 @@ julia 0.4
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BIGUQ/versions/0.2.1/requires
+++ b/BIGUQ/versions/0.2.1/requires
@@ -2,7 +2,7 @@ julia 0.4
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BIGUQ/versions/0.2.2/requires
+++ b/BIGUQ/versions/0.2.2/requires
@@ -2,7 +2,7 @@ julia 0.5
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BIGUQ/versions/0.3.0/requires
+++ b/BIGUQ/versions/0.3.0/requires
@@ -2,7 +2,7 @@ julia 0.5
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BIGUQ/versions/0.3.1/requires
+++ b/BIGUQ/versions/0.3.1/requires
@@ -2,7 +2,7 @@ julia 0.5
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BIGUQ/versions/0.3.2/requires
+++ b/BIGUQ/versions/0.3.2/requires
@@ -2,7 +2,7 @@ julia 0.5
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BIGUQ/versions/0.3.3/requires
+++ b/BIGUQ/versions/0.3.3/requires
@@ -2,7 +2,7 @@ julia 0.5
 RobustPmap
 AffineInvariantMCMC
 Klara 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 BlackBoxOptim
 Distributions

--- a/BayesNets/versions/0.0.1/requires
+++ b/BayesNets/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/BayesNets/versions/0.0.10/requires
+++ b/BayesNets/versions/0.0.10/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.0.2/requires
+++ b/BayesNets/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.0.3/requires
+++ b/BayesNets/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.0.4/requires
+++ b/BayesNets/versions/0.0.4/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.0.5/requires
+++ b/BayesNets/versions/0.0.5/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.0.6/requires
+++ b/BayesNets/versions/0.0.6/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.0.7/requires
+++ b/BayesNets/versions/0.0.7/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.0.8/requires
+++ b/BayesNets/versions/0.0.8/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.0.9/requires
+++ b/BayesNets/versions/0.0.9/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.1.0/requires
+++ b/BayesNets/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.3- 0.5.0-rc0
 Graphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs

--- a/BayesNets/versions/0.2.0/requires
+++ b/BayesNets/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.3
 LightGraphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs
 LightXML

--- a/BayesNets/versions/0.2.1/requires
+++ b/BayesNets/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.3
 LightGraphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs
 LightXML

--- a/BayesNets/versions/0.3.0/requires
+++ b/BayesNets/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 LightGraphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs
 LightXML

--- a/BayesNets/versions/0.4.0/requires
+++ b/BayesNets/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 LightGraphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs
 LightXML
 Reexport

--- a/BayesNets/versions/0.4.1/requires
+++ b/BayesNets/versions/0.4.1/requires
@@ -1,6 +1,6 @@
 julia 0.4
 LightGraphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs
 LightXML
 Reexport

--- a/BayesNets/versions/1.0.0/requires
+++ b/BayesNets/versions/1.0.0/requires
@@ -4,7 +4,7 @@ Distributions
 Discretizers
 Iterators
 LightGraphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs
 LightXML
 Reexport

--- a/BayesNets/versions/1.0.1/requires
+++ b/BayesNets/versions/1.0.1/requires
@@ -4,7 +4,7 @@ Distributions
 Discretizers
 Iterators
 LightGraphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs
 LightXML
 Reexport

--- a/BayesNets/versions/1.0.2/requires
+++ b/BayesNets/versions/1.0.2/requires
@@ -4,7 +4,7 @@ Distributions
 Discretizers
 Iterators
 LightGraphs
-DataFrames
+DataFrames 0.0.1 0.11.0
 TikzGraphs
 LightXML
 Reexport

--- a/BayesNets/versions/1.0.3/requires
+++ b/BayesNets/versions/1.0.3/requires
@@ -4,7 +4,7 @@ Distributions 0.10.0
 Discretizers 0.3.0
 Iterators 0.1.9
 LightGraphs 0.6.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 TikzGraphs 0.1.1
 LightXML 0.3.0
 Reexport 0.0.3

--- a/BayesNets/versions/1.0.4/requires
+++ b/BayesNets/versions/1.0.4/requires
@@ -4,7 +4,7 @@ Distributions 0.10.0
 Discretizers 0.3.0
 Iterators 0.1.9
 LightGraphs 0.6.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 TikzGraphs 0.1.1
 LightXML 0.3.0
 Reexport 0.0.3

--- a/BayesNets/versions/1.0.5/requires
+++ b/BayesNets/versions/1.0.5/requires
@@ -4,7 +4,7 @@ Distributions 0.11.0
 Discretizers 0.3.0
 Iterators 0.1.9
 LightGraphs 0.6.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 TikzGraphs 0.1.1
 LightXML 0.3.0
 Reexport 0.0.3

--- a/BayesNets/versions/2.0.0/requires
+++ b/BayesNets/versions/2.0.0/requires
@@ -3,7 +3,7 @@ Distributions 0.11.0
 Discretizers 0.3.0
 Iterators 0.1.9
 LightGraphs 0.6.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 TikzGraphs 0.1.1
 LightXML 0.3.0
 Reexport 0.0.3

--- a/BayesNets/versions/2.1.0/requires
+++ b/BayesNets/versions/2.1.0/requires
@@ -3,7 +3,7 @@ Distributions 0.11.0
 Discretizers 0.3.0
 Iterators 0.1.9
 LightGraphs 0.6.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 TikzGraphs 0.1.1
 LightXML 0.3.0
 Reexport 0.0.3

--- a/BayesNets/versions/2.1.1/requires
+++ b/BayesNets/versions/2.1.1/requires
@@ -3,7 +3,7 @@ Distributions 0.11.0
 Discretizers 0.3.0
 Iterators 0.1.9
 LightGraphs 0.6.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 TikzGraphs 0.1.1
 LightXML 0.3.0
 Reexport 0.0.3

--- a/BayesianDataFusion/versions/0.1.0/requires
+++ b/BayesianDataFusion/versions/0.1.0/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/BayesianDataFusion/versions/0.2.0/requires
+++ b/BayesianDataFusion/versions/0.2.0/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/BayesianDataFusion/versions/0.3.0/requires
+++ b/BayesianDataFusion/versions/0.3.0/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/BayesianDataFusion/versions/0.3.1/requires
+++ b/BayesianDataFusion/versions/0.3.1/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/BayesianDataFusion/versions/0.3.2/requires
+++ b/BayesianDataFusion/versions/0.3.2/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/BayesianDataFusion/versions/0.3.3/requires
+++ b/BayesianDataFusion/versions/0.3.3/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/BayesianDataFusion/versions/0.3.4/requires
+++ b/BayesianDataFusion/versions/0.3.4/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators

--- a/BayesianDataFusion/versions/0.3.5/requires
+++ b/BayesianDataFusion/versions/0.3.5/requires
@@ -1,4 +1,4 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions 0.7.3
 Iterators
 Compat 0.4.4

--- a/BayesianDataFusion/versions/1.0.0/requires
+++ b/BayesianDataFusion/versions/1.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions 0.7.3
 Iterators
 Compat 0.4.4

--- a/BayesianDataFusion/versions/1.1.0/requires
+++ b/BayesianDataFusion/versions/1.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions 0.7.3
 Iterators
 Compat 0.4.4

--- a/BayesianDataFusion/versions/1.2.0/requires
+++ b/BayesianDataFusion/versions/1.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.8
+DataFrames 0.8 0.11.0
 Distributions 0.10
 Iterators 0.2.0
 Compat 0.9

--- a/BeaData/versions/0.0.1/requires
+++ b/BeaData/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Requests
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 

--- a/BeaData/versions/0.0.2/requires
+++ b/BeaData/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Requests
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 

--- a/BeaData/versions/0.0.3/requires
+++ b/BeaData/versions/0.0.3/requires
@@ -1,6 +1,6 @@
 julia 0.4
 Requests
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 DocStringExtensions
 Compat 0.7.9

--- a/BeaData/versions/0.1.0/requires
+++ b/BeaData/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 HTTP
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 DocStringExtensions

--- a/BeaData/versions/0.2.0/requires
+++ b/BeaData/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 HTTP
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 DocStringExtensions

--- a/Bedgraph/versions/0.1.0/requires
+++ b/Bedgraph/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.6
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0

--- a/Bedgraph/versions/0.1.1/requires
+++ b/Bedgraph/versions/0.1.1/requires
@@ -1,2 +1,2 @@
 julia 0.6
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0

--- a/BedgraphFiles/versions/0.1.0/requires
+++ b/BedgraphFiles/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 IterableTables 0.4.2 0.5.0
 FileIO 0.5.1
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0

--- a/BedgraphFiles/versions/0.1.1/requires
+++ b/BedgraphFiles/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.6
 IterableTables 0.4.2
 FileIO 0.5.1
-DataFrames 0.9.1
+DataFrames 0.9.1 0.11.0

--- a/BedgraphFiles/versions/0.1.2/requires
+++ b/BedgraphFiles/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.6
 IterableTables 0.4.2
 FileIO 0.5.1
-DataFrames 0.9.1
+DataFrames 0.9.1 0.11.0

--- a/BedgraphFiles/versions/1.0.0/requires
+++ b/BedgraphFiles/versions/1.0.0/requires
@@ -2,4 +2,4 @@ julia 0.6
 TableTraits 0.0.1
 IterableTables 0.5.0
 FileIO 0.5.1
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0

--- a/Benchmark/versions/0.0.0/requires
+++ b/Benchmark/versions/0.0.0/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Benchmark/versions/0.0.1/requires
+++ b/Benchmark/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Benchmark/versions/0.0.2/requires
+++ b/Benchmark/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Benchmark/versions/0.0.3/requires
+++ b/Benchmark/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Benchmark/versions/0.1.0/requires
+++ b/Benchmark/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.3-
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/BioMedQuery/versions/0.1.1/requires
+++ b/BioMedQuery/versions/0.1.1/requires
@@ -10,5 +10,5 @@ SQLite 0.3.5
 ZipFile 0.2.6
 XMLconvert 0.0.1
 MySQL 0.0.2
-DataFrames 0.8.3
+DataFrames 0.8.3 0.11.0
 NullableArrays 0.0.8

--- a/BioMedQuery/versions/0.2.0/requires
+++ b/BioMedQuery/versions/0.2.0/requires
@@ -10,6 +10,6 @@ SQLite 0.3.5
 ZipFile 0.2.6
 XMLconvert 0.0.1
 MySQL 0.0.2
-DataFrames 0.8.3
+DataFrames 0.8.3 0.11.0
 NullableArrays 0.0.8
 DataStructures 0.4.6

--- a/BioMedQuery/versions/0.2.1/requires
+++ b/BioMedQuery/versions/0.2.1/requires
@@ -10,6 +10,6 @@ SQLite 0.3.5
 ZipFile 0.2.6
 XMLconvert 0.0.1
 MySQL 0.0.2
-DataFrames 0.8.3
+DataFrames 0.8.3 0.11.0
 NullableArrays 0.0.8
 DataStructures 0.4.6

--- a/BioMedQuery/versions/0.2.2/requires
+++ b/BioMedQuery/versions/0.2.2/requires
@@ -10,6 +10,6 @@ SQLite 0.3.5
 ZipFile 0.2.6
 XMLconvert 0.0.1
 MySQL 0.0.2
-DataFrames 0.8.3
+DataFrames 0.8.3 0.11.0
 NullableArrays 0.0.8
 DataStructures 0.4.6

--- a/BlsData/versions/0.0.1/requires
+++ b/BlsData/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Requests
-DataFrames
+DataFrames 0.0.1 0.11.0
 JSON

--- a/BlsData/versions/0.0.2/requires
+++ b/BlsData/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.4
 Requests
-DataFrames
+DataFrames 0.0.1 0.11.0
 JSON
 HttpCommon
 Compat 0.7.9

--- a/Bootstrap/versions/0.1.0/requires
+++ b/Bootstrap/versions/0.1.0/requires
@@ -2,5 +2,5 @@ julia 0.3-
 StatsBase
 Iterators
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/Bootstrap/versions/0.1.1/requires
+++ b/Bootstrap/versions/0.1.1/requires
@@ -2,6 +2,6 @@ julia 0.3-
 StatsBase
 Iterators
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Bootstrap/versions/0.2.0/requires
+++ b/Bootstrap/versions/0.2.0/requires
@@ -2,6 +2,6 @@ julia 0.3
 StatsBase
 Iterators
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Bootstrap/versions/0.3.0/requires
+++ b/Bootstrap/versions/0.3.0/requires
@@ -2,6 +2,6 @@ julia 0.3
 StatsBase
 Iterators
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Bootstrap/versions/0.3.1/requires
+++ b/Bootstrap/versions/0.3.1/requires
@@ -2,6 +2,6 @@ julia 0.3
 StatsBase
 Iterators
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Bootstrap/versions/0.3.2/requires
+++ b/Bootstrap/versions/0.3.2/requires
@@ -2,6 +2,6 @@ julia 0.3
 StatsBase
 Iterators
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Bootstrap/versions/0.3.3/requires
+++ b/Bootstrap/versions/0.3.3/requires
@@ -2,7 +2,7 @@ julia 0.3
 StatsBase
 Iterators
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon
 Compat

--- a/Bootstrap/versions/1.0.0/requires
+++ b/Bootstrap/versions/1.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 FactCheck

--- a/Bootstrap/versions/1.1.0/requires
+++ b/Bootstrap/versions/1.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 StatsBase
 Distributions
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0
 FactCheck
 Compat 0.17.0

--- a/Brim/versions/1.0.0/requires
+++ b/Brim/versions/1.0.0/requires
@@ -1,4 +1,4 @@
 julia 0.3-
 Cairo
 Color 0.2.10-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Brim/versions/1.1.0/requires
+++ b/Brim/versions/1.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Cairo
 Color 0.2.10-
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lexicon
 Logging
 StatsBase

--- a/Brim/versions/1.2.1/requires
+++ b/Brim/versions/1.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Cairo
 Colors
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase

--- a/Brim/versions/1.2.2/requires
+++ b/Brim/versions/1.2.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Cairo
 Colors
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase

--- a/COMTRADE/versions/0.1.0/requires
+++ b/COMTRADE/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/CQLdriver/versions/0.8.3/requires
+++ b/CQLdriver/versions/0.8.3/requires
@@ -1,2 +1,2 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/CSV/versions/0.0.11/requires
+++ b/CSV/versions/0.0.11/requires
@@ -1,4 +1,4 @@
 julia 0.4.1
 DataStreams 0.0.8 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.2 0.3.0

--- a/CSV/versions/0.0.12/requires
+++ b/CSV/versions/0.0.12/requires
@@ -1,4 +1,4 @@
 julia 0.4.1
 DataStreams 0.0.10 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0

--- a/CSV/versions/0.0.13/requires
+++ b/CSV/versions/0.0.13/requires
@@ -1,4 +1,4 @@
 julia 0.4.1
 DataStreams 0.0.12 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0

--- a/CSV/versions/0.0.14/requires
+++ b/CSV/versions/0.0.14/requires
@@ -1,4 +1,4 @@
 julia 0.4.1
 DataStreams 0.0.13 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0

--- a/CSV/versions/0.0.6/requires
+++ b/CSV/versions/0.0.6/requires
@@ -1,5 +1,5 @@
 julia 0.4.1
 DataStreams 0.0.5 0.0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0

--- a/CSV/versions/0.0.7/requires
+++ b/CSV/versions/0.0.7/requires
@@ -1,5 +1,5 @@
 julia 0.4.1
 DataStreams 0.0.5 0.0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0

--- a/CSV/versions/0.0.8/requires
+++ b/CSV/versions/0.0.8/requires
@@ -1,5 +1,5 @@
 julia 0.4.1
 DataStreams 0.0.5 0.0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0

--- a/CSV/versions/0.0.9/requires
+++ b/CSV/versions/0.0.9/requires
@@ -1,5 +1,5 @@
 julia 0.4.1
 DataStreams 0.0.5 0.0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0

--- a/CSV/versions/0.1.0/requires
+++ b/CSV/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0

--- a/CSV/versions/0.1.1/requires
+++ b/CSV/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0

--- a/CSV/versions/0.1.2/requires
+++ b/CSV/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0

--- a/CSV/versions/0.1.4/requires
+++ b/CSV/versions/0.1.4/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Compat 0.9.5
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0

--- a/CSV/versions/0.1.5/requires
+++ b/CSV/versions/0.1.5/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Compat 0.9.5
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0

--- a/Celeste/versions/0.1.0/requires
+++ b/Celeste/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.4 0.6
 Compat
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 DocOpt
 ForwardDiff 0.0 0.2

--- a/Celeste/versions/0.2.0/requires
+++ b/Celeste/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5- 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 DocOpt
 Dtree

--- a/Celeste/versions/0.2.1/requires
+++ b/Celeste/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.5- 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 FITSIO 0.8.4
 ForwardDiff 0.2

--- a/Celeste/versions/0.3.0/requires
+++ b/Celeste/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.6-
 Compat 0.18.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures 0.5.2
 Distributions
 FITSIO 0.8.4

--- a/Celeste/versions/0.4.0/requires
+++ b/Celeste/versions/0.4.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 BinDeps
 Compat 0.18.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures 0.7.0
 Distributions
 FITSIO 0.11.0

--- a/Clarus/versions/0.0.4/requires
+++ b/Clarus/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.6
 Requests 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Clarus/versions/0.0.5/requires
+++ b/Clarus/versions/0.0.5/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Requests 0.5
-DataFrames 0.10
+DataFrames 0.10 0.11.0
 CSV 0.1

--- a/Clarus/versions/0.0.6/requires
+++ b/Clarus/versions/0.0.6/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Requests 0.5
-DataFrames 0.10
+DataFrames 0.10 0.11.0
 CSV 0.1

--- a/Clarus/versions/0.1.1/requires
+++ b/Clarus/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Requests 0.5
-DataFrames 0.10
+DataFrames 0.10 0.11.0
 CSV 0.1

--- a/Clarus/versions/0.1.2/requires
+++ b/Clarus/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Requests 0.5
-DataFrames 0.10
+DataFrames 0.10 0.11.0
 CSV 0.1

--- a/CovarianceMatrices/versions/0.0.1/requires
+++ b/CovarianceMatrices/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.3-
 StatsBase 0.6.10-
 GLM
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/CovarianceMatrices/versions/0.0.2/requires
+++ b/CovarianceMatrices/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.3
 StatsBase 0.6.10
 GLM
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/CovarianceMatrices/versions/0.0.3/requires
+++ b/CovarianceMatrices/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.3
 StatsBase 
 GLM
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/CovarianceMatrices/versions/0.0.4/requires
+++ b/CovarianceMatrices/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 julia 0.3
 StatsBase 
 GLM
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/CovarianceMatrices/versions/0.0.5/requires
+++ b/CovarianceMatrices/versions/0.0.5/requires
@@ -1,5 +1,5 @@
 julia 0.3
 StatsBase 
 GLM
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/CovarianceMatrices/versions/0.1.0/requires
+++ b/CovarianceMatrices/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 StatsBase 
 GLM
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/CovarianceMatrices/versions/0.1.1/requires
+++ b/CovarianceMatrices/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 StatsBase 
 GLM
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/CovarianceMatrices/versions/0.1.2/requires
+++ b/CovarianceMatrices/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.4 0.5
 StatsBase 
 GLM 0.5.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat 0.8.4

--- a/CovarianceMatrices/versions/0.2.0/requires
+++ b/CovarianceMatrices/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 StatsBase 
 GLM 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/CovarianceMatrices/versions/0.2.1/requires
+++ b/CovarianceMatrices/versions/0.2.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 StatsBase 
 GLM 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/CovarianceMatrices/versions/0.2.2/requires
+++ b/CovarianceMatrices/versions/0.2.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 StatsBase 
 GLM 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/CovarianceMatrices/versions/0.3.1/requires
+++ b/CovarianceMatrices/versions/0.3.1/requires
@@ -1,4 +1,4 @@
 julia 0.6.0-pre
 StatsBase 
 GLM 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/CrossfilterCharts/versions/0.0.1/requires
+++ b/CrossfilterCharts/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
-DataFrames 0.7.0
+DataFrames 0.7.0 0.11.0
 

--- a/CrossfilterCharts/versions/0.1.0/requires
+++ b/CrossfilterCharts/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.4
-DataFrames 0.7.0
+DataFrames 0.7.0 0.11.0
 

--- a/CrossfilterCharts/versions/0.1.1/requires
+++ b/CrossfilterCharts/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
-DataFrames 0.7.0
+DataFrames 0.7.0 0.11.0
 Compat 0.8.0
 

--- a/CrossfilterCharts/versions/2.0.0/requires
+++ b/CrossfilterCharts/versions/2.0.0/requires
@@ -1,3 +1,3 @@
 julia 0.6
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0
 

--- a/DBFTables/versions/0.0.1/requires
+++ b/DBFTables/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.6
 Nulls
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DSGE/versions/0.2.0/requires
+++ b/DSGE/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 Calculus
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 Distributions
 FredData

--- a/DSGE/versions/0.3.0/requires
+++ b/DSGE/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 Calculus
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 Distributions
 FredData

--- a/DSGE/versions/0.3.1/requires
+++ b/DSGE/versions/0.3.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 Calculus
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 Distributions
 FredData

--- a/DSGE/versions/0.4.0/requires
+++ b/DSGE/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 Calculus
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 Distributions
 FredData

--- a/DataCubes/versions/0.0.3/requires
+++ b/DataCubes/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.4
 
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DataCubes/versions/0.0.4/requires
+++ b/DataCubes/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.4
 
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DataCubes/versions/0.0.5/requires
+++ b/DataCubes/versions/0.0.5/requires
@@ -1,4 +1,4 @@
 julia 0.4
 
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting

--- a/DataCubes/versions/0.0.6/requires
+++ b/DataCubes/versions/0.0.6/requires
@@ -1,4 +1,4 @@
 julia 0.4
 
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting

--- a/DataCubes/versions/0.1.0/requires
+++ b/DataCubes/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting

--- a/DataCubes/versions/0.2.0/requires
+++ b/DataCubes/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting
 DataStructures

--- a/DataFrames/versions/0.11.0/requires
+++ b/DataFrames/versions/0.11.0/requires
@@ -1,0 +1,9 @@
+julia 0.6
+Missings 0.2.1
+CategoricalArrays 0.3.0
+StatsBase 0.11.0
+SortingAlgorithms
+Reexport
+WeakRefStrings 0.4.0
+DataStreams 0.3.0
+GZip

--- a/DataFrames/versions/0.11.0/sha1
+++ b/DataFrames/versions/0.11.0/sha1
@@ -1,0 +1,1 @@
+7cc19d5bf44b603f1f6f3eedea1491ef36ff923f

--- a/DataFramesMeta/versions/0.0.0/requires
+++ b/DataFramesMeta/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 julia 0.3-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DataFramesMeta/versions/0.0.1/requires
+++ b/DataFramesMeta/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.3-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DataFramesMeta/versions/0.1.0/requires
+++ b/DataFramesMeta/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.4-
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/DataFramesMeta/versions/0.1.1/requires
+++ b/DataFramesMeta/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/DataFramesMeta/versions/0.1.2/requires
+++ b/DataFramesMeta/versions/0.1.2/requires
@@ -1,3 +1,3 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/DataFramesMeta/versions/0.1.3/requires
+++ b/DataFramesMeta/versions/0.1.3/requires
@@ -1,3 +1,3 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/DataFramesMeta/versions/0.2.0/requires
+++ b/DataFramesMeta/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat 0.17

--- a/DataStreams/versions/0.0.10/requires
+++ b/DataStreams/versions/0.0.10/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.1.3 0.3.0
 CategoricalArrays 0.0.1 0.0.5

--- a/DataStreams/versions/0.0.11/requires
+++ b/DataStreams/versions/0.0.11/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.3 0.0.5
 WeakRefStrings 0.1.3 0.3.0

--- a/DataStreams/versions/0.0.12/requires
+++ b/DataStreams/versions/0.0.12/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.4 0.0.5
 WeakRefStrings 0.1.3 0.3.0

--- a/DataStreams/versions/0.0.13/requires
+++ b/DataStreams/versions/0.0.13/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.4 0.0.5
 WeakRefStrings 0.1.3 0.3.0

--- a/DataStreams/versions/0.0.14/requires
+++ b/DataStreams/versions/0.0.14/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.5 0.2.0
 WeakRefStrings 0.1.3 0.3.0

--- a/DataStreams/versions/0.0.15/requires
+++ b/DataStreams/versions/0.0.15/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.4 0.0.5
 WeakRefStrings 0.1.3 0.3.0

--- a/DataStreams/versions/0.0.5/requires
+++ b/DataStreams/versions/0.0.5/requires
@@ -1,5 +1,5 @@
 julia 0.4
 NullableArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 CategoricalArrays 0.0.1 0.0.5
 WeakRefStrings 0.0.0 0.3.0

--- a/DataStreams/versions/0.0.6/requires
+++ b/DataStreams/versions/0.0.6/requires
@@ -1,5 +1,5 @@
 julia 0.4
 NullableArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 CategoricalArrays 0.0.1 0.0.5
 WeakRefStrings 0.0.0 0.3.0

--- a/DataStreams/versions/0.0.7/requires
+++ b/DataStreams/versions/0.0.7/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.1.2 0.3.0
 CategoricalArrays 0.0.1 0.0.5

--- a/DataStreams/versions/0.0.8/requires
+++ b/DataStreams/versions/0.0.8/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.1.3 0.3.0
 CategoricalArrays 0.0.1 0.0.5

--- a/DataStreams/versions/0.0.9/requires
+++ b/DataStreams/versions/0.0.9/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.1.3 0.3.0
 CategoricalArrays 0.0.1 0.0.5

--- a/DataStreams/versions/0.1.0/requires
+++ b/DataStreams/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.9
 CategoricalArrays 0.0.5 0.2.0
 WeakRefStrings 0.1.3 0.3.0

--- a/DataStreams/versions/0.1.1/requires
+++ b/DataStreams/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.9
 CategoricalArrays 0.0.5 0.2.0
 WeakRefStrings 0.1.3 0.3.0

--- a/DataStreams/versions/0.1.2/requires
+++ b/DataStreams/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.9
 CategoricalArrays 0.0.5 0.2.0
 WeakRefStrings 0.1.3 0.3.0

--- a/DataStreams/versions/0.1.3/requires
+++ b/DataStreams/versions/0.1.3/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.9
 CategoricalArrays 0.0.5 0.2.0
 WeakRefStrings 0.1.3 0.3.0

--- a/DatasetsCF/versions/0.2.0/requires
+++ b/DatasetsCF/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 Persa
 MLBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 BinDeps

--- a/Deldir/versions/0.0.1/requires
+++ b/Deldir/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Deldir/versions/0.0.2/requires
+++ b/Deldir/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Deldir/versions/0.0.3/requires
+++ b/Deldir/versions/0.0.3/requires
@@ -1,2 +1,2 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Deldir/versions/1.0.0/requires
+++ b/Deldir/versions/1.0.0/requires
@@ -1,2 +1,2 @@
 julia 0.6
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0

--- a/DimensionalityReduction/versions/0.0.0/requires
+++ b/DimensionalityReduction/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 julia 0.0- 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DimensionalityReduction/versions/0.0.1/requires
+++ b/DimensionalityReduction/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.0- 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DimensionalityReduction/versions/0.1.0/requires
+++ b/DimensionalityReduction/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.0- 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DimensionalityReduction/versions/0.1.1/requires
+++ b/DimensionalityReduction/versions/0.1.1/requires
@@ -1,2 +1,2 @@
 julia 0.0- 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/DimensionalityReduction/versions/0.1.2/requires
+++ b/DimensionalityReduction/versions/0.1.2/requires
@@ -1,2 +1,2 @@
 julia 0.1 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Diversity/versions/0.3.0/requires
+++ b/Diversity/versions/0.3.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
 Compat 0.18.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0

--- a/Diversity/versions/0.3.1/requires
+++ b/Diversity/versions/0.3.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Compat 0.18.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0
 

--- a/EEG/versions/0.0.1/requires
+++ b/EEG/versions/0.0.1/requires
@@ -2,7 +2,7 @@ julia 0.3
 AWS
 DSP # Requires master for filter coeffients to be exported
 BDF
-DataFrames
+DataFrames 0.0.1 0.11.0
 SIUnits # Requires master
 ProgressMeter
 Distributions

--- a/EEG/versions/0.0.2/requires
+++ b/EEG/versions/0.0.2/requires
@@ -2,7 +2,7 @@ julia 0.4
 AWS
 DSP # Requires master for filter coeffients to be exported
 BDF
-DataFrames
+DataFrames 0.0.1 0.11.0
 SIUnits # Requires master
 ProgressMeter
 Distributions

--- a/EEG/versions/0.0.3/requires
+++ b/EEG/versions/0.0.3/requires
@@ -2,7 +2,7 @@ julia 0.4
 AWS
 DSP # Requires master for filter coeffients to be exported
 BDF
-DataFrames
+DataFrames 0.0.1 0.11.0
 SIUnits # Requires master
 ProgressMeter
 Distributions

--- a/EEG/versions/0.0.4/requires
+++ b/EEG/versions/0.0.4/requires
@@ -2,7 +2,7 @@ julia 0.4 0.5-
 AWS
 DSP 0.0.9
 BDF
-DataFrames
+DataFrames 0.0.1 0.11.0
 SIUnits 0.0.6
 ProgressMeter
 Distributions

--- a/EEG/versions/0.1.0/requires
+++ b/EEG/versions/0.1.0/requires
@@ -2,7 +2,7 @@ julia 0.4 0.5-
 AWS
 DSP 0.0.9
 BDF
-DataFrames
+DataFrames 0.0.1 0.11.0
 SIUnits 0.0.6
 ProgressMeter
 Distributions

--- a/EEG/versions/0.1.1/requires
+++ b/EEG/versions/0.1.1/requires
@@ -4,7 +4,7 @@ AWS
 Compat
 DSP
 BDF
-DataFrames
+DataFrames 0.0.1 0.11.0
 SIUnits
 ProgressMeter
 Distributions

--- a/EEG/versions/0.2.0/requires
+++ b/EEG/versions/0.2.0/requires
@@ -2,7 +2,7 @@ julia 0.5-
 AWS
 DSP
 BDF
-DataFrames
+DataFrames 0.0.1 0.11.0
 SIUnits
 ProgressMeter
 Distributions

--- a/EasyPhys/versions/0.1.4/requires
+++ b/EasyPhys/versions/0.1.4/requires
@@ -2,5 +2,5 @@ julia 0.5
 LsqFit
 PyCall
 PyPlot
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays

--- a/EasyPhys/versions/0.2.0/requires
+++ b/EasyPhys/versions/0.2.0/requires
@@ -2,6 +2,6 @@ julia 0.5
 LsqFit 0.2
 PyCall 1.7
 PyPlot 2.2
-DataFrames 0.8
+DataFrames 0.8 0.11.0
 DataArrays 0.3.8
 Compat 0.17

--- a/EconDatasets/versions/0.0.1/requires
+++ b/EconDatasets/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.4-
 DataArrays 0.2-
-DataFrames 0.5.8-
+DataFrames 0.5.8- 0.11.0
 Dates 0.4.1-
 Gumbo 0.1.0-
 TimeSeries 0.4.3-

--- a/EconDatasets/versions/0.0.2/requires
+++ b/EconDatasets/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.3.2-
 DataArrays 0.2-
-DataFrames 0.5.8-
+DataFrames 0.5.8- 0.11.0
 Dates 0.3.2-
 Gumbo 0.1.0-
 TimeSeries 0.4.3-

--- a/EconModels/versions/0.0.1/requires
+++ b/EconModels/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/EventHistory/versions/0.0.1/requires
+++ b/EventHistory/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.4
+DataFrames 0.4 0.11.0
 Distributions 0.2.0
 StatsBase 0.3
 Calculus 0.1.3

--- a/EventHistory/versions/0.0.2/requires
+++ b/EventHistory/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.4
+DataFrames 0.4 0.11.0
 Distributions 0.2.0
 StatsBase 0.3
 Calculus 0.1.3

--- a/EventHistory/versions/0.1.0/requires
+++ b/EventHistory/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames 0.4
+DataFrames 0.4 0.11.0
 Distributions 0.2.0
 StatsBase 0.3
 Calculus 0.1.3

--- a/ExcelFiles/versions/0.0.1/requires
+++ b/ExcelFiles/versions/0.0.1/requires
@@ -4,4 +4,4 @@ IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0

--- a/ExcelFiles/versions/0.1.0/requires
+++ b/ExcelFiles/versions/0.1.0/requires
@@ -4,4 +4,4 @@ IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0

--- a/ExcelFiles/versions/0.2.0/requires
+++ b/ExcelFiles/versions/0.2.0/requires
@@ -5,4 +5,4 @@ IterableTables 0.5.0
 DataValues 0.1.0
 DataTables 0.0.3
 FileIO 0.4.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0

--- a/ExcelReaders/versions/0.1.0/requires
+++ b/ExcelReaders/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 PyCall
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates

--- a/ExcelReaders/versions/0.2.0/requires
+++ b/ExcelReaders/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 PyCall
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates

--- a/ExcelReaders/versions/0.3.0/requires
+++ b/ExcelReaders/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 PyCall

--- a/ExcelReaders/versions/0.3.1/requires
+++ b/ExcelReaders/versions/0.3.1/requires
@@ -1,7 +1,7 @@
 julia 0.3
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 PyCall 1.1
 Conda

--- a/ExcelReaders/versions/0.4.0/requires
+++ b/ExcelReaders/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 PyCall 1.1
 Conda

--- a/ExcelReaders/versions/0.4.1/requires
+++ b/ExcelReaders/versions/0.4.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 PyCall 1.5

--- a/ExcelReaders/versions/0.5.0/requires
+++ b/ExcelReaders/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 PyCall 1.5

--- a/ExcelReaders/versions/0.6.0/requires
+++ b/ExcelReaders/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 PyCall 1.5
 Compat 0.8.6

--- a/ExcelReaders/versions/0.7.0/requires
+++ b/ExcelReaders/versions/0.7.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 PyCall 1.5
 Compat 0.9.5

--- a/ExcelReaders/versions/0.8.0/requires
+++ b/ExcelReaders/versions/0.8.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 PyCall 1.5

--- a/ExcelReaders/versions/0.8.1/requires
+++ b/ExcelReaders/versions/0.8.1/requires
@@ -1,4 +1,4 @@
 julia 0.6
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 PyCall 1.5

--- a/ExcelReaders/versions/0.8.2/requires
+++ b/ExcelReaders/versions/0.8.2/requires
@@ -1,4 +1,4 @@
 julia 0.6
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 PyCall 1.5

--- a/ExperimentalAnalysis/versions/0.0.1/requires
+++ b/ExperimentalAnalysis/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Plots 0.0 0.7
 PyPlot
 GLM

--- a/ExperimentalAnalysis/versions/0.0.2/requires
+++ b/ExperimentalAnalysis/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Plots 0.0 0.7
 PyPlot
 GLM

--- a/ExperimentalAnalysis/versions/0.1.0/requires
+++ b/ExperimentalAnalysis/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 Plots
 GLM
 Coverage

--- a/ExperimentalAnalysis/versions/0.1.1/requires
+++ b/ExperimentalAnalysis/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 Plots
 GLM
 Coverage

--- a/FProfile/versions/0.0.1/requires
+++ b/FProfile/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures

--- a/FProfile/versions/0.0.2/requires
+++ b/FProfile/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures

--- a/FProfile/versions/0.0.3/requires
+++ b/FProfile/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures

--- a/FProfile/versions/0.0.4/requires
+++ b/FProfile/versions/0.0.4/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 Requires

--- a/FaSTLMM/versions/0.0.1/requires
+++ b/FaSTLMM/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Optim
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/FaSTLMM/versions/0.0.2/requires
+++ b/FaSTLMM/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Optim
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/FaSTLMM/versions/0.0.3/requires
+++ b/FaSTLMM/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Optim
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/FaSTLMM/versions/0.1.0/requires
+++ b/FaSTLMM/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Optim
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Feather/versions/0.1.1/requires
+++ b/Feather/versions/0.1.1/requires
@@ -1,7 +1,7 @@
 julia 0.4
 FlatBuffers 0.1.0 0.2.0
 DataStreams 0.0.1 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0
 CategoricalArrays 0.0.1 0.0.5

--- a/Feather/versions/0.1.2/requires
+++ b/Feather/versions/0.1.2/requires
@@ -1,7 +1,7 @@
 julia 0.4
 FlatBuffers 0.1.0 0.2.0
 DataStreams 0.0.1 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0
 CategoricalArrays 0.0.1 0.0.5

--- a/Feather/versions/0.1.3/requires
+++ b/Feather/versions/0.1.3/requires
@@ -1,7 +1,7 @@
 julia 0.4
 FlatBuffers 0.1.1 0.2.0
 DataStreams 0.0.10 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.1.3 0.3.0
 CategoricalArrays 0.0.1 0.0.5

--- a/Feather/versions/0.1.4/requires
+++ b/Feather/versions/0.1.4/requires
@@ -2,6 +2,6 @@ julia 0.4
 FlatBuffers 0.1.1 0.2.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.4 0.0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStreams 0.0.12 0.0.13
 WeakRefStrings 0.1.3 0.3.0

--- a/Feather/versions/0.1.5/requires
+++ b/Feather/versions/0.1.5/requires
@@ -2,6 +2,6 @@ julia 0.4
 FlatBuffers 0.1.1 0.2.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.4 0.0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStreams 0.0.13 0.2.0
 WeakRefStrings 0.1.3 0.3.0

--- a/Feather/versions/0.2.0/requires
+++ b/Feather/versions/0.2.0/requires
@@ -2,6 +2,6 @@ julia 0.5
 FlatBuffers 0.1.1 0.2.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.6 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0

--- a/Feather/versions/0.2.1/requires
+++ b/Feather/versions/0.2.1/requires
@@ -2,7 +2,7 @@ julia 0.5
 FlatBuffers 0.1.1 0.2.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.6 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0
 DataArrays

--- a/Feather/versions/0.2.2/requires
+++ b/Feather/versions/0.2.2/requires
@@ -2,7 +2,7 @@ julia 0.5
 FlatBuffers 0.1.1 0.2.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.6 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0
 DataArrays

--- a/Feather/versions/0.2.3/requires
+++ b/Feather/versions/0.2.3/requires
@@ -2,7 +2,7 @@ julia 0.5
 FlatBuffers 0.1.1 0.2.0
 NullableArrays 0.0.8
 CategoricalArrays 0.0.6 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0
 DataArrays

--- a/Feather/versions/0.2.5/requires
+++ b/Feather/versions/0.2.5/requires
@@ -2,7 +2,7 @@ julia 0.5
 FlatBuffers 0.2.0 0.2.1
 NullableArrays 0.0.8
 CategoricalArrays 0.0.6 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0
 DataArrays

--- a/FinancialMarkets/versions/0.1.0/requires
+++ b/FinancialMarkets/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.0- 0.6
 Dates 0.3.1
-DataFrames 0.5.7
+DataFrames 0.5.7 0.11.0

--- a/FinancialMarkets/versions/0.1.1/requires
+++ b/FinancialMarkets/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.0- 0.6
 Dates 0.3.1
-DataFrames 0.5.7
+DataFrames 0.5.7 0.11.0

--- a/FixedEffectModels/versions/0.3.1/requires
+++ b/FixedEffectModels/versions/0.3.1/requires
@@ -2,4 +2,4 @@ julia 0.5
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays 0.3.4
-DataFrames 0.9
+DataFrames 0.9 0.11.0

--- a/FixedEffectModels/versions/0.4.0/requires
+++ b/FixedEffectModels/versions/0.4.0/requires
@@ -2,4 +2,4 @@ julia 0.6.0-pre
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays 0.3.4
-DataFrames 0.9
+DataFrames 0.9 0.11.0

--- a/FredData/versions/0.1.0/requires
+++ b/FredData/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 JSON
 Requests

--- a/FredData/versions/0.1.1/requires
+++ b/FredData/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 JSON
 Requests

--- a/FredData/versions/0.1.2/requires
+++ b/FredData/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 JSON
 Requests

--- a/FredData/versions/0.1.3/requires
+++ b/FredData/versions/0.1.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 JSON
 Requests
 Compat 0.7.9

--- a/FredData/versions/0.1.4/requires
+++ b/FredData/versions/0.1.4/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 JSON
 Requests
 Compat 0.7.9

--- a/FreqTables/versions/0.0.1/requires
+++ b/FreqTables/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 NamedArrays
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/FreqTables/versions/0.0.2/requires
+++ b/FreqTables/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.4.2
 NamedArrays
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/FreqTables/versions/0.1.0/requires
+++ b/FreqTables/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 NamedArrays
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/GLM/versions/0.0.0/requires
+++ b/GLM/versions/0.0.0/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 StatsBase 0.0.0 0.8.3

--- a/GLM/versions/0.2.0/requires
+++ b/GLM/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.2-
-DataFrames 0.3.6-
+DataFrames 0.3.6- 0.11.0
 Distributions 0.2.0-
 NumericExtensions 0.2.12-
 StatsBase 0.0.0 0.8.3

--- a/GLM/versions/0.2.1/requires
+++ b/GLM/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.2-
-DataFrames 0.3.6-
+DataFrames 0.3.6- 0.11.0
 Distributions 0.2.0-
 NumericExtensions 0.2.17-
 StatsBase 0.0.0 0.8.3

--- a/GLM/versions/0.2.2/requires
+++ b/GLM/versions/0.2.2/requires
@@ -1,5 +1,5 @@
 julia 0.2-
-DataFrames 0.3.6-
+DataFrames 0.3.6- 0.11.0
 Distributions 0.2.0-
 NumericExtensions 0.2.17-
 StatsBase 0.0.0 0.8.3

--- a/GLM/versions/0.3.0/requires
+++ b/GLM/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions 0.4-
 NumericExtensions 0.5-
 StatsBase 0.3.7- 0.8.3

--- a/GLM/versions/0.3.1/requires
+++ b/GLM/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions 0.4-
 NumericExtensions 0.6-
 NumericFuns 0.2.1-

--- a/GLM/versions/0.3.2/requires
+++ b/GLM/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions 0.4-
 NumericExtensions 0.6-
 NumericFuns 0.2.1-

--- a/GLMNet/versions/0.0.1/requires
+++ b/GLMNet/versions/0.0.1/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/GLMNet/versions/0.0.2/requires
+++ b/GLMNet/versions/0.0.2/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/GLMNet/versions/0.0.3/requires
+++ b/GLMNet/versions/0.0.3/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions

--- a/GLMNet/versions/0.0.4/requires
+++ b/GLMNet/versions/0.0.4/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Compat

--- a/GLMNet/versions/0.0.5/requires
+++ b/GLMNet/versions/0.0.5/requires
@@ -1,4 +1,4 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Compat

--- a/Gadfly/versions/0.0.0/requires
+++ b/Gadfly/versions/0.0.0/requires
@@ -2,7 +2,7 @@ julia 0.0- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.0/requires
+++ b/Gadfly/versions/0.1.0/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.1/requires
+++ b/Gadfly/versions/0.1.1/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.10/requires
+++ b/Gadfly/versions/0.1.10/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.11/requires
+++ b/Gadfly/versions/0.1.11/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.12/requires
+++ b/Gadfly/versions/0.1.12/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.13/requires
+++ b/Gadfly/versions/0.1.13/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.14/requires
+++ b/Gadfly/versions/0.1.14/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.15/requires
+++ b/Gadfly/versions/0.1.15/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.16/requires
+++ b/Gadfly/versions/0.1.16/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.17/requires
+++ b/Gadfly/versions/0.1.17/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.18/requires
+++ b/Gadfly/versions/0.1.18/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 JSON
 Loess

--- a/Gadfly/versions/0.1.19/requires
+++ b/Gadfly/versions/0.1.19/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.2/requires
+++ b/Gadfly/versions/0.1.2/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.20/requires
+++ b/Gadfly/versions/0.1.20/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.21/requires
+++ b/Gadfly/versions/0.1.21/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.22/requires
+++ b/Gadfly/versions/0.1.22/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.23/requires
+++ b/Gadfly/versions/0.1.23/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.24/requires
+++ b/Gadfly/versions/0.1.24/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.25/requires
+++ b/Gadfly/versions/0.1.25/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.26/requires
+++ b/Gadfly/versions/0.1.26/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.27/requires
+++ b/Gadfly/versions/0.1.27/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.28/requires
+++ b/Gadfly/versions/0.1.28/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.29/requires
+++ b/Gadfly/versions/0.1.29/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Iterators

--- a/Gadfly/versions/0.1.3/requires
+++ b/Gadfly/versions/0.1.3/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.30/requires
+++ b/Gadfly/versions/0.1.30/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.1.31/requires
+++ b/Gadfly/versions/0.1.31/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.1.4/requires
+++ b/Gadfly/versions/0.1.4/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.5/requires
+++ b/Gadfly/versions/0.1.5/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.6/requires
+++ b/Gadfly/versions/0.1.6/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.7/requires
+++ b/Gadfly/versions/0.1.7/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.8/requires
+++ b/Gadfly/versions/0.1.8/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.1.9/requires
+++ b/Gadfly/versions/0.1.9/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 ArgParse
 Codecs
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 Iterators
 JSON

--- a/Gadfly/versions/0.2.0/requires
+++ b/Gadfly/versions/0.2.0/requires
@@ -2,7 +2,7 @@ julia 0.3- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.2.1/requires
+++ b/Gadfly/versions/0.2.1/requires
@@ -2,7 +2,7 @@ julia 0.3- 0.5
 Codecs
 Color
 Compose
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.2.2/requires
+++ b/Gadfly/versions/0.2.2/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.2.3/requires
+++ b/Gadfly/versions/0.2.3/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.2.4/requires
+++ b/Gadfly/versions/0.2.4/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.2.5/requires
+++ b/Gadfly/versions/0.2.5/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.2.6/requires
+++ b/Gadfly/versions/0.2.6/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.2.7/requires
+++ b/Gadfly/versions/0.2.7/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 Datetime
 Distributions
 Hexagons

--- a/Gadfly/versions/0.2.8/requires
+++ b/Gadfly/versions/0.2.8/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.2.9/requires
+++ b/Gadfly/versions/0.2.9/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.0/requires
+++ b/Gadfly/versions/0.3.0/requires
@@ -2,7 +2,7 @@ julia 0.2- 0.5
 Codecs
 Color
 Compose 0.3.0
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.1/requires
+++ b/Gadfly/versions/0.3.1/requires
@@ -3,7 +3,7 @@ Codecs
 Color
 Contour 0.0.0 0.2-
 Compose 0.3.0
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.10/requires
+++ b/Gadfly/versions/0.3.10/requires
@@ -4,7 +4,7 @@ Color 0.3.4
 Compat
 Compose 0.3.10
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.11/requires
+++ b/Gadfly/versions/0.3.11/requires
@@ -4,7 +4,7 @@ Color 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.12/requires
+++ b/Gadfly/versions/0.3.12/requires
@@ -4,7 +4,7 @@ Color 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.13/requires
+++ b/Gadfly/versions/0.3.13/requires
@@ -4,7 +4,7 @@ Color 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.14/requires
+++ b/Gadfly/versions/0.3.14/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.15/requires
+++ b/Gadfly/versions/0.3.15/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.16/requires
+++ b/Gadfly/versions/0.3.16/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.17/requires
+++ b/Gadfly/versions/0.3.17/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.18/requires
+++ b/Gadfly/versions/0.3.18/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.3.2/requires
+++ b/Gadfly/versions/0.3.2/requires
@@ -3,7 +3,7 @@ Codecs
 Color
 Contour 0.0.0 0.2-
 Compose 0.3.0
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.3/requires
+++ b/Gadfly/versions/0.3.3/requires
@@ -3,7 +3,7 @@ Codecs
 Color
 Contour 0.0.0 0.2-
 Compose 0.3.0
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.4/requires
+++ b/Gadfly/versions/0.3.4/requires
@@ -3,7 +3,7 @@ Codecs
 Color
 Compose 0.3.0
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.5/requires
+++ b/Gadfly/versions/0.3.5/requires
@@ -3,7 +3,7 @@ Codecs
 Color
 Compose 0.3.0
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.6/requires
+++ b/Gadfly/versions/0.3.6/requires
@@ -3,7 +3,7 @@ Codecs
 Color
 Compose 0.3.6
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.7/requires
+++ b/Gadfly/versions/0.3.7/requires
@@ -3,7 +3,7 @@ Codecs
 Color 0.3.4
 Compose 0.3.7
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.8/requires
+++ b/Gadfly/versions/0.3.8/requires
@@ -3,7 +3,7 @@ Codecs
 Color 0.3.4
 Compose 0.3.8
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Datetime
 Distributions

--- a/Gadfly/versions/0.3.9/requires
+++ b/Gadfly/versions/0.3.9/requires
@@ -3,7 +3,7 @@ Codecs
 Color 0.3.4
 Compose 0.3.9
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.4.0/requires
+++ b/Gadfly/versions/0.4.0/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.4.1/requires
+++ b/Gadfly/versions/0.4.1/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.4.2/requires
+++ b/Gadfly/versions/0.4.2/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat
 Compose 0.3.11
 Contour 0.0.0 0.2-
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Dates
 Distributions

--- a/Gadfly/versions/0.4.3/requires
+++ b/Gadfly/versions/0.4.3/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat 0.8.5
 Compose 0.4.4
 Contour 0.1.1
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.4.4/requires
+++ b/Gadfly/versions/0.4.4/requires
@@ -4,7 +4,7 @@ Colors 0.3.4
 Compat 0.8.5
 Compose 0.4.4
 Contour 0.1.1
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.5.0/requires
+++ b/Gadfly/versions/0.5.0/requires
@@ -3,7 +3,7 @@ Colors 0.3.4
 Compat 0.8.5
 Compose 0.4.4
 Contour 0.1.1
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.5.1/requires
+++ b/Gadfly/versions/0.5.1/requires
@@ -3,7 +3,7 @@ Colors 0.3.4
 Compat 0.8.5
 Compose 0.4.4
 Contour 0.1.1
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.5.2/requires
+++ b/Gadfly/versions/0.5.2/requires
@@ -3,7 +3,7 @@ Colors 0.3.4
 Compat 0.8.5
 Compose 0.4.4
 Contour 0.1.1
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.5.3/requires
+++ b/Gadfly/versions/0.5.3/requires
@@ -3,7 +3,7 @@ Colors 0.3.4
 Compat 0.8.5
 Compose 0.4.4
 Contour 0.1.1
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.6.0/requires
+++ b/Gadfly/versions/0.6.0/requires
@@ -3,7 +3,7 @@ Colors 0.3.4
 Compat 0.8.5
 Compose 0.4.4
 Contour 0.1.1
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.6.1/requires
+++ b/Gadfly/versions/0.6.1/requires
@@ -3,7 +3,7 @@ Colors 0.3.4
 Compat 0.18.0
 Compose 0.5
 Contour 0.1.1
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.6.2/requires
+++ b/Gadfly/versions/0.6.2/requires
@@ -4,7 +4,7 @@ Compat 0.18.0
 Compose 0.5.1
 Contour 0.1.1
 CoupledFields
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataStructures
 Distributions
 Hexagons

--- a/Gadfly/versions/0.6.3/requires
+++ b/Gadfly/versions/0.6.3/requires
@@ -4,7 +4,7 @@ Compat 0.18.0
 Compose 0.5.2
 Contour 0.1.1
 CoupledFields
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataArrays
 DataStructures
 Distributions

--- a/Gadfly/versions/0.6.4/requires
+++ b/Gadfly/versions/0.6.4/requires
@@ -4,7 +4,7 @@ Compat 0.18.0
 Compose 0.5.2
 Contour 0.1.1
 CoupledFields
-DataFrames 0.4.2
+DataFrames 0.4.2 0.11.0
 DataArrays
 DataStructures
 Distributions

--- a/GenomicVectors/versions/0.0.1/requires
+++ b/GenomicVectors/versions/0.0.1/requires
@@ -3,4 +3,4 @@ IntervalTrees
 AxisArrays
 RLEVectors
 Bio
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/GenomicVectors/versions/0.0.2/requires
+++ b/GenomicVectors/versions/0.0.2/requires
@@ -3,4 +3,4 @@ IntervalTrees
 AxisArrays
 RLEVectors
 Bio
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/GenomicVectors/versions/0.0.3/requires
+++ b/GenomicVectors/versions/0.0.3/requires
@@ -3,4 +3,4 @@ IntervalTrees
 AxisArrays
 RLEVectors
 Bio
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/GeoIP/versions/0.0.0/requires
+++ b/GeoIP/versions/0.0.0/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/GeoIP/versions/0.1.0/requires
+++ b/GeoIP/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays

--- a/GeoIP/versions/0.2.0/requires
+++ b/GeoIP/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 IPNets
-DataFrames
+DataFrames 0.0.1 0.11.0
 ZipFile
 Requests

--- a/GeoIP/versions/0.2.1/requires
+++ b/GeoIP/versions/0.2.1/requires
@@ -1,4 +1,4 @@
 IPNets
-DataFrames
+DataFrames 0.0.1 0.11.0
 ZipFile 0.2.4
 Requests

--- a/GeoIP/versions/0.2.2/requires
+++ b/GeoIP/versions/0.2.2/requires
@@ -1,5 +1,5 @@
 julia 0.3
 IPNets
-DataFrames
+DataFrames 0.0.1 0.11.0
 ZipFile 0.2.4
 Requests 0.2.4

--- a/GeoStats/versions/0.4.0/requires
+++ b/GeoStats/versions/0.4.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 Reexport
 GeoStatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Combinatorics
 SpecialFunctions
 Parameters

--- a/GeoStats/versions/0.4.1/requires
+++ b/GeoStats/versions/0.4.1/requires
@@ -1,7 +1,7 @@
 julia 0.6
 Reexport
 GeoStatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Combinatorics
 SpecialFunctions
 Parameters

--- a/GeoStatsDevTools/versions/0.0.1/requires
+++ b/GeoStatsDevTools/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.6
 GeoStatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/GeoStatsDevTools/versions/0.0.2/requires
+++ b/GeoStatsDevTools/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.6
 GeoStatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Parameters

--- a/GeoStatsDevTools/versions/0.0.3/requires
+++ b/GeoStatsDevTools/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.6
 GeoStatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Parameters 0.7.3

--- a/GeoStatsDevTools/versions/0.0.4/requires
+++ b/GeoStatsDevTools/versions/0.0.4/requires
@@ -1,4 +1,4 @@
 julia 0.6
 GeoStatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Parameters 0.7.3

--- a/Gillespie/versions/0.0.1/requires
+++ b/Gillespie/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.4
 Distributions
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Gillespie/versions/0.0.2/requires
+++ b/Gillespie/versions/0.0.2/requires
@@ -2,4 +2,4 @@ julia 0.4
 Compat 0.8.6
 Distributions
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/GoogleCharts/versions/0.0.0/requires
+++ b/GoogleCharts/versions/0.0.0/requires
@@ -1,4 +1,4 @@
 Mustache
-DataFrames
+DataFrames 0.0.1 0.11.0
 Calendar 
 JSON

--- a/GoogleCharts/versions/0.0.1/requires
+++ b/GoogleCharts/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.2-
 Mustache
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 JSON

--- a/GoogleCharts/versions/0.0.2/requires
+++ b/GoogleCharts/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.2-
 Mustache
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 JSON

--- a/GoogleCharts/versions/0.0.3/requires
+++ b/GoogleCharts/versions/0.0.3/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Mustache
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 JSON

--- a/GoogleCharts/versions/0.0.4/requires
+++ b/GoogleCharts/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 julia 0.4-
 Mustache
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 JSON

--- a/GoogleCharts/versions/0.0.5/requires
+++ b/GoogleCharts/versions/0.0.5/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Mustache
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 JSON

--- a/GoogleCharts/versions/0.0.6/requires
+++ b/GoogleCharts/versions/0.0.6/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Mustache
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 JSON

--- a/GoogleCharts/versions/0.0.7/requires
+++ b/GoogleCharts/versions/0.0.7/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Mustache
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Dates
 JSON

--- a/Graft/versions/0.0.1/requires
+++ b/Graft/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.5.0-rc0
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Graft/versions/0.0.2/requires
+++ b/Graft/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5.0-rc0
-DataFrames
+DataFrames 0.0.1 0.11.0
 ProgressMeter

--- a/GraphGLRM/versions/0.2.1/requires
+++ b/GraphGLRM/versions/0.2.1/requires
@@ -2,5 +2,5 @@ julia 0.5
 LowRankModels
 LightGraphs
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase

--- a/Graphs/versions/0.0.0/requires
+++ b/Graphs/versions/0.0.0/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Hive/versions/0.0.1/requires
+++ b/Hive/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Thrift
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Hive/versions/0.0.3/requires
+++ b/Hive/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Compat 0.8.0
 Thrift
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/InteractiveFixedEffectModels/versions/0.1.0/requires
+++ b/InteractiveFixedEffectModels/versions/0.1.0/requires
@@ -2,7 +2,7 @@ julia 0.5-
 Distances  0.1.1
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 LeastSquaresOptim 0.2.0
 Reexport
 FixedEffectModels 0.3.0

--- a/InteractiveFixedEffectModels/versions/0.1.1/requires
+++ b/InteractiveFixedEffectModels/versions/0.1.1/requires
@@ -2,7 +2,7 @@ julia 0.5
 Distances  0.1.1
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 LeastSquaresOptim 0.2.0
 Reexport
 FixedEffectModels 0.3.1

--- a/InteractiveFixedEffectModels/versions/0.2.0/requires
+++ b/InteractiveFixedEffectModels/versions/0.2.0/requires
@@ -2,7 +2,7 @@ julia 0.6.0-pre
 Distances  0.1.1
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 LeastSquaresOptim 0.3.0
 Reexport
 FixedEffectModels 0.4.0

--- a/InteractiveFixedEffectModels/versions/0.2.1/requires
+++ b/InteractiveFixedEffectModels/versions/0.2.1/requires
@@ -2,7 +2,7 @@ julia 0.6.0-pre
 Distances  0.1.1
 StatsBase 0.7.1
 DataArrays
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 LeastSquaresOptim 0.4.0
 Reexport
 FixedEffectModels 0.4.0

--- a/JWAS/versions/0.1.0/requires
+++ b/JWAS/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.4
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/JWAS/versions/0.1.1/requires
+++ b/JWAS/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 ProgressMeter
 Plots

--- a/JWAS/versions/0.2.0/requires
+++ b/JWAS/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 ProgressMeter

--- a/JuliaFEM/versions/0.2.1/requires
+++ b/JuliaFEM/versions/0.2.1/requires
@@ -2,6 +2,6 @@ julia 0.5
 ForwardDiff
 LightXML 0.4
 HDF5 0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting
 Logging

--- a/JuliaFEM/versions/0.3.0/requires
+++ b/JuliaFEM/versions/0.3.0/requires
@@ -2,7 +2,7 @@ julia 0.6
 ForwardDiff
 LightXML 0.4
 HDF5 0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting
 Logging
 TimerOutputs

--- a/JuliaFEM/versions/0.3.1/requires
+++ b/JuliaFEM/versions/0.3.1/requires
@@ -2,7 +2,7 @@ julia 0.6
 ForwardDiff
 LightXML 0.4
 HDF5 0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting
 Logging
 TimerOutputs

--- a/JuliaFEM/versions/0.3.2/requires
+++ b/JuliaFEM/versions/0.3.2/requires
@@ -2,7 +2,7 @@ julia 0.6
 ForwardDiff
 LightXML 0.4
 HDF5 0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting
 Logging
 TimerOutputs

--- a/JuliaFEM/versions/0.3.3/requires
+++ b/JuliaFEM/versions/0.3.3/requires
@@ -2,7 +2,7 @@ julia 0.6
 ForwardDiff
 LightXML 0.4
 HDF5 0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting
 Logging
 TimerOutputs

--- a/JuliaFEM/versions/0.3.4/requires
+++ b/JuliaFEM/versions/0.3.4/requires
@@ -3,7 +3,7 @@ FEMBase
 ForwardDiff
 LightXML 0.4
 HDF5 0.7
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting
 Logging
 TimerOutputs

--- a/Latexify/versions/0.0.1/requires
+++ b/Latexify/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.6
 DifferentialEquations 3.0
 SymEngine 0.2.0
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0

--- a/LazyQuery/versions/0.0.1/requires
+++ b/LazyQuery/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 MacroTools
 LazyContext 0.0.1 0.1.0
 Query 0.0.0 0.7.0

--- a/LazyQuery/versions/0.1.0/requires
+++ b/LazyQuery/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LazyContext 0.1.1
-DataFrames
+DataFrames 0.0.1 0.11.0
 MacroTools 0.3.3
 Query 0.0.1 0.7.0
 NamedTuples

--- a/LazyQuery/versions/0.1.1/requires
+++ b/LazyQuery/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LazyContext 0.1.2
-DataFrames
+DataFrames 0.0.1 0.11.0
 MacroTools 0.3.2
 Query 0.0.1 0.7.0
 NamedTuples

--- a/LazyQuery/versions/0.1.2/requires
+++ b/LazyQuery/versions/0.1.2/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LazyContext 0.1.2
-DataFrames
+DataFrames 0.0.1 0.11.0
 MacroTools 0.3.2
 Query 0.0.0 0.8.0
 NamedTuples

--- a/LazyQuery/versions/0.1.3/requires
+++ b/LazyQuery/versions/0.1.3/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LazyContext 0.1.2
-DataFrames
+DataFrames 0.0.1 0.11.0
 MacroTools 0.3.2
 Query 0.0.0 0.8.0
 NamedTuples

--- a/LifeTable/versions/0.0.1/requires
+++ b/LifeTable/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 LsqFit
 GLM

--- a/LifeTable/versions/0.0.2/requires
+++ b/LifeTable/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 LsqFit
 GLM

--- a/LifeTable/versions/0.0.3/requires
+++ b/LifeTable/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 LsqFit
 GLM

--- a/LifeTable/versions/0.1.0/requires
+++ b/LifeTable/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 LsqFit
 GLM

--- a/LinguisticData/versions/0.0.1/requires
+++ b/LinguisticData/versions/0.0.1/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Reexport

--- a/LinguisticData/versions/0.0.2/requires
+++ b/LinguisticData/versions/0.0.2/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Reexport

--- a/LogParser/versions/0.1.0/requires
+++ b/LogParser/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.3-
-DataFrames
+DataFrames 0.0.1 0.11.0
 GZip

--- a/LogParser/versions/0.2.0/requires
+++ b/LogParser/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.4-
-DataFrames
+DataFrames 0.0.1 0.11.0
 GZip

--- a/LogParser/versions/0.2.1/requires
+++ b/LogParser/versions/0.2.1/requires
@@ -1,3 +1,3 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 GZip

--- a/LogParser/versions/0.3.0/requires
+++ b/LogParser/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.5.0-rc0
-DataFrames
+DataFrames 0.0.1 0.11.0
 GZip
 Compat

--- a/LogParser/versions/0.4.0/requires
+++ b/LogParser/versions/0.4.0/requires
@@ -1,3 +1,3 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 GZip

--- a/LowRankModels/versions/0.0.1/requires
+++ b/LowRankModels/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.3-
-DataFrames
+DataFrames 0.0.1 0.11.0
 ArrayViews
 Optim 0.0 0.5

--- a/LowRankModels/versions/0.0.2/requires
+++ b/LowRankModels/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataFrames
+DataFrames 0.0.1 0.11.0
 ArrayViews
 Optim 0.0 0.5
 Compat

--- a/LowRankModels/versions/0.1.0/requires
+++ b/LowRankModels/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ArrayViews
 Optim 0.0 0.5

--- a/LowRankModels/versions/0.1.1/requires
+++ b/LowRankModels/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ArrayViews
 Optim 0.0 0.5

--- a/LowRankModels/versions/0.1.2/requires
+++ b/LowRankModels/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ArrayViews
 Optim 0.0 0.5

--- a/LowRankModels/versions/0.2.0/requires
+++ b/LowRankModels/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames 0.8
+DataFrames 0.8 0.11.0
 StatsBase 0.10
 ArrayViews 0.6
 Optim 0.6

--- a/MLDataUtils/versions/0.1.0/requires
+++ b/MLDataUtils/versions/0.1.0/requires
@@ -3,4 +3,4 @@ StatsBase 0.13
 LearnBase 0.1.5 0.2.0
 MLLabelUtils 0.0.3
 MLDataPattern 0.0.1
-DataFrames 0.9
+DataFrames 0.9 0.11.0

--- a/MLDataUtils/versions/0.2.0/requires
+++ b/MLDataUtils/versions/0.2.0/requires
@@ -3,4 +3,4 @@ StatsBase 0.13
 LearnBase 0.1.5 0.2.0
 MLLabelUtils 0.0.3
 MLDataPattern 0.0.1
-DataFrames 0.9
+DataFrames 0.9 0.11.0

--- a/MachineLearning/versions/0.0.1/requires
+++ b/MachineLearning/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Devectorize
 Distributions
 Gadfly

--- a/MachineLearning/versions/0.0.2/requires
+++ b/MachineLearning/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Devectorize
 Distributions
 Gadfly

--- a/MachineLearning/versions/0.0.3/requires
+++ b/MachineLearning/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Devectorize
 Distributions
 Gadfly

--- a/Mads/versions/0.1.0/requires
+++ b/Mads/versions/0.1.0/requires
@@ -22,4 +22,4 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Mads/versions/0.1.1/requires
+++ b/Mads/versions/0.1.1/requires
@@ -21,5 +21,5 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lexicon

--- a/Mads/versions/0.1.10/requires
+++ b/Mads/versions/0.1.10/requires
@@ -21,6 +21,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.1.11/requires
+++ b/Mads/versions/0.1.11/requires
@@ -24,6 +24,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.1.12/requires
+++ b/Mads/versions/0.1.12/requires
@@ -21,6 +21,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.1.13/requires
+++ b/Mads/versions/0.1.13/requires
@@ -21,6 +21,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.1.14/requires
+++ b/Mads/versions/0.1.14/requires
@@ -16,7 +16,7 @@ LightXML
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 ForwardDiff
 ODE
 Lora

--- a/Mads/versions/0.1.15/requires
+++ b/Mads/versions/0.1.15/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 ODE
 Lora
 Optim

--- a/Mads/versions/0.1.16/requires
+++ b/Mads/versions/0.1.16/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 ODE
 Lora
 Optim

--- a/Mads/versions/0.1.17/requires
+++ b/Mads/versions/0.1.17/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 ODE
 Lora
 Optim

--- a/Mads/versions/0.1.18/requires
+++ b/Mads/versions/0.1.18/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Lora 0.5

--- a/Mads/versions/0.1.2/requires
+++ b/Mads/versions/0.1.2/requires
@@ -22,5 +22,5 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lexicon

--- a/Mads/versions/0.1.3/requires
+++ b/Mads/versions/0.1.3/requires
@@ -22,5 +22,5 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lexicon

--- a/Mads/versions/0.1.4/requires
+++ b/Mads/versions/0.1.4/requires
@@ -22,5 +22,5 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Lexicon

--- a/Mads/versions/0.1.5/requires
+++ b/Mads/versions/0.1.5/requires
@@ -21,6 +21,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.1.6/requires
+++ b/Mads/versions/0.1.6/requires
@@ -21,6 +21,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.1.7/requires
+++ b/Mads/versions/0.1.7/requires
@@ -21,6 +21,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.1.8/requires
+++ b/Mads/versions/0.1.8/requires
@@ -21,6 +21,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.1.9/requires
+++ b/Mads/versions/0.1.9/requires
@@ -21,6 +21,6 @@ YAML
 JSON
 JLD
 Gadfly
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Lexicon

--- a/Mads/versions/0.2.0/requires
+++ b/Mads/versions/0.2.0/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Lora 0.5

--- a/Mads/versions/0.2.1/requires
+++ b/Mads/versions/0.2.1/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Lora 0.5

--- a/Mads/versions/0.2.10/requires
+++ b/Mads/versions/0.2.10/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.11/requires
+++ b/Mads/versions/0.2.11/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.12/requires
+++ b/Mads/versions/0.2.12/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.13/requires
+++ b/Mads/versions/0.2.13/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.14/requires
+++ b/Mads/versions/0.2.14/requires
@@ -16,7 +16,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.15/requires
+++ b/Mads/versions/0.2.15/requires
@@ -16,7 +16,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.16/requires
+++ b/Mads/versions/0.2.16/requires
@@ -16,7 +16,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.17/requires
+++ b/Mads/versions/0.2.17/requires
@@ -16,7 +16,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.18/requires
+++ b/Mads/versions/0.2.18/requires
@@ -17,7 +17,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.19/requires
+++ b/Mads/versions/0.2.19/requires
@@ -17,7 +17,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.2/requires
+++ b/Mads/versions/0.2.2/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Lora 0.5

--- a/Mads/versions/0.2.3/requires
+++ b/Mads/versions/0.2.3/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Lora 0.5

--- a/Mads/versions/0.2.4/requires
+++ b/Mads/versions/0.2.4/requires
@@ -14,7 +14,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.5/requires
+++ b/Mads/versions/0.2.5/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.6/requires
+++ b/Mads/versions/0.2.6/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.7/requires
+++ b/Mads/versions/0.2.7/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.8/requires
+++ b/Mads/versions/0.2.8/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.2.9/requires
+++ b/Mads/versions/0.2.9/requires
@@ -15,7 +15,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.6

--- a/Mads/versions/0.3.0/requires
+++ b/Mads/versions/0.3.0/requires
@@ -17,7 +17,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.7

--- a/Mads/versions/0.3.1/requires
+++ b/Mads/versions/0.3.1/requires
@@ -17,7 +17,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.7

--- a/Mads/versions/0.3.10/requires
+++ b/Mads/versions/0.3.10/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.3.2/requires
+++ b/Mads/versions/0.3.2/requires
@@ -19,7 +19,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.7

--- a/Mads/versions/0.3.3/requires
+++ b/Mads/versions/0.3.3/requires
@@ -19,7 +19,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.7

--- a/Mads/versions/0.3.4/requires
+++ b/Mads/versions/0.3.4/requires
@@ -19,7 +19,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.7

--- a/Mads/versions/0.3.5/requires
+++ b/Mads/versions/0.3.5/requires
@@ -19,7 +19,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 Klara 0.7

--- a/Mads/versions/0.3.6/requires
+++ b/Mads/versions/0.3.6/requires
@@ -19,7 +19,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.3.7/requires
+++ b/Mads/versions/0.3.7/requires
@@ -19,7 +19,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.3.8/requires
+++ b/Mads/versions/0.3.8/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.3.9/requires
+++ b/Mads/versions/0.3.9/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.0/requires
+++ b/Mads/versions/0.4.0/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.1/requires
+++ b/Mads/versions/0.4.1/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.10/requires
+++ b/Mads/versions/0.4.10/requires
@@ -22,7 +22,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.11/requires
+++ b/Mads/versions/0.4.11/requires
@@ -22,7 +22,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.12/requires
+++ b/Mads/versions/0.4.12/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 ODE
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.13/requires
+++ b/Mads/versions/0.4.13/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 ODE
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.14/requires
+++ b/Mads/versions/0.4.14/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 ODE
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.15/requires
+++ b/Mads/versions/0.4.15/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 ODE
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.16/requires
+++ b/Mads/versions/0.4.16/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.17/requires
+++ b/Mads/versions/0.4.17/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.18/requires
+++ b/Mads/versions/0.4.18/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.19/requires
+++ b/Mads/versions/0.4.19/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.2/requires
+++ b/Mads/versions/0.4.2/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.20/requires
+++ b/Mads/versions/0.4.20/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.21/requires
+++ b/Mads/versions/0.4.21/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.22/requires
+++ b/Mads/versions/0.4.22/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.23/requires
+++ b/Mads/versions/0.4.23/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.24/requires
+++ b/Mads/versions/0.4.24/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.25/requires
+++ b/Mads/versions/0.4.25/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.26/requires
+++ b/Mads/versions/0.4.26/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.27/requires
+++ b/Mads/versions/0.4.27/requires
@@ -23,7 +23,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.28/requires
+++ b/Mads/versions/0.4.28/requires
@@ -24,7 +24,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.29/requires
+++ b/Mads/versions/0.4.29/requires
@@ -24,7 +24,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.3/requires
+++ b/Mads/versions/0.4.3/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.30/requires
+++ b/Mads/versions/0.4.30/requires
@@ -24,7 +24,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.31/requires
+++ b/Mads/versions/0.4.31/requires
@@ -24,7 +24,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 OrdinaryDiffEq
 NMF
 BlackBoxOptim

--- a/Mads/versions/0.4.4/requires
+++ b/Mads/versions/0.4.4/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.5/requires
+++ b/Mads/versions/0.4.5/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions 0.12.5
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.6/requires
+++ b/Mads/versions/0.4.6/requires
@@ -20,7 +20,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.7/requires
+++ b/Mads/versions/0.4.7/requires
@@ -21,7 +21,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.8/requires
+++ b/Mads/versions/0.4.8/requires
@@ -21,7 +21,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/Mads/versions/0.4.9/requires
+++ b/Mads/versions/0.4.9/requires
@@ -21,7 +21,7 @@ JLD
 ProgressMeter
 Distributions
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase
 ODE
 NMF

--- a/MarketTechnicals/versions/0.0.0/requires
+++ b/MarketTechnicals/versions/0.0.0/requires
@@ -1,5 +1,5 @@
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Calendar
 UTF16
 TimeSeries

--- a/MarketTechnicals/versions/0.1.0/requires
+++ b/MarketTechnicals/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime

--- a/MarketTechnicals/versions/0.1.1/requires
+++ b/MarketTechnicals/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/MarketTechnicals/versions/0.1.2/requires
+++ b/MarketTechnicals/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/MarketTechnicals/versions/0.1.3/requires
+++ b/MarketTechnicals/versions/0.1.3/requires
@@ -1,4 +1,4 @@
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/MarketTechnicals/versions/0.1.4/requires
+++ b/MarketTechnicals/versions/0.1.4/requires
@@ -1,4 +1,4 @@
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/MarketTechnicals/versions/0.1.5/requires
+++ b/MarketTechnicals/versions/0.1.5/requires
@@ -1,4 +1,4 @@
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/Microbiome/versions/0.1.0/requires
+++ b/Microbiome/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6-
 RecipesBase
 Distances
-DataFrames
+DataFrames 0.0.1 0.11.0
 Clustering
 Colors

--- a/Microeconometrics/versions/0.1.0/requires
+++ b/Microeconometrics/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-pre
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0
 StatsBase 0.16.0
 StatsFuns 0.5.0
 Optim 0.9.1

--- a/Microeconometrics/versions/0.1.1/requires
+++ b/Microeconometrics/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-pre
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0
 StatsBase 0.16.0
 StatsFuns 0.5.0
 Optim 0.9.1

--- a/Microeconometrics/versions/0.1.2/requires
+++ b/Microeconometrics/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-pre
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0
 StatsBase 0.16.0
 StatsFuns 0.5.0
 Optim 0.9.1

--- a/Mimi/versions/0.0.1/requires
+++ b/Mimi/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.3
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Compat

--- a/Mimi/versions/0.0.2/requires
+++ b/Mimi/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.3
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Compat

--- a/Mimi/versions/0.0.3/requires
+++ b/Mimi/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/Mimi/versions/0.1.0/requires
+++ b/Mimi/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Documenter

--- a/Mimi/versions/0.1.1/requires
+++ b/Mimi/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Documenter

--- a/Mimi/versions/0.2.0/requires
+++ b/Mimi/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Documenter
 Compat 0.8.6

--- a/Mimi/versions/0.2.1/requires
+++ b/Mimi/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.4
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Documenter
 Compat 0.8.6

--- a/Mimi/versions/0.2.2/requires
+++ b/Mimi/versions/0.2.2/requires
@@ -1,6 +1,6 @@
 julia 0.4
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Documenter
 Compat 0.8.6

--- a/Mimi/versions/0.2.3/requires
+++ b/Mimi/versions/0.2.3/requires
@@ -1,6 +1,6 @@
 julia 0.4
 DataStructures
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 Documenter
 Compat 0.8.6

--- a/Mimi/versions/0.3.0/requires
+++ b/Mimi/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DataStructures 0.4.6
 Distributions 0.11.0
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Documenter 0.9.0
 NamedArrays 0.5.3
 Plots 0.9.4

--- a/MixedModels/versions/0.10.0/requires
+++ b/MixedModels/versions/0.10.0/requires
@@ -5,7 +5,7 @@ CategoricalArrays 0.0.1 0.2.0
 Compat 0.19.0
 DataArrays
 DataStructures
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.11.0/requires
+++ b/MixedModels/versions/0.11.0/requires
@@ -2,7 +2,7 @@ julia 0.6
 ArgCheck
 BlockArrays
 DataArrays
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 Distributions 0.11
 GLM 0.7
 NamedArrays

--- a/MixedModels/versions/0.12.0/requires
+++ b/MixedModels/versions/0.12.0/requires
@@ -2,7 +2,7 @@ julia 0.6
 ArgCheck
 BlockArrays
 DataArrays
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 Distributions 0.11
 GLM 0.7
 NamedArrays

--- a/MixedModels/versions/0.3.1/requires
+++ b/MixedModels/versions/0.3.1/requires
@@ -1,6 +1,6 @@
 julia 0.3- 0.6
 NLopt 0.0.3-
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0

--- a/MixedModels/versions/0.3.10/requires
+++ b/MixedModels/versions/0.3.10/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.12/requires
+++ b/MixedModels/versions/0.3.12/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.13/requires
+++ b/MixedModels/versions/0.3.13/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.14/requires
+++ b/MixedModels/versions/0.3.14/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.15/requires
+++ b/MixedModels/versions/0.3.15/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.16/requires
+++ b/MixedModels/versions/0.3.16/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.17/requires
+++ b/MixedModels/versions/0.3.17/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.18/requires
+++ b/MixedModels/versions/0.3.18/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.19/requires
+++ b/MixedModels/versions/0.3.19/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.2/requires
+++ b/MixedModels/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-

--- a/MixedModels/versions/0.3.20/requires
+++ b/MixedModels/versions/0.3.20/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.1-
 PDMats 0.2.3-

--- a/MixedModels/versions/0.3.21/requires
+++ b/MixedModels/versions/0.3.21/requires
@@ -1,6 +1,6 @@
 julia 0.3- 0.6
 Compat
-DataFrames 0.6-
+DataFrames 0.6- 0.11.0
 Distributions 0.6-
 Docile 0.4-
 NLopt 0.2-

--- a/MixedModels/versions/0.3.22/requires
+++ b/MixedModels/versions/0.3.22/requires
@@ -1,6 +1,6 @@
 julia 0.3- 0.6
 Compat
-DataFrames 0.6-
+DataFrames 0.6- 0.11.0
 Distributions 0.6-
 Docile 0.4-
 NLopt 0.2-

--- a/MixedModels/versions/0.3.3/requires
+++ b/MixedModels/versions/0.3.3/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.0.3-
 NumericExtensions 0.6-

--- a/MixedModels/versions/0.3.4/requires
+++ b/MixedModels/versions/0.3.4/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.0.3-
 NumericExtensions 0.6-

--- a/MixedModels/versions/0.3.5/requires
+++ b/MixedModels/versions/0.3.5/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.0.3-
 NumericExtensions 0.6-

--- a/MixedModels/versions/0.3.6/requires
+++ b/MixedModels/versions/0.3.6/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.0.3-
 NumericExtensions 0.6-

--- a/MixedModels/versions/0.3.7/requires
+++ b/MixedModels/versions/0.3.7/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.0.3-
 NumericExtensions 0.6-

--- a/MixedModels/versions/0.3.8/requires
+++ b/MixedModels/versions/0.3.8/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.0.3-
 NumericExtensions 0.6-

--- a/MixedModels/versions/0.3.9/requires
+++ b/MixedModels/versions/0.3.9/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions
 NLopt 0.0.3-
 NumericExtensions 0.6-

--- a/MixedModels/versions/0.4.0/requires
+++ b/MixedModels/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.4- 0.6
-DataFrames 0.6+
+DataFrames 0.6+ 0.11.0
 Distributions 0.6+
 NLopt 0.2+
 Showoff

--- a/MixedModels/versions/0.4.1/requires
+++ b/MixedModels/versions/0.4.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 Distributions 0.8
 NLopt 0.2
 Showoff

--- a/MixedModels/versions/0.4.2/requires
+++ b/MixedModels/versions/0.4.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 Distributions 0.8
 NLopt 0.2
 Showoff

--- a/MixedModels/versions/0.4.3/requires
+++ b/MixedModels/versions/0.4.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 Distributions 0.8
 NLopt 0.2
 Showoff

--- a/MixedModels/versions/0.4.4/requires
+++ b/MixedModels/versions/0.4.4/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 Distributions 0.8
 NLopt 0.2
 Showoff

--- a/MixedModels/versions/0.4.5/requires
+++ b/MixedModels/versions/0.4.5/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 Distributions 0.8
 NLopt 0.2
 Showoff

--- a/MixedModels/versions/0.5.0/requires
+++ b/MixedModels/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 Distributions 0.8
 GLM 0.5
 NLopt 0.2

--- a/MixedModels/versions/0.5.1/requires
+++ b/MixedModels/versions/0.5.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.6
+DataFrames 0.6 0.11.0
 Distributions 0.8
 GLM 0.5
 NLopt 0.2

--- a/MixedModels/versions/0.5.2/requires
+++ b/MixedModels/versions/0.5.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 Distributions 0.8
 GLM 0.5
 NLopt 0.3

--- a/MixedModels/versions/0.5.3/requires
+++ b/MixedModels/versions/0.5.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 Distributions 0.8
 GLM 0.5
 NLopt 0.3

--- a/MixedModels/versions/0.5.4/requires
+++ b/MixedModels/versions/0.5.4/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 Distributions 0.8
 GLM 0.5.2
 NLopt 0.3

--- a/MixedModels/versions/0.5.5/requires
+++ b/MixedModels/versions/0.5.5/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 Distributions 0.8
 GLM 0.5.2
 NLopt 0.3

--- a/MixedModels/versions/0.5.6/requires
+++ b/MixedModels/versions/0.5.6/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 Distributions 0.8
 GLM 0.5.2
 NLopt 0.3

--- a/MixedModels/versions/0.5.7/requires
+++ b/MixedModels/versions/0.5.7/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.8
+DataFrames 0.8 0.11.0
 Distributions 0.10
 GLM 0.5.2
 NLopt 0.3

--- a/MixedModels/versions/0.5.8/requires
+++ b/MixedModels/versions/0.5.8/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.8
+DataFrames 0.8 0.11.0
 Distributions 0.10
 GLM 0.5.2
 NLopt 0.3

--- a/MixedModels/versions/0.6.0/requires
+++ b/MixedModels/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6
 NamedArrays

--- a/MixedModels/versions/0.6.1/requires
+++ b/MixedModels/versions/0.6.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6
 NamedArrays

--- a/MixedModels/versions/0.6.2/requires
+++ b/MixedModels/versions/0.6.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.6.3/requires
+++ b/MixedModels/versions/0.6.3/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.7.0/requires
+++ b/MixedModels/versions/0.7.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.7.2/requires
+++ b/MixedModels/versions/0.7.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.7.3/requires
+++ b/MixedModels/versions/0.7.3/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.7.4/requires
+++ b/MixedModels/versions/0.7.4/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.7.5/requires
+++ b/MixedModels/versions/0.7.5/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.7.6/requires
+++ b/MixedModels/versions/0.7.6/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.7.7/requires
+++ b/MixedModels/versions/0.7.7/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataArrays
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.8.0/requires
+++ b/MixedModels/versions/0.8.0/requires
@@ -4,7 +4,7 @@ CategoricalArrays 0.0.1 0.2.0
 Compat 0.19.0
 DataArrays
 DataStructures
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MixedModels/versions/0.9.0/requires
+++ b/MixedModels/versions/0.9.0/requires
@@ -5,7 +5,7 @@ CategoricalArrays 0.0.1 0.2.0
 Compat 0.19.0
 DataArrays
 DataStructures
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 Distributions 0.11
 GLM 0.6.1
 NamedArrays

--- a/MultiDimEquations/versions/0.1.0/requires
+++ b/MultiDimEquations/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 DataFramesMeta
 MacroTools

--- a/MultiDimEquations/versions/0.1.1/requires
+++ b/MultiDimEquations/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataStructures
 DataFramesMeta
 MacroTools

--- a/MultidimensionalTables/versions/0.0.1/requires
+++ b/MultidimensionalTables/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.4.0 0.4.3
 
-DataFrames
+DataFrames 0.0.1 0.11.0
 RDatasets
 FactCheck

--- a/MultidimensionalTables/versions/0.0.2/requires
+++ b/MultidimensionalTables/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.4.0 0.4.3
 
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/MultidimensionalTables/versions/0.0.3/requires
+++ b/MultidimensionalTables/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.4.0 0.4.3
 
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Mustache/versions/0.0.0/requires
+++ b/Mustache/versions/0.0.0/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Mustache/versions/0.0.1/requires
+++ b/Mustache/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/MySQL/versions/0.0.1/requires
+++ b/MySQL/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat
 Dates

--- a/MySQL/versions/0.0.2/requires
+++ b/MySQL/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat
 Dates

--- a/MySQL/versions/0.1.0/requires
+++ b/MySQL/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat 0.8.0
 ConfParser

--- a/MySQL/versions/0.2.0/requires
+++ b/MySQL/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat 0.17.0
 ConfParser

--- a/NLOptControl/versions/0.1.2/requires
+++ b/NLOptControl/versions/0.1.2/requires
@@ -2,6 +2,6 @@ julia 0.6
 MathProgBase
 FastGaussQuadrature
 JuMP
-DataFrames
+DataFrames 0.0.1 0.11.0
 Ranges
 Ipopt

--- a/NLOptControl/versions/0.1.3/requires
+++ b/NLOptControl/versions/0.1.3/requires
@@ -2,6 +2,6 @@ julia 0.6
 MathProgBase
 FastGaussQuadrature
 JuMP
-DataFrames
+DataFrames 0.0.1 0.11.0
 Ranges
 Ipopt

--- a/NLreg/versions/0.0.0/requires
+++ b/NLreg/versions/0.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.2- 0.6
-DataFrames 0.3.6-
+DataFrames 0.3.6- 0.11.0
 NumericExtensions 0.2.15-
 Distributions 0.2.9-
 StatsBase 0.2.7-

--- a/NLreg/versions/0.1.0/requires
+++ b/NLreg/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.3.6-
+DataFrames 0.3.6- 0.11.0
 NumericExtensions 0.3.5-
 Distributions 0.2.13-
 StatsBase 0.2.9-

--- a/NLreg/versions/0.1.1/requires
+++ b/NLreg/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.3- 0.6
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 Distributions 0.5-
 NLopt
 NumericExtensions 0.3.5-

--- a/ODBC/versions/0.1.0/requires
+++ b/ODBC/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.1- 0.2-
-DataFrames v0.1.0
+DataFrames v0.1.0 0.11.0

--- a/ODBC/versions/0.2.0/requires
+++ b/ODBC/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-DataFrames v0.2.0
+DataFrames v0.2.0 0.11.0
 Datetime
 ProgressMeter
 julia 0.2- 0.3

--- a/ODBC/versions/0.2.1/requires
+++ b/ODBC/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-DataFrames v0.2.0
+DataFrames v0.2.0 0.11.0
 Datetime
 ProgressMeter
 julia 0.2- 0.3

--- a/ODBC/versions/0.3.0/requires
+++ b/ODBC/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-DataFrames v0.2.0
+DataFrames v0.2.0 0.11.0
 Datetime
 UTF16
 julia 0.2- 0.3

--- a/ODBC/versions/0.3.1/requires
+++ b/ODBC/versions/0.3.1/requires
@@ -1,4 +1,4 @@
-DataFrames 0.3-
+DataFrames 0.3- 0.11.0
 Datetime 0.1-
 UTF16
 julia 0.2- 0.3

--- a/ODBC/versions/0.3.10/requires
+++ b/ODBC/versions/0.3.10/requires
@@ -1,4 +1,4 @@
-DataFrames 0.5.2
+DataFrames 0.5.2 0.11.0
 Dates 0.3.1-
 julia 0.3- 0.4
 

--- a/ODBC/versions/0.3.11/requires
+++ b/ODBC/versions/0.3.11/requires
@@ -1,4 +1,4 @@
-DataFrames v0.6.10
+DataFrames v0.6.10 0.11.0
 Dates 
 julia 0.3 0.5-
 

--- a/ODBC/versions/0.3.2/requires
+++ b/ODBC/versions/0.3.2/requires
@@ -1,3 +1,3 @@
-DataFrames 0.4-
+DataFrames 0.4- 0.11.0
 Datetime 0.1-
 julia 0.3- 0.4

--- a/ODBC/versions/0.3.3/requires
+++ b/ODBC/versions/0.3.3/requires
@@ -1,3 +1,3 @@
-DataFrames 0.4-
+DataFrames 0.4- 0.11.0
 Datetime 0.1-
 julia 0.3- 0.4

--- a/ODBC/versions/0.3.4/requires
+++ b/ODBC/versions/0.3.4/requires
@@ -1,3 +1,3 @@
-DataFrames 0.4-
+DataFrames 0.4- 0.11.0
 Datetime 0.1-
 julia 0.3- 0.4

--- a/ODBC/versions/0.3.5/requires
+++ b/ODBC/versions/0.3.5/requires
@@ -1,3 +1,3 @@
-DataFrames 0.4-
+DataFrames 0.4- 0.11.0
 Datetime 0.1-
 julia 0.3- 0.4

--- a/ODBC/versions/0.3.6/requires
+++ b/ODBC/versions/0.3.6/requires
@@ -1,4 +1,4 @@
-DataFrames v0.5.2
+DataFrames v0.5.2 0.11.0
 Datetime v0.1.2
 julia 0.3- 0.4
 

--- a/ODBC/versions/0.3.7/requires
+++ b/ODBC/versions/0.3.7/requires
@@ -1,4 +1,4 @@
-DataFrames v0.5.2
+DataFrames v0.5.2 0.11.0
 Datetime v0.1.2
 julia 0.3- 0.4
 

--- a/ODBC/versions/0.3.8/requires
+++ b/ODBC/versions/0.3.8/requires
@@ -1,4 +1,4 @@
-DataFrames 0.5.2
+DataFrames 0.5.2 0.11.0
 Datetime 0.1.2
 julia 0.3- 0.4
 

--- a/ODBC/versions/0.3.9/requires
+++ b/ODBC/versions/0.3.9/requires
@@ -1,4 +1,4 @@
-DataFrames 0.5.2
+DataFrames 0.5.2 0.11.0
 Dates 0.3.1-
 julia 0.3- 0.4
 

--- a/ODBC/versions/0.4.2/requires
+++ b/ODBC/versions/0.4.2/requires
@@ -2,7 +2,7 @@ julia 0.4.1 0.5
 SQLite
 CSV
 DataStreams
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings
 DecFP

--- a/ODBC/versions/0.5.0/requires
+++ b/ODBC/versions/0.5.0/requires
@@ -1,6 +1,6 @@
 julia 0.5 0.7
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.9
 CategoricalArrays 0.0.5 0.2.0
 WeakRefStrings

--- a/ODBC/versions/0.5.1/requires
+++ b/ODBC/versions/0.5.1/requires
@@ -1,6 +1,6 @@
 julia 0.5 0.7
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.9
 CategoricalArrays 0.0.5 0.2.0
 WeakRefStrings

--- a/ODBC/versions/0.5.2/requires
+++ b/ODBC/versions/0.5.2/requires
@@ -1,6 +1,6 @@
 julia 0.5 0.7
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays 0.0.9
 CategoricalArrays 0.0.5 0.2.0
 WeakRefStrings

--- a/OdsIO/versions/0.1.0/requires
+++ b/OdsIO/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 PyCall 1.7
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 DataStructures 0.5.0

--- a/OdsIO/versions/0.1.1/requires
+++ b/OdsIO/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 PyCall 1.7
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 DataStructures 0.5.0

--- a/OdsIO/versions/0.1.2/requires
+++ b/OdsIO/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 PyCall 1.7
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 DataStructures 0.5.0

--- a/OdsIO/versions/0.2.0/requires
+++ b/OdsIO/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 PyCall 1.7
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 DataStructures 0.5.0

--- a/OpenGene/versions/0.1.1/requires
+++ b/OpenGene/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Libz
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/OpenGene/versions/0.1.10/requires
+++ b/OpenGene/versions/0.1.10/requires
@@ -1,6 +1,6 @@
 julia 0.4
 GZip
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 SHA
 Compat

--- a/OpenGene/versions/0.1.11/requires
+++ b/OpenGene/versions/0.1.11/requires
@@ -1,6 +1,6 @@
 julia 0.4
 GZip
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 SHA
 Compat

--- a/OpenGene/versions/0.1.2/requires
+++ b/OpenGene/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Libz
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/OpenGene/versions/0.1.3/requires
+++ b/OpenGene/versions/0.1.3/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Libz
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/OpenGene/versions/0.1.4/requires
+++ b/OpenGene/versions/0.1.4/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Libz
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/OpenGene/versions/0.1.5/requires
+++ b/OpenGene/versions/0.1.5/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Libz
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/OpenGene/versions/0.1.6/requires
+++ b/OpenGene/versions/0.1.6/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Libz
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 SHA

--- a/OpenGene/versions/0.1.7/requires
+++ b/OpenGene/versions/0.1.7/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Libz
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 SHA

--- a/OpenGene/versions/0.1.8/requires
+++ b/OpenGene/versions/0.1.8/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Libz
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 SHA

--- a/OpenGene/versions/0.1.9/requires
+++ b/OpenGene/versions/0.1.9/requires
@@ -1,6 +1,6 @@
 julia 0.4
 GZip
 DataStructures
-DataFrames
+DataFrames 0.0.1 0.11.0
 SHA
 Compat

--- a/OpenSecrets/versions/0.0.1/requires
+++ b/OpenSecrets/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.2- 0.6
 
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/OptiMimi/versions/0.0.2/requires
+++ b/OptiMimi/versions/0.0.2/requires
@@ -3,5 +3,5 @@ Mimi
 NLopt
 ForwardDiff
 MathProgBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Clp

--- a/PGFPlots/versions/1.4.3/requires
+++ b/PGFPlots/versions/1.4.3/requires
@@ -8,5 +8,5 @@ Contour 0.2.0
 ImageMagick
 Discretizers
 StatsBase 0.9.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 Reel 0.1.0

--- a/PGFPlots/versions/1.5.0/requires
+++ b/PGFPlots/versions/1.5.0/requires
@@ -8,6 +8,6 @@ Contour 0.2.0
 ImageMagick 0.2.3
 Discretizers
 StatsBase 0.9.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 Reel 0.1.0
 IndirectArrays 0.1.1

--- a/PGFPlots/versions/1.5.1/requires
+++ b/PGFPlots/versions/1.5.1/requires
@@ -8,6 +8,6 @@ Contour 0.2.0
 ImageMagick 0.2.3
 Discretizers
 StatsBase 0.9.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 Reel 0.1.0
 IndirectArrays 0.1.1

--- a/PGFPlots/versions/1.6.0/requires
+++ b/PGFPlots/versions/1.6.0/requires
@@ -8,6 +8,6 @@ Contour 0.2.0
 ImageMagick 0.2.3
 Discretizers
 StatsBase 0.9.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 Reel 0.1.0
 IndirectArrays 0.1.1

--- a/PGFPlots/versions/1.7.0/requires
+++ b/PGFPlots/versions/1.7.0/requires
@@ -8,7 +8,7 @@ Contour 0.2.0
 ImageMagick 0.2.3
 Discretizers
 StatsBase 0.9.0
-DataFrames 0.8.0
+DataFrames 0.8.0 0.11.0
 Reel 0.1.0
 IndirectArrays 0.1.1
 

--- a/PGFPlots/versions/2.0.0/requires
+++ b/PGFPlots/versions/2.0.0/requires
@@ -7,7 +7,7 @@ Contour 0.4.0
 ImageMagick 0.2.3
 Discretizers 2.0.0
 StatsBase 0.9.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0
 Reel 1.0.1
 IndirectArrays 0.1.1
 

--- a/PGFPlots/versions/2.1.0/requires
+++ b/PGFPlots/versions/2.1.0/requires
@@ -7,6 +7,6 @@ Contour 0.4.0
 ImageMagick 0.2.3
 Discretizers 2.0.0
 StatsBase 0.9.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0
 IndirectArrays 0.1.1
 

--- a/PGFPlots/versions/2.2.0/requires
+++ b/PGFPlots/versions/2.2.0/requires
@@ -7,6 +7,6 @@ Contour 0.4.0
 ImageMagick 0.2.3
 Discretizers 2.0.0
 StatsBase 0.9.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0
 IndirectArrays 0.1.1
 

--- a/PGFPlots/versions/2.2.1/requires
+++ b/PGFPlots/versions/2.2.1/requires
@@ -7,6 +7,6 @@ Contour 0.4.0
 ImageMagick 0.2.3
 Discretizers 2.0.0
 StatsBase 0.9.0
-DataFrames 0.9.0
+DataFrames 0.9.0 0.11.0
 IndirectArrays 0.1.1
 

--- a/Persa/versions/0.0.3/requires
+++ b/Persa/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 MLBase
 Distances

--- a/Persa/versions/0.0.4/requires
+++ b/Persa/versions/0.0.4/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 MLBase
 Distances

--- a/PhyloNetworks/versions/0.0.1/requires
+++ b/PhyloNetworks/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Compat
-DataFrames
+DataFrames 0.0.1 0.11.0
 NLopt
 GraphViz

--- a/PhyloNetworks/versions/0.0.2/requires
+++ b/PhyloNetworks/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Compat
-DataFrames
+DataFrames 0.0.1 0.11.0
 NLopt
 GraphViz

--- a/PhyloNetworks/versions/0.0.3/requires
+++ b/PhyloNetworks/versions/0.0.3/requires
@@ -1,6 +1,6 @@
 julia 0.4
 Compat
-DataFrames
+DataFrames 0.0.1 0.11.0
 NLopt
 Gadfly
 GLM

--- a/PhyloNetworks/versions/0.1.0/requires
+++ b/PhyloNetworks/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Compat
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 NLopt
 ColorTypes
 Gadfly

--- a/PhyloNetworks/versions/0.2.0/requires
+++ b/PhyloNetworks/versions/0.2.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Compat
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 NLopt
 ColorTypes
 Gadfly

--- a/PhyloNetworks/versions/0.3.0/requires
+++ b/PhyloNetworks/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 Compat 0.8
 StatsBase 0.9
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 NLopt 0.3
 ColorTypes 0.2
 Gadfly 0.4

--- a/PhyloNetworks/versions/0.4.0/requires
+++ b/PhyloNetworks/versions/0.4.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Compat 0.8
 StatsBase 0.9
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 NLopt 0.3
 ColorTypes 0.2
 Gadfly 0.4

--- a/PhyloNetworks/versions/0.5.0/requires
+++ b/PhyloNetworks/versions/0.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Compat 0.8
 StatsBase 0.9
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 NLopt 0.3
 ColorTypes 0.2
 Gadfly 0.4

--- a/PhyloNetworks/versions/0.5.1/requires
+++ b/PhyloNetworks/versions/0.5.1/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Compat 0.8
 StatsBase 0.11
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 NLopt 0.3
 ColorTypes 0.2
 Gadfly 0.4

--- a/PhyloNetworks/versions/0.6.0/requires
+++ b/PhyloNetworks/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 StatsBase 0.11
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 DataStructures 0.5.2
 NLopt 0.3
 ColorTypes 0.2

--- a/PlotlyJS/versions/0.6.0/requires
+++ b/PlotlyJS/versions/0.6.0/requires
@@ -6,4 +6,4 @@ Compat 0.8.4
 LaTeXStrings
 DocStringExtensions
 Juno
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PlotlyJS/versions/0.6.1/requires
+++ b/PlotlyJS/versions/0.6.1/requires
@@ -6,4 +6,4 @@ Compat 0.8.4
 LaTeXStrings
 DocStringExtensions
 Juno
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PlotlyJS/versions/0.6.2/requires
+++ b/PlotlyJS/versions/0.6.2/requires
@@ -6,4 +6,4 @@ Compat 0.8.4
 LaTeXStrings
 DocStringExtensions
 Juno
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PlotlyJS/versions/0.6.3/requires
+++ b/PlotlyJS/versions/0.6.3/requires
@@ -6,4 +6,4 @@ Compat 0.18
 LaTeXStrings
 DocStringExtensions
 Juno
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PlotlyJS/versions/0.6.4/requires
+++ b/PlotlyJS/versions/0.6.4/requires
@@ -6,4 +6,4 @@ Compat 0.18
 LaTeXStrings
 DocStringExtensions
 Juno
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PlotlyJS/versions/0.6.5/requires
+++ b/PlotlyJS/versions/0.6.5/requires
@@ -6,4 +6,4 @@ Compat 0.18
 LaTeXStrings
 DocStringExtensions
 Juno
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PlotlyJS/versions/0.7.0/requires
+++ b/PlotlyJS/versions/0.7.0/requires
@@ -5,4 +5,4 @@ Colors
 LaTeXStrings
 DocStringExtensions
 Juno
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PlotlyJS/versions/0.7.1/requires
+++ b/PlotlyJS/versions/0.7.1/requires
@@ -5,4 +5,4 @@ Colors
 LaTeXStrings
 DocStringExtensions
 Juno
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PrettyPlots/versions/0.0.1/requires
+++ b/PrettyPlots/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 Colors
-DataFrames
+DataFrames 0.0.1 0.11.0
 Plots
 GR
 VehicleModels 0.1.3

--- a/ProjectTemplate/versions/0.0.0/requires
+++ b/ProjectTemplate/versions/0.0.0/requires
@@ -1,3 +1,3 @@
 julia 0.2 0.4
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ProjectTemplate/versions/0.0.1/requires
+++ b/ProjectTemplate/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.2- 0.4
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PySide/versions/0.0.0/requires
+++ b/PySide/versions/0.0.0/requires
@@ -1,4 +1,4 @@
 julia 0.2-
 PyCall
 Mustache
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PySide/versions/0.0.1/requires
+++ b/PySide/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 PyCall
 Mustache
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/PySide/versions/0.0.2/requires
+++ b/PySide/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 PyCall
 Mustache
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Q/versions/0.0.1/requires
+++ b/Q/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.6
-DataFrames 0.10.1
+DataFrames 0.10.1 0.11.0
 Documenter 0.11.2

--- a/Q/versions/0.0.2/requires
+++ b/Q/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.6
-DataFrames 0.10.1
+DataFrames 0.10.1 0.11.0
 Documenter 0.11.2

--- a/Q/versions/0.0.3/requires
+++ b/Q/versions/0.0.3/requires
@@ -1,2 +1,2 @@
 julia 0.6
-DataFrames 0.10.1
+DataFrames 0.10.1 0.11.0

--- a/Q/versions/0.0.4/requires
+++ b/Q/versions/0.0.4/requires
@@ -1,2 +1,2 @@
 julia 0.6
-DataFrames 0.10.1
+DataFrames 0.10.1 0.11.0

--- a/Quandl/versions/0.0.0/requires
+++ b/Quandl/versions/0.0.0/requires
@@ -1,4 +1,4 @@
 julia 0.1- 0.2- 
-DataFrames
+DataFrames 0.0.1 0.11.0
 Calendar
 TimeSeries

--- a/Quandl/versions/0.0.1/requires
+++ b/Quandl/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 # julia 0.1- 0.2-
 Calendar
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Quandl/versions/0.3.0/requires
+++ b/Quandl/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 

--- a/Quandl/versions/0.3.1/requires
+++ b/Quandl/versions/0.3.1/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 

--- a/Quandl/versions/0.3.10/requires
+++ b/Quandl/versions/0.3.10/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON
 Reexport

--- a/Quandl/versions/0.3.11/requires
+++ b/Quandl/versions/0.3.11/requires
@@ -1,7 +1,7 @@
 julia 0.3-
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON
 Reexport

--- a/Quandl/versions/0.3.12/requires
+++ b/Quandl/versions/0.3.12/requires
@@ -1,7 +1,7 @@
 julia 0.3-
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON
 Reexport

--- a/Quandl/versions/0.3.13/requires
+++ b/Quandl/versions/0.3.13/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON

--- a/Quandl/versions/0.3.14/requires
+++ b/Quandl/versions/0.3.14/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON

--- a/Quandl/versions/0.3.15/requires
+++ b/Quandl/versions/0.3.15/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON

--- a/Quandl/versions/0.3.2/requires
+++ b/Quandl/versions/0.3.2/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 

--- a/Quandl/versions/0.3.3/requires
+++ b/Quandl/versions/0.3.3/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 

--- a/Quandl/versions/0.3.4/requires
+++ b/Quandl/versions/0.3.4/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON

--- a/Quandl/versions/0.3.5/requires
+++ b/Quandl/versions/0.3.5/requires
@@ -1,7 +1,7 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON
 Reexport

--- a/Quandl/versions/0.3.6/requires
+++ b/Quandl/versions/0.3.6/requires
@@ -1,7 +1,7 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON
 Reexport

--- a/Quandl/versions/0.3.7/requires
+++ b/Quandl/versions/0.3.7/requires
@@ -1,7 +1,7 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON
 Reexport

--- a/Quandl/versions/0.3.8/requires
+++ b/Quandl/versions/0.3.8/requires
@@ -1,7 +1,7 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON
 Reexport

--- a/Quandl/versions/0.3.9/requires
+++ b/Quandl/versions/0.3.9/requires
@@ -1,7 +1,7 @@
 julia 0.3-
 Datetime
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON
 Reexport

--- a/Quandl/versions/0.4.0/requires
+++ b/Quandl/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON

--- a/Quandl/versions/0.4.1/requires
+++ b/Quandl/versions/0.4.1/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON

--- a/Quandl/versions/0.4.2/requires
+++ b/Quandl/versions/0.4.2/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON

--- a/Quandl/versions/0.4.3/requires
+++ b/Quandl/versions/0.4.3/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Dates
 TimeSeries
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests
 JSON

--- a/Quandl/versions/0.4.4/requires
+++ b/Quandl/versions/0.4.4/requires
@@ -1,5 +1,5 @@
 julia 0.3 0.4-
 Dates
 TimeSeries 0.5.11 0.6.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests

--- a/Quandl/versions/0.5.0/requires
+++ b/Quandl/versions/0.5.0/requires
@@ -1,4 +1,4 @@
 julia 0.4- 0.5-
 TimeSeries 0.6.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests

--- a/Quandl/versions/0.5.1/requires
+++ b/Quandl/versions/0.5.1/requires
@@ -1,4 +1,4 @@
 julia 0.4- 0.5-
 TimeSeries 0.6.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests

--- a/Quandl/versions/0.5.2/requires
+++ b/Quandl/versions/0.5.2/requires
@@ -1,4 +1,4 @@
 julia 0.4- 0.5-
 TimeSeries 0.6.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests

--- a/Quandl/versions/0.5.3/requires
+++ b/Quandl/versions/0.5.3/requires
@@ -1,4 +1,4 @@
 julia 0.4- 0.5-
 TimeSeries 0.6.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests

--- a/Quandl/versions/0.5.4/requires
+++ b/Quandl/versions/0.5.4/requires
@@ -1,4 +1,4 @@
 julia 0.4- 0.5-
 TimeSeries 0.6.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests

--- a/Quandl/versions/0.6.0/requires
+++ b/Quandl/versions/0.6.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 TimeSeries 0.9.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests

--- a/Quandl/versions/0.6.1/requires
+++ b/Quandl/versions/0.6.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 TimeSeries 0.9.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 Requests

--- a/RCall/versions/0.0.1/requires
+++ b/RCall/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.0.2/requires
+++ b/RCall/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.0.3/requires
+++ b/RCall/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.1.0/requires
+++ b/RCall/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.1.1/requires
+++ b/RCall/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.1.2/requires
+++ b/RCall/versions/0.1.2/requires
@@ -2,5 +2,5 @@ julia 0.1 0.6
 BinDeps
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.2.0/requires
+++ b/RCall/versions/0.2.0/requires
@@ -2,5 +2,5 @@ julia 0.1 0.6
 BinDeps
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.2.1/requires
+++ b/RCall/versions/0.2.1/requires
@@ -2,5 +2,5 @@ julia 0.1 0.6
 BinDeps
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.3.0/requires
+++ b/RCall/versions/0.3.0/requires
@@ -2,5 +2,5 @@ julia 0.3 0.6
 BinDeps
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.3.1/requires
+++ b/RCall/versions/0.3.1/requires
@@ -2,5 +2,5 @@ julia 0.3 0.6
 BinDeps
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.3.2/requires
+++ b/RCall/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.3 0.6
 Compat
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile

--- a/RCall/versions/0.4.0/requires
+++ b/RCall/versions/0.4.0/requires
@@ -1,3 +1,3 @@
 julia 0.4 0.6
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/RCall/versions/0.4.1/requires
+++ b/RCall/versions/0.4.1/requires
@@ -1,4 +1,4 @@
 julia 0.4 0.6
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 @windows WinReg

--- a/RCall/versions/0.5.0/requires
+++ b/RCall/versions/0.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 DataStructures
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat
 @windows WinReg
 CategoricalArrays 0.0.1 0.2.0

--- a/RCall/versions/0.5.1/requires
+++ b/RCall/versions/0.5.1/requires
@@ -1,7 +1,7 @@
 julia 0.4
 DataStructures
 DataArrays 0.3.8
-DataFrames 0.7.6
+DataFrames 0.7.6 0.11.0
 Compat 0.8
 @windows WinReg
 CategoricalArrays 0.0.1 0.2.0

--- a/RCall/versions/0.5.2/requires
+++ b/RCall/versions/0.5.2/requires
@@ -1,7 +1,7 @@
 julia 0.4
 DataStructures
 DataArrays 0.3.8
-DataFrames 0.7.6
+DataFrames 0.7.6 0.11.0
 Compat 0.8
 @windows WinReg
 CategoricalArrays 0.0.1 0.2.0

--- a/RCall/versions/0.6.0/requires
+++ b/RCall/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.4.3
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 NullableArrays 0.0.10
 CategoricalArrays 0.0.6 0.2.0
 Compat 0.8

--- a/RCall/versions/0.6.1/requires
+++ b/RCall/versions/0.6.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.4.3
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 NullableArrays 0.0.10
 CategoricalArrays 0.0.6 0.2.0
 Compat 0.8

--- a/RCall/versions/0.6.2/requires
+++ b/RCall/versions/0.6.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.4.3
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 NullableArrays 0.0.10
 CategoricalArrays 0.0.6 0.2.0
 Compat 0.8

--- a/RCall/versions/0.6.3/requires
+++ b/RCall/versions/0.6.3/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.4.3
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 NullableArrays 0.0.10
 CategoricalArrays 0.0.6 0.2.0
 Compat 0.8

--- a/RCall/versions/0.6.4/requires
+++ b/RCall/versions/0.6.4/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.4.3
-DataFrames 0.8.4
+DataFrames 0.8.4 0.11.0
 NullableArrays 0.0.10
 CategoricalArrays 0.0.6 0.2.0
 Compat 0.8

--- a/RCall/versions/0.7.0/requires
+++ b/RCall/versions/0.7.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.5.0
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 NullableArrays 0.1.0
 CategoricalArrays 0.1.0 0.2.0
 AxisArrays 0.0.6

--- a/RCall/versions/0.7.1/requires
+++ b/RCall/versions/0.7.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.5.0
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 NullableArrays 0.1.0
 CategoricalArrays 0.1.0 0.2.0
 AxisArrays 0.0.6

--- a/RCall/versions/0.7.2/requires
+++ b/RCall/versions/0.7.2/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.5.0
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 NullableArrays 0.1.0
 CategoricalArrays 0.1.0 0.2.0
 AxisArrays 0.0.6

--- a/RCall/versions/0.7.3/requires
+++ b/RCall/versions/0.7.3/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.5.0
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 NullableArrays 0.1.0
 CategoricalArrays 0.1.0 0.2.0
 AxisArrays 0.0.6

--- a/RCall/versions/0.7.4/requires
+++ b/RCall/versions/0.7.4/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.5.0
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 NullableArrays 0.1.0
 CategoricalArrays 0.1.0 0.2.0
 AxisArrays 0.0.6

--- a/RCall/versions/0.7.5/requires
+++ b/RCall/versions/0.7.5/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataStructures 0.5.0
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 NullableArrays 0.1.0
 CategoricalArrays 0.1.0 0.3.0
 AxisArrays 0.0.6

--- a/RCall/versions/0.8.0/requires
+++ b/RCall/versions/0.8.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 Nulls 0.1.0
 DataStructures 0.5.0
-DataFrames 0.10
+DataFrames 0.10 0.11.0
 DataArrays 0.5.0
 CategoricalArrays 0.1.0 0.3.0
 NullableArrays 0.1.0

--- a/RCall/versions/0.8.1/requires
+++ b/RCall/versions/0.8.1/requires
@@ -1,7 +1,7 @@
 julia 0.6
 Nulls 0.1.0
 DataStructures 0.5.0
-DataFrames 0.10
+DataFrames 0.10 0.11.0
 DataArrays 0.5.0
 CategoricalArrays 0.1.0 0.3.0
 NullableArrays 0.1.0

--- a/RData/versions/0.0.1/requires
+++ b/RData/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 FileIO
 GZip

--- a/RData/versions/0.0.2/requires
+++ b/RData/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 DataArrays 0.3
 FileIO 0.1
 GZip 0.2

--- a/RData/versions/0.0.3/requires
+++ b/RData/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 DataArrays 0.3
 FileIO 0.1
 GZip 0.2

--- a/RData/versions/0.0.4/requires
+++ b/RData/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 DataArrays 0.3
 FileIO 0.1.2
 GZip 0.2

--- a/RData/versions/0.1.0/requires
+++ b/RData/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames 0.7
+DataFrames 0.7 0.11.0
 DataArrays 0.3
 FileIO 0.1.2
 GZip 0.2

--- a/RData/versions/0.2.0/requires
+++ b/RData/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DataFrames 0.9
+DataFrames 0.9 0.11.0
 DataArrays 0.4
 FileIO 0.1.2
 CodecZlib 0.4

--- a/RDatasets/versions/0.0.0/requires
+++ b/RDatasets/versions/0.0.0/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/RDatasets/versions/0.0.1/requires
+++ b/RDatasets/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/RDatasets/versions/0.0.2/requires
+++ b/RDatasets/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/RDatasets/versions/0.0.3/requires
+++ b/RDatasets/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 DataArrays 0.0-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/RDatasets/versions/0.1.0/requires
+++ b/RDatasets/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 DataArrays 0.1-
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/RDatasets/versions/0.1.1/requires
+++ b/RDatasets/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/RDatasets/versions/0.1.2/requires
+++ b/RDatasets/versions/0.1.2/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Reexport

--- a/RDatasets/versions/0.1.3/requires
+++ b/RDatasets/versions/0.1.3/requires
@@ -1,4 +1,4 @@
 julia 0.3
-DataFrames
+DataFrames 0.0.1 0.11.0
 Reexport
 Compat

--- a/RDatasets/versions/0.2.0/requires
+++ b/RDatasets/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Reexport
 Compat
 RData

--- a/ROCAnalysis/versions/0.0.1/requires
+++ b/ROCAnalysis/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.3
 Requires
 NumericFuns
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ROCAnalysis/versions/0.1.0/requires
+++ b/ROCAnalysis/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Compat 0.8.8
 Requires 0.2.2
-DataFrames 0.7.8
+DataFrames 0.7.8 0.11.0

--- a/ReadStat/versions/0.1.0/requires
+++ b/ReadStat/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DataArrays
 NullableArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataTables
 BinDeps
 @windows WinRPM

--- a/ReadStat/versions/0.1.1/requires
+++ b/ReadStat/versions/0.1.1/requires
@@ -1,7 +1,7 @@
 julia 0.5
 DataArrays
 NullableArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataTables
 BinDeps
 @windows WinRPM

--- a/Resampling/versions/0.0.0/requires
+++ b/Resampling/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 julia 0.2 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Rif/versions/0.0.1/requires
+++ b/Rif/versions/0.0.1/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Rif/versions/0.0.10/requires
+++ b/Rif/versions/0.0.10/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/Rif/versions/0.0.11/requires
+++ b/Rif/versions/0.0.11/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/Rif/versions/0.0.12/requires
+++ b/Rif/versions/0.0.12/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/Rif/versions/0.0.2/requires
+++ b/Rif/versions/0.0.2/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Rif/versions/0.0.3/requires
+++ b/Rif/versions/0.0.3/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Rif/versions/0.0.4/requires
+++ b/Rif/versions/0.0.4/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Rif/versions/0.0.5/requires
+++ b/Rif/versions/0.0.5/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Rif/versions/0.0.6/requires
+++ b/Rif/versions/0.0.6/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Rif/versions/0.0.7/requires
+++ b/Rif/versions/0.0.7/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Rif/versions/0.0.8/requires
+++ b/Rif/versions/0.0.8/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/Rif/versions/0.0.9/requires
+++ b/Rif/versions/0.0.9/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/Robotlib/versions/0.0.1/requires
+++ b/Robotlib/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.4
 MAT
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Plots
 StatsBase

--- a/Robotlib/versions/0.0.2/requires
+++ b/Robotlib/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.4
 MAT
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Plots
 StatsBase

--- a/Robotlib/versions/0.1.0/requires
+++ b/Robotlib/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 MAT
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 RecipesBase
 Plots

--- a/Robotlib/versions/0.2.0/requires
+++ b/Robotlib/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0-pre
 MAT
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 RecipesBase
 Plots

--- a/Robotlib/versions/0.2.1/requires
+++ b/Robotlib/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0-pre
 MAT
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 RecipesBase
 Plots

--- a/Robotlib/versions/0.2.2/requires
+++ b/Robotlib/versions/0.2.2/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 MAT
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 RecipesBase
 StatsBase

--- a/RobustStats/versions/0.0.0/requires
+++ b/RobustStats/versions/0.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 Rmath
 StatsBase
 Distributions

--- a/RobustStats/versions/0.0.1/requires
+++ b/RobustStats/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.3- 0.4
 
-DataFrames 0.5-
+DataFrames 0.5- 0.11.0
 DataArrays
 Rmath
 StatsBase 0.3.7-

--- a/SALSA/versions/0.0.1/requires
+++ b/SALSA/versions/0.0.1/requires
@@ -6,5 +6,5 @@ StatsBase
 Distances
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Clustering

--- a/SALSA/versions/0.0.2/requires
+++ b/SALSA/versions/0.0.2/requires
@@ -6,5 +6,5 @@ StatsBase
 Distances
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Clustering

--- a/SALSA/versions/0.0.3/requires
+++ b/SALSA/versions/0.0.3/requires
@@ -6,5 +6,5 @@ StatsBase
 Distances
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Clustering

--- a/SALSA/versions/0.0.4/requires
+++ b/SALSA/versions/0.0.4/requires
@@ -6,5 +6,5 @@ StatsBase
 Distances
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Clustering

--- a/SQLite/versions/0.1.0/requires
+++ b/SQLite/versions/0.1.0/requires
@@ -1,2 +1,2 @@
-DataFrames 0.2
+DataFrames 0.2 0.11.0
 julia 0.2- 0.4

--- a/SQLite/versions/0.1.1/requires
+++ b/SQLite/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.2- 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays

--- a/SQLite/versions/0.1.2/requires
+++ b/SQLite/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.2- 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 BinDeps

--- a/SQLite/versions/0.1.3/requires
+++ b/SQLite/versions/0.1.3/requires
@@ -1,5 +1,5 @@
 julia 0.2- 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 BinDeps
 @osx Homebrew

--- a/SQLite/versions/0.1.4/requires
+++ b/SQLite/versions/0.1.4/requires
@@ -1,5 +1,5 @@
 julia 0.2- 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 BinDeps
 @osx Homebrew

--- a/SQLite/versions/0.1.5/requires
+++ b/SQLite/versions/0.1.5/requires
@@ -1,5 +1,5 @@
 julia 0.2- 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 BinDeps
 @osx Homebrew

--- a/SQLite/versions/0.1.6/requires
+++ b/SQLite/versions/0.1.6/requires
@@ -1,5 +1,5 @@
 julia 0.2- 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 BinDeps
 @osx Homebrew

--- a/SQLite/versions/0.3.2/requires
+++ b/SQLite/versions/0.3.2/requires
@@ -2,7 +2,7 @@ julia 0.4.1
 BinDeps
 CSV 0.0.8
 DataStreams 0.0.1 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0
 @osx Homebrew

--- a/SQLite/versions/0.3.3/requires
+++ b/SQLite/versions/0.3.3/requires
@@ -2,7 +2,7 @@ julia 0.4.1
 BinDeps
 CSV 0.0.8
 DataStreams 0.0.1 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0
 @osx Homebrew

--- a/SQLite/versions/0.3.4/requires
+++ b/SQLite/versions/0.3.4/requires
@@ -3,6 +3,6 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams 0.0.9 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0
 LegacyStrings

--- a/SQLite/versions/0.3.5/requires
+++ b/SQLite/versions/0.3.5/requires
@@ -3,6 +3,6 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams 0.0.10 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0
 LegacyStrings

--- a/SQLite/versions/0.3.6/requires
+++ b/SQLite/versions/0.3.6/requires
@@ -3,6 +3,6 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams 0.0.12 0.0.13
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0
 LegacyStrings

--- a/SQLite/versions/0.3.7/requires
+++ b/SQLite/versions/0.3.7/requires
@@ -3,6 +3,6 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams 0.0.13 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0
 LegacyStrings

--- a/SQLite/versions/0.4.0/requires
+++ b/SQLite/versions/0.4.0/requires
@@ -3,6 +3,6 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0
 LegacyStrings

--- a/SQLite/versions/0.4.1/requires
+++ b/SQLite/versions/0.4.1/requires
@@ -3,6 +3,6 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0
 LegacyStrings

--- a/SQLite/versions/0.4.2/requires
+++ b/SQLite/versions/0.4.2/requires
@@ -3,6 +3,6 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0
 LegacyStrings

--- a/SQLite/versions/0.4.5/requires
+++ b/SQLite/versions/0.4.5/requires
@@ -3,7 +3,7 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams 0.1.0 0.2.0
-DataFrames
+DataFrames 0.0.1 0.11.0
 WeakRefStrings 0.1.3 0.3.0
 LegacyStrings
 Compat 0.9.5

--- a/ScikitLearn/versions/0.3.0/requires
+++ b/ScikitLearn/versions/0.3.0/requires
@@ -7,4 +7,4 @@ ScikitLearnBase 0.0.6
 StatsBase 0.8.0
 Iterators 0.1.9
 Compat 0.18.0
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/SloanDigitalSkySurvey/versions/0.0.1/requires
+++ b/SloanDigitalSkySurvey/versions/0.0.1/requires
@@ -2,7 +2,7 @@ julia 0.3
 DualNumbers
 FITSIO
 WCSLIB
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Grid
 GaussianMixtures

--- a/SloanDigitalSkySurvey/versions/0.0.2/requires
+++ b/SloanDigitalSkySurvey/versions/0.0.2/requires
@@ -2,7 +2,7 @@ julia 0.3
 DualNumbers
 FITSIO
 WCSLIB
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Grid
 GaussianMixtures

--- a/SloanDigitalSkySurvey/versions/0.0.3/requires
+++ b/SloanDigitalSkySurvey/versions/0.0.3/requires
@@ -2,7 +2,7 @@ julia 0.3
 DualNumbers
 FITSIO
 WCSLIB
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Grid
 GaussianMixtures

--- a/SloanDigitalSkySurvey/versions/0.1.0/requires
+++ b/SloanDigitalSkySurvey/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.4
 FITSIO
 WCS 0.1.1
-DataFrames
+DataFrames 0.0.1 0.11.0
 Docile
 Grid
 GaussianMixtures

--- a/SloanDigitalSkySurvey/versions/0.1.1/requires
+++ b/SloanDigitalSkySurvey/versions/0.1.1/requires
@@ -3,5 +3,5 @@ FITSIO
 ForwardDiff
 Optim 0.4.6 0.4.7-
 WCS 0.1.1
-DataFrames
+DataFrames 0.0.1 0.11.0
 Grid

--- a/Sparrow/versions/0.0.1/requires
+++ b/Sparrow/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.3
 Compat
-DataFrames
+DataFrames 0.0.1 0.11.0
 Color

--- a/SpatialEcology/versions/0.1.0/requires
+++ b/SpatialEcology/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.6-pre
 
 RecipesBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Reexport
 PlotUtils
 #RCall #this should be changed as this is heavy-handed - there is an issue for this on RCall

--- a/SpeedDate/versions/0.1.0/requires
+++ b/SpeedDate/versions/0.1.0/requires
@@ -2,4 +2,4 @@ julia 0.5
 Bio 0.4.3
 ArgParse 0.4
 Gtk 0.10.4
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/SpeedDate/versions/0.2.0/requires
+++ b/SpeedDate/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 Query
-DataFrames
+DataFrames 0.0.1 0.11.0
 Gadfly
 Bio 0.4.3
 ArgParse 0.4

--- a/SpeedDate/versions/0.2.1/requires
+++ b/SpeedDate/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 Gadfly
 Bio 0.4.3
 ArgParse 0.4

--- a/SpeedDate/versions/0.2.2/requires
+++ b/SpeedDate/versions/0.2.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 Gadfly
 Bio 0.4.7
 ArgParse 0.4

--- a/StackedNets/versions/0.0.1/requires
+++ b/StackedNets/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.3-
-DataFrames
+DataFrames 0.0.1 0.11.0
 StatsBase

--- a/Stan/versions/0.0.1/requires
+++ b/Stan/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.3-
-DataFrames 0.5.6-
+DataFrames 0.5.6- 0.11.0
 StatsBase 0.5.3-

--- a/StatFiles/versions/0.0.1/requires
+++ b/StatFiles/versions/0.0.1/requires
@@ -2,5 +2,5 @@ julia 0.6-pre
 ReadStat 0.1.1
 IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0
 FileIO 0.4.0

--- a/StatFiles/versions/0.0.2/requires
+++ b/StatFiles/versions/0.0.2/requires
@@ -2,5 +2,5 @@ julia 0.6-pre
 ReadStat 0.1.1
 IterableTables 0.2.0 0.5.0
 DataValues 0.1.0
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0
 FileIO 0.4.0

--- a/StatFiles/versions/0.1.0/requires
+++ b/StatFiles/versions/0.1.0/requires
@@ -3,5 +3,5 @@ TableTraits 0.0.1
 ReadStat 0.1.1
 IterableTables 0.5.0
 DataValues 0.1.0
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0
 FileIO 0.4.0

--- a/StatFiles/versions/0.1.1/requires
+++ b/StatFiles/versions/0.1.1/requires
@@ -3,5 +3,5 @@ TableTraits 0.0.1
 ReadStat 0.1.1
 IterableTables 0.5.0
 DataValues 0.1.0
-DataFrames 0.10.0
+DataFrames 0.10.0 0.11.0
 FileIO 0.4.0

--- a/StatPlots/versions/0.0.1/requires
+++ b/StatPlots/versions/0.0.1/requires
@@ -4,5 +4,5 @@ Reexport
 Plots
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity

--- a/StatPlots/versions/0.0.2/requires
+++ b/StatPlots/versions/0.0.2/requires
@@ -4,5 +4,5 @@ Reexport
 Plots
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity

--- a/StatPlots/versions/0.0.3/requires
+++ b/StatPlots/versions/0.0.3/requires
@@ -4,5 +4,5 @@ Reexport
 Plots
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity

--- a/StatPlots/versions/0.1.0/requires
+++ b/StatPlots/versions/0.1.0/requires
@@ -3,5 +3,5 @@ Reexport
 Plots
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity

--- a/StatPlots/versions/0.1.1/requires
+++ b/StatPlots/versions/0.1.1/requires
@@ -3,5 +3,5 @@ Reexport
 Plots
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity

--- a/StatPlots/versions/0.2.0/requires
+++ b/StatPlots/versions/0.2.0/requires
@@ -3,5 +3,5 @@ Reexport
 Plots 0.10
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity

--- a/StatPlots/versions/0.2.1/requires
+++ b/StatPlots/versions/0.2.1/requires
@@ -4,5 +4,5 @@ Reexport
 Plots 0.10
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity

--- a/StatPlots/versions/0.3.0/requires
+++ b/StatPlots/versions/0.3.0/requires
@@ -4,6 +4,6 @@ Reexport
 Plots 0.10
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity
 Loess

--- a/StatPlots/versions/0.4.0/requires
+++ b/StatPlots/versions/0.4.0/requires
@@ -4,6 +4,6 @@ Reexport
 Plots 0.12.0
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity
 Loess

--- a/StatPlots/versions/0.4.1/requires
+++ b/StatPlots/versions/0.4.1/requires
@@ -4,6 +4,6 @@ Reexport
 Plots 0.12.0
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity
 Loess

--- a/StatPlots/versions/0.4.2/requires
+++ b/StatPlots/versions/0.4.2/requires
@@ -4,6 +4,6 @@ Reexport
 Plots 0.12.0
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity
 Loess

--- a/StatPlots/versions/0.5.0/requires
+++ b/StatPlots/versions/0.5.0/requires
@@ -4,7 +4,7 @@ Reexport
 Plots 0.12.4
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity
 Loess
 IterableTables 0.5.0

--- a/StatPlots/versions/0.5.1/requires
+++ b/StatPlots/versions/0.5.1/requires
@@ -4,7 +4,7 @@ Reexport
 Plots 0.13
 StatsBase
 Distributions
-DataFrames
+DataFrames 0.0.1 0.11.0
 KernelDensity
 Loess
 IterableTables 0.5.0

--- a/StatsModels/versions/0.0.1/requires
+++ b/StatsModels/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataFrames 0.8.3
+DataFrames 0.8.3 0.11.0
 CategoricalArrays 0.0.6 0.2.0
 NullableArrays 0.0.10
 StatsBase 0.11.1

--- a/SymPy/versions/0.2.2/requires
+++ b/SymPy/versions/0.2.2/requires
@@ -1,4 +1,4 @@
 julia 0.2-
 PyCall
-DataFrames
+DataFrames 0.0.1 0.11.0
 Gadfly

--- a/SymPy/versions/0.2.3/requires
+++ b/SymPy/versions/0.2.3/requires
@@ -1,4 +1,4 @@
 julia 0.2-
 PyCall
-DataFrames
+DataFrames 0.0.1 0.11.0
 Gadfly

--- a/Taro/versions/0.1.0/requires
+++ b/Taro/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Taro/versions/0.1.1/requires
+++ b/Taro/versions/0.1.1/requires
@@ -1,2 +1,2 @@
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Taro/versions/0.1.2/requires
+++ b/Taro/versions/0.1.2/requires
@@ -1,2 +1,2 @@
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Taro/versions/0.1.3/requires
+++ b/Taro/versions/0.1.3/requires
@@ -1,2 +1,2 @@
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Taro/versions/0.1.4/requires
+++ b/Taro/versions/0.1.4/requires
@@ -1,2 +1,2 @@
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Taro/versions/0.2.0/requires
+++ b/Taro/versions/0.2.0/requires
@@ -1,2 +1,2 @@
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Taro/versions/0.2.1/requires
+++ b/Taro/versions/0.2.1/requires
@@ -1,4 +1,4 @@
 julia 0.3
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/Taro/versions/0.3.0/requires
+++ b/Taro/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/Taro/versions/0.3.1/requires
+++ b/Taro/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Compat

--- a/Taro/versions/0.4.0/requires
+++ b/Taro/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Compat 0.8

--- a/Taro/versions/0.5.0/requires
+++ b/Taro/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 JavaCall
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Compat 0.8

--- a/TermWin/versions/0.0.23/requires
+++ b/TermWin/versions/0.0.23/requires
@@ -3,4 +3,4 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.1
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/TermWin/versions/0.0.24/requires
+++ b/TermWin/versions/0.0.24/requires
@@ -3,4 +3,4 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.1
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/TermWin/versions/0.0.25/requires
+++ b/TermWin/versions/0.0.25/requires
@@ -3,5 +3,5 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.1
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.26/requires
+++ b/TermWin/versions/0.0.26/requires
@@ -3,5 +3,5 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.2
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.27/requires
+++ b/TermWin/versions/0.0.27/requires
@@ -3,5 +3,5 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.2
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.28/requires
+++ b/TermWin/versions/0.0.28/requires
@@ -3,5 +3,5 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.2
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.29/requires
+++ b/TermWin/versions/0.0.29/requires
@@ -3,5 +3,5 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.2
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.30/requires
+++ b/TermWin/versions/0.0.30/requires
@@ -3,5 +3,5 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.2
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.31/requires
+++ b/TermWin/versions/0.0.31/requires
@@ -3,6 +3,6 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.2
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataFramesMeta
 Lazy

--- a/TextAnalysis/versions/0.0.0/requires
+++ b/TextAnalysis/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 Languages
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/TextAnalysis/versions/0.0.1/requires
+++ b/TextAnalysis/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 Languages
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/TextAnalysis/versions/0.0.2/requires
+++ b/TextAnalysis/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 Languages
-DataFrames
+DataFrames 0.0.1 0.11.0
 BinDeps

--- a/TextAnalysis/versions/0.0.3/requires
+++ b/TextAnalysis/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.3
 Languages
-DataFrames
+DataFrames 0.0.1 0.11.0
 BinDeps

--- a/TextAnalysis/versions/0.0.4/requires
+++ b/TextAnalysis/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Languages
-DataFrames
+DataFrames 0.0.1 0.11.0
 BinDeps
 Compat

--- a/TextAnalysis/versions/0.0.5/requires
+++ b/TextAnalysis/versions/0.0.5/requires
@@ -1,5 +1,5 @@
 julia 0.3
 Languages
-DataFrames
+DataFrames 0.0.1 0.11.0
 BinDeps
 Compat

--- a/TextAnalysis/versions/0.1.0/requires
+++ b/TextAnalysis/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 Languages 0.0.5+
-DataFrames
+DataFrames 0.0.1 0.11.0
 BinDeps
 Compat 0.8.8

--- a/TextAnalysis/versions/0.2.0/requires
+++ b/TextAnalysis/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Languages 0.1.0+
-DataFrames
+DataFrames 0.0.1 0.11.0
 BinDeps
 Compat 0.17

--- a/TextAnalysis/versions/0.2.1/requires
+++ b/TextAnalysis/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Languages 0.1.0+
-DataFrames
+DataFrames 0.0.1 0.11.0
 BinDeps
 Compat 0.17

--- a/TimeData/versions/0.0.1/requires
+++ b/TimeData/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
-DataFrames 0.4.1
+DataFrames 0.4.1 0.11.0
 Datetime 0.1.2

--- a/TimeData/versions/0.1.0/requires
+++ b/TimeData/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.3-
 DataArrays 0.1.1-
-DataFrames 0.5.1-
+DataFrames 0.5.1- 0.11.0
 Datetime 0.1.2-

--- a/TimeData/versions/0.1.1/requires
+++ b/TimeData/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 julia 0.3-
 DataArrays 0.1.2-
-DataFrames 0.5.2-
+DataFrames 0.5.2- 0.11.0
 Datetime 0.1.2-

--- a/TimeData/versions/0.1.2/requires
+++ b/TimeData/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.3-
 DataArrays 0.1.2-
-DataFrames 0.5.2-
+DataFrames 0.5.2- 0.11.0
 Datetime 0.1.2-

--- a/TimeData/versions/0.2.0/requires
+++ b/TimeData/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.3-
 DataArrays 0.1.11-
-DataFrames 0.5.6-
+DataFrames 0.5.6- 0.11.0
 Datetime 0.1.6-

--- a/TimeData/versions/0.3.0/requires
+++ b/TimeData/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.3-
 DataArrays 0.1.11-
-DataFrames 0.5.6-
+DataFrames 0.5.6- 0.11.0
 Datetime 0.1.6-

--- a/TimeData/versions/0.3.1/requires
+++ b/TimeData/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.3-
 DataArrays 0.1.11-
-DataFrames 0.5.6-
+DataFrames 0.5.6- 0.11.0
 Dates 0.0.2-
 TimeSeries 0.4.3-

--- a/TimeData/versions/0.3.2/requires
+++ b/TimeData/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.3-
 DataArrays 0.1.11-
-DataFrames 0.5.6-
+DataFrames 0.5.6- 0.11.0
 Dates 0.0.2-
 TimeSeries 0.4.3-

--- a/TimeData/versions/0.4.0/requires
+++ b/TimeData/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.4-
 DataArrays 0.1.11-
-DataFrames 0.5.6-
+DataFrames 0.5.6- 0.11.0
 TimeSeries 0.4.3-

--- a/TimeData/versions/0.5.0/requires
+++ b/TimeData/versions/0.5.0/requires
@@ -1,4 +1,4 @@
 julia 0.4-
 DataArrays 0.2.0-
-DataFrames 0.5.8-
+DataFrames 0.5.8- 0.11.0
 TimeSeries 0.4.5-

--- a/TimeData/versions/0.5.1/requires
+++ b/TimeData/versions/0.5.1/requires
@@ -1,4 +1,4 @@
 julia 0.3.2-
 DataArrays 0.2.0-
-DataFrames 0.5.8-
+DataFrames 0.5.8- 0.11.0
 TimeSeries 0.4.5-

--- a/TimeData/versions/0.6.0/requires
+++ b/TimeData/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 DataArrays 0.2.0-
-DataFrames 0.5.8-
+DataFrames 0.5.8- 0.11.0
 TimeSeries 0.4.5-
 Compat 0.4-
 Docile 0.5-

--- a/TimeData/versions/0.6.1/requires
+++ b/TimeData/versions/0.6.1/requires
@@ -1,6 +1,6 @@
 julia 0.3
 DataArrays 0.2.0
-DataFrames 0.5.8
+DataFrames 0.5.8 0.11.0
 TimeSeries 0.4.5
 Compat 0.4
 Docile 0.5

--- a/TimeData/versions/0.7.0/requires
+++ b/TimeData/versions/0.7.0/requires
@@ -1,6 +1,6 @@
 julia 0.3
 DataArrays 0.2.0
-DataFrames 0.5.8
+DataFrames 0.5.8 0.11.0
 TimeSeries 0.4.5
 Compat
 Docile

--- a/TimeModels/versions/0.0.0/requires
+++ b/TimeModels/versions/0.0.0/requires
@@ -1,5 +1,5 @@
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Calendar
 UTF16
 TimeSeries

--- a/TimeModels/versions/0.0.1/requires
+++ b/TimeModels/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime
 TimeSeries
 Winston

--- a/TimeSeries/versions/0.0.0/requires
+++ b/TimeSeries/versions/0.0.0/requires
@@ -1,4 +1,4 @@
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Calendar
 UTF16

--- a/TimeSeries/versions/0.0.1/requires
+++ b/TimeSeries/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 StatsBase
-DataFrames
+DataFrames 0.0.1 0.11.0
 Calendar
 UTF16

--- a/TimeSeries/versions/0.1.0/requires
+++ b/TimeSeries/versions/0.1.0/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime

--- a/TimeSeries/versions/0.1.1/requires
+++ b/TimeSeries/versions/0.1.1/requires
@@ -1,2 +1,2 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 Datetime

--- a/TimeSeries/versions/0.1.2/requires
+++ b/TimeSeries/versions/0.1.2/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/TimeSeries/versions/0.1.3/requires
+++ b/TimeSeries/versions/0.1.3/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/TimeSeries/versions/0.1.4/requires
+++ b/TimeSeries/versions/0.1.4/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/TimeSeries/versions/0.1.5/requires
+++ b/TimeSeries/versions/0.1.5/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/TimeSeries/versions/0.1.6/requires
+++ b/TimeSeries/versions/0.1.6/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/TimeSeries/versions/0.1.7/requires
+++ b/TimeSeries/versions/0.1.7/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/TimeSeries/versions/0.2.0/requires
+++ b/TimeSeries/versions/0.2.0/requires
@@ -1,3 +1,3 @@
-DataFrames
+DataFrames 0.0.1 0.11.0
 DataArrays
 Datetime

--- a/TimeSeriesIO/versions/0.0.1/requires
+++ b/TimeSeriesIO/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 TimeSeries

--- a/TimeSeriesIO/versions/0.0.2/requires
+++ b/TimeSeriesIO/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 TimeSeries

--- a/TimeSeriesIO/versions/0.0.3/requires
+++ b/TimeSeriesIO/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 TimeSeries

--- a/TimeSeriesIO/versions/0.0.4/requires
+++ b/TimeSeriesIO/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0
 TimeSeries

--- a/Twitter/versions/0.0.1/requires
+++ b/Twitter/versions/0.0.1/requires
@@ -4,4 +4,4 @@ HttpCommon
 Requests
 JSON
 Nettle
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Twitter/versions/0.0.2/requires
+++ b/Twitter/versions/0.0.2/requires
@@ -4,4 +4,4 @@ HttpCommon
 Requests
 JSON
 Nettle
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Twitter/versions/0.0.3/requires
+++ b/Twitter/versions/0.0.3/requires
@@ -4,4 +4,4 @@ HttpCommon
 Requests
 JSON
 Nettle
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Twitter/versions/0.1.0/requires
+++ b/Twitter/versions/0.1.0/requires
@@ -4,4 +4,4 @@ HttpCommon
 Requests
 JSON
 Nettle
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/Twitter/versions/0.2.0/requires
+++ b/Twitter/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.3
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 OAuth

--- a/Twitter/versions/0.2.1/requires
+++ b/Twitter/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.3
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 OAuth
 Compat

--- a/Twitter/versions/0.2.2/requires
+++ b/Twitter/versions/0.2.2/requires
@@ -1,4 +1,4 @@
 julia 0.4-
-DataFrames
+DataFrames 0.0.1 0.11.0
 OAuth
 Compat

--- a/Twitter/versions/0.3.0/requires
+++ b/Twitter/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
-DataFrames
+DataFrames 0.0.1 0.11.0
 OAuth
 Compat

--- a/UAParser/versions/0.1.0/requires
+++ b/UAParser/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 YAML
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/UAParser/versions/0.2.0/requires
+++ b/UAParser/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.3-
 YAML
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/UAParser/versions/0.3.0/requires
+++ b/UAParser/versions/0.3.0/requires
@@ -1,3 +1,3 @@
 julia 0.3-
 YAML
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/UAParser/versions/0.4.0/requires
+++ b/UAParser/versions/0.4.0/requires
@@ -1,3 +1,3 @@
 julia 0.4
 YAML
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.1/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.2/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.3/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.4/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.4/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.5/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.5/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.1.0/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Distributions
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/WorldBankData/versions/0.0.1/requires
+++ b/WorldBankData/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 HTTPClient
 JSON
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/WorldBankData/versions/0.0.2/requires
+++ b/WorldBankData/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 HTTPClient
 JSON
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/WorldBankData/versions/0.0.3/requires
+++ b/WorldBankData/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 HTTPClient
 JSON
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/WorldBankData/versions/0.0.4/requires
+++ b/WorldBankData/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 HTTPClient
 JSON
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/WorldBankData/versions/0.0.5/requires
+++ b/WorldBankData/versions/0.0.5/requires
@@ -2,5 +2,5 @@ julia 0.3
 HTTPClient
 JSON
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0
 Compat

--- a/WorldBankData/versions/0.0.6/requires
+++ b/WorldBankData/versions/0.0.6/requires
@@ -2,4 +2,4 @@ julia 0.6
 HTTP
 JSON
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/WorldBankData/versions/0.1.0/requires
+++ b/WorldBankData/versions/0.1.0/requires
@@ -2,4 +2,4 @@ julia 0.6
 HTTP
 JSON
 DataArrays
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/XSim/versions/0.1.0/requires
+++ b/XSim/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.4 0.6
-DataFrames
+DataFrames 0.0.1 0.11.0
 Distributions
 JWAS 0.1- 0.2

--- a/ZipCode/versions/0.0.1/requires
+++ b/ZipCode/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/ZipCode/versions/0.0.2/requires
+++ b/ZipCode/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 julia 0.5
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/kNN/versions/0.0.0/requires
+++ b/kNN/versions/0.0.0/requires
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.0.1 0.11.0

--- a/mPulseAPI/versions/1.0.0/requires
+++ b/mPulseAPI/versions/1.0.0/requires
@@ -3,5 +3,5 @@ Requests
 LightXML
 HttpCommon
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting

--- a/mPulseAPI/versions/1.0.1/requires
+++ b/mPulseAPI/versions/1.0.1/requires
@@ -3,5 +3,5 @@ Requests
 LightXML
 HttpCommon
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting

--- a/mPulseAPI/versions/1.0.2/requires
+++ b/mPulseAPI/versions/1.0.2/requires
@@ -3,5 +3,5 @@ Requests 0.3.9
 LightXML
 HttpCommon
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting

--- a/mPulseAPI/versions/1.0.3/requires
+++ b/mPulseAPI/versions/1.0.3/requires
@@ -3,5 +3,5 @@ Requests 0.3.9
 LightXML
 HttpCommon
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting

--- a/mPulseAPI/versions/1.0.4/requires
+++ b/mPulseAPI/versions/1.0.4/requires
@@ -3,5 +3,5 @@ Requests 0.3.9
 LightXML
 HttpCommon
 JSON
-DataFrames
+DataFrames 0.0.1 0.11.0
 Formatting

--- a/mPulseAPI/versions/1.0.5/requires
+++ b/mPulseAPI/versions/1.0.5/requires
@@ -4,5 +4,5 @@ LightXML
 HttpCommon
 HttpParser 0.2.0
 JSON
-DataFrames 0.7.3
+DataFrames 0.7.3 0.11.0
 Formatting

--- a/mPulseAPI/versions/1.0.6/requires
+++ b/mPulseAPI/versions/1.0.6/requires
@@ -4,5 +4,5 @@ LightXML
 HttpCommon
 HttpParser 0.2.0
 JSON
-DataFrames 0.7.3
+DataFrames 0.7.3 0.11.0
 Formatting


### PR DESCRIPTION
Since this release breaks backward compatibility, add an upper bound to all dependencies.

If you're looking for the DataFrames 0.11.0 tag in the diff, it's [here](https://github.com/JuliaLang/METADATA.jl/pull/12188/files#diff-50d78a41f8271295fdab77ccfcb6a932).