### PR TITLE
Fix upper bounds added for DataArrays 0.7.0

### DIFF
--- a/Benchmark/versions/0.0.0/requires
+++ b/Benchmark/versions/0.0.0/requires
@@ -1,1 +1,2 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Benchmark/versions/0.0.0/requires
+++ b/Benchmark/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Benchmark/versions/0.0.1/requires
+++ b/Benchmark/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Benchmark/versions/0.0.1/requires
+++ b/Benchmark/versions/0.0.1/requires
@@ -1,2 +1,3 @@
 julia 0.2-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Benchmark/versions/0.0.2/requires
+++ b/Benchmark/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Benchmark/versions/0.0.2/requires
+++ b/Benchmark/versions/0.0.2/requires
@@ -1,2 +1,3 @@
 julia 0.2-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Benchmark/versions/0.0.3/requires
+++ b/Benchmark/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.2-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/Benchmark/versions/0.1.0/requires
+++ b/Benchmark/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/DataFrames/versions/0.2.0/requires
+++ b/DataFrames/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 Options
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.2.1/requires
+++ b/DataFrames/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 Options
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.2.2/requires
+++ b/DataFrames/versions/0.2.2/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 Options
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.2.3/requires
+++ b/DataFrames/versions/0.2.3/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 

--- a/DataFrames/versions/0.2.4/requires
+++ b/DataFrames/versions/0.2.4/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 

--- a/DataFrames/versions/0.2.5/requires
+++ b/DataFrames/versions/0.2.5/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 

--- a/DataFrames/versions/0.3.0/requires
+++ b/DataFrames/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 

--- a/DataFrames/versions/0.3.1/requires
+++ b/DataFrames/versions/0.3.1/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 

--- a/DataFrames/versions/0.3.10/requires
+++ b/DataFrames/versions/0.3.10/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 

--- a/DataFrames/versions/0.3.11/requires
+++ b/DataFrames/versions/0.3.11/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 Blocks

--- a/DataFrames/versions/0.3.12/requires
+++ b/DataFrames/versions/0.3.12/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 Blocks

--- a/DataFrames/versions/0.3.13/requires
+++ b/DataFrames/versions/0.3.13/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3
 Blocks

--- a/DataFrames/versions/0.3.14/requires
+++ b/DataFrames/versions/0.3.14/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 StatsBase 0.0.0 0.8.3
 GZip
 Blocks

--- a/DataFrames/versions/0.3.15/requires
+++ b/DataFrames/versions/0.3.15/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 StatsBase 0.0.0 0.8.3
 GZip
 Blocks

--- a/DataFrames/versions/0.3.16/requires
+++ b/DataFrames/versions/0.3.16/requires
@@ -1,4 +1,4 @@
-julia 0.2-
+julia 0.2- 0.6
 StatsBase 0.0.0 0.8.3
 GZip
 Blocks

--- a/DataFrames/versions/0.3.2/requires
+++ b/DataFrames/versions/0.3.2/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.3.3/requires
+++ b/DataFrames/versions/0.3.3/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.3.4/requires
+++ b/DataFrames/versions/0.3.4/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.3.5/requires
+++ b/DataFrames/versions/0.3.5/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.3.6/requires
+++ b/DataFrames/versions/0.3.6/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.3.7/requires
+++ b/DataFrames/versions/0.3.7/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.3.8/requires
+++ b/DataFrames/versions/0.3.8/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.3.9/requires
+++ b/DataFrames/versions/0.3.9/requires
@@ -1,3 +1,3 @@
-julia 0.2-
+julia 0.2- 0.6
 GZip
 StatsBase 0.0.0 0.8.3

--- a/DataFrames/versions/0.4.0/requires
+++ b/DataFrames/versions/0.4.0/requires
@@ -3,4 +3,4 @@ StatsBase 0.0.0 0.8.3
 GZip
 Blocks
 SortingAlgorithms
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/DataFrames/versions/0.4.1/requires
+++ b/DataFrames/versions/0.4.1/requires
@@ -3,4 +3,4 @@ StatsBase 0.0.0 0.8.3
 GZip
 Blocks
 SortingAlgorithms
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/DataFrames/versions/0.4.2/requires
+++ b/DataFrames/versions/0.4.2/requires
@@ -3,4 +3,4 @@ Stats
 GZip
 Blocks
 SortingAlgorithms
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/DataFrames/versions/0.4.3/requires
+++ b/DataFrames/versions/0.4.3/requires
@@ -1,5 +1,5 @@
 julia 0.2- 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.8- 0.8.3
 GZip
 Blocks

--- a/DataFrames/versions/0.5.1/requires
+++ b/DataFrames/versions/0.5.1/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.0.0 0.8.3
 GZip
 Blocks

--- a/DataFrames/versions/0.5.10/requires
+++ b/DataFrames/versions/0.5.10/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.5.11/requires
+++ b/DataFrames/versions/0.5.11/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.5.12/requires
+++ b/DataFrames/versions/0.5.12/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.5.2/requires
+++ b/DataFrames/versions/0.5.2/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.0.0 0.8.3
 GZip
 Blocks

--- a/DataFrames/versions/0.5.3/requires
+++ b/DataFrames/versions/0.5.3/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.0.0 0.8.3
 GZip
 Blocks

--- a/DataFrames/versions/0.5.4/requires
+++ b/DataFrames/versions/0.5.4/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 Blocks

--- a/DataFrames/versions/0.5.5/requires
+++ b/DataFrames/versions/0.5.5/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.5.6/requires
+++ b/DataFrames/versions/0.5.6/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.5.7/requires
+++ b/DataFrames/versions/0.5.7/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.5.8/requires
+++ b/DataFrames/versions/0.5.8/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.5.9/requires
+++ b/DataFrames/versions/0.5.9/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.6.0/requires
+++ b/DataFrames/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.3-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.6.1/requires
+++ b/DataFrames/versions/0.6.1/requires
@@ -1,5 +1,5 @@
 julia 0.3.4-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.6.2/requires
+++ b/DataFrames/versions/0.6.2/requires
@@ -1,5 +1,5 @@
 julia 0.3.4-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.6.3/requires
+++ b/DataFrames/versions/0.6.3/requires
@@ -1,5 +1,5 @@
 julia 0.3.4-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.6.4/requires
+++ b/DataFrames/versions/0.6.4/requires
@@ -1,5 +1,5 @@
 julia 0.3.4-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/DataFrames/versions/0.6.5/requires
+++ b/DataFrames/versions/0.6.5/requires
@@ -1,5 +1,5 @@
 julia 0.3.4-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 StatsBase 0.3.9+ 0.8.3
 GZip
 SortingAlgorithms

--- a/EasyPhys/versions/0.1.3/requires
+++ b/EasyPhys/versions/0.1.3/requires
@@ -1,5 +1,6 @@
-julia 0.5 0.6
+julia 0.5
 LsqFit
 PyPlot
 PyCall
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/EasyPhys/versions/0.1.3/requires
+++ b/EasyPhys/versions/0.1.3/requires
@@ -3,4 +3,4 @@ LsqFit
 PyPlot
 PyCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/EasyPhys/versions/0.1.3/requires
+++ b/EasyPhys/versions/0.1.3/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.6
 LsqFit
 PyPlot
 PyCall

--- a/EasyPhys/versions/0.1.4/requires
+++ b/EasyPhys/versions/0.1.4/requires
@@ -3,4 +3,4 @@ LsqFit
 PyCall
 PyPlot
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/ExcelReaders/versions/0.1.0/requires
+++ b/ExcelReaders/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 PyCall
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates

--- a/ExcelReaders/versions/0.2.0/requires
+++ b/ExcelReaders/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 PyCall
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates

--- a/ExcelReaders/versions/0.3.0/requires
+++ b/ExcelReaders/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 PyCall

--- a/ExcelReaders/versions/0.3.1/requires
+++ b/ExcelReaders/versions/0.3.1/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 PyCall 1.1

--- a/ExcelReaders/versions/0.4.0/requires
+++ b/ExcelReaders/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 PyCall 1.1

--- a/ExcelReaders/versions/0.4.1/requires
+++ b/ExcelReaders/versions/0.4.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 PyCall 1.5

--- a/ExcelReaders/versions/0.5.0/requires
+++ b/ExcelReaders/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 PyCall 1.5

--- a/ExcelReaders/versions/0.6.0/requires
+++ b/ExcelReaders/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 PyCall 1.5

--- a/ExcelReaders/versions/0.7.0/requires
+++ b/ExcelReaders/versions/0.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 PyCall 1.5

--- a/ExcelReaders/versions/0.8.0/requires
+++ b/ExcelReaders/versions/0.8.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 PyCall 1.5

--- a/ExcelReaders/versions/0.8.1/requires
+++ b/ExcelReaders/versions/0.8.1/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 PyCall 1.5

--- a/ExcelReaders/versions/0.8.2/requires
+++ b/ExcelReaders/versions/0.8.2/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 PyCall 1.5

--- a/FaSTLMM/versions/0.0.1/requires
+++ b/FaSTLMM/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Optim
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/FaSTLMM/versions/0.0.2/requires
+++ b/FaSTLMM/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Optim
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/FaSTLMM/versions/0.0.3/requires
+++ b/FaSTLMM/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Optim
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/FaSTLMM/versions/0.1.0/requires
+++ b/FaSTLMM/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Optim
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/FactorModels/versions/0.0.2/requires
+++ b/FactorModels/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.3.4- 0.6
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 GLM
 Gadfly
 DimensionalityReduction

--- a/Feather/versions/0.1.1/requires
+++ b/Feather/versions/0.1.1/requires
@@ -5,4 +5,4 @@ DataFrames 0.0.0 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0
 CategoricalArrays 0.0.1 0.0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Feather/versions/0.1.1/requires
+++ b/Feather/versions/0.1.1/requires
@@ -5,3 +5,4 @@ DataFrames 0.0.0 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0
 CategoricalArrays 0.0.1 0.0.5
+DataArrays 0.0.1 0.7.0

--- a/Feather/versions/0.1.2/requires
+++ b/Feather/versions/0.1.2/requires
@@ -5,4 +5,4 @@ DataFrames 0.0.0 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0
 CategoricalArrays 0.0.1 0.0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Feather/versions/0.1.2/requires
+++ b/Feather/versions/0.1.2/requires
@@ -5,3 +5,4 @@ DataFrames 0.0.0 0.11.0
 NullableArrays
 WeakRefStrings 0.0.0 0.3.0
 CategoricalArrays 0.0.1 0.0.5
+DataArrays 0.0.1 0.7.0

--- a/Feather/versions/0.1.3/requires
+++ b/Feather/versions/0.1.3/requires
@@ -5,4 +5,4 @@ DataFrames 0.0.0 0.11.0
 NullableArrays
 WeakRefStrings 0.1.3 0.3.0
 CategoricalArrays 0.0.1 0.0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Feather/versions/0.1.3/requires
+++ b/Feather/versions/0.1.3/requires
@@ -5,3 +5,4 @@ DataFrames 0.0.0 0.11.0
 NullableArrays
 WeakRefStrings 0.1.3 0.3.0
 CategoricalArrays 0.0.1 0.0.5
+DataArrays 0.0.1 0.7.0

--- a/Feather/versions/0.1.4/requires
+++ b/Feather/versions/0.1.4/requires
@@ -5,4 +5,4 @@ CategoricalArrays 0.0.4 0.0.5
 DataFrames 0.0.0 0.11.0
 DataStreams 0.0.12 0.0.13
 WeakRefStrings 0.1.3 0.3.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Feather/versions/0.1.4/requires
+++ b/Feather/versions/0.1.4/requires
@@ -5,3 +5,4 @@ CategoricalArrays 0.0.4 0.0.5
 DataFrames 0.0.0 0.11.0
 DataStreams 0.0.12 0.0.13
 WeakRefStrings 0.1.3 0.3.0
+DataArrays 0.0.1 0.7.0

--- a/Feather/versions/0.1.5/requires
+++ b/Feather/versions/0.1.5/requires
@@ -5,4 +5,4 @@ CategoricalArrays 0.0.4 0.0.5
 DataFrames 0.0.0 0.11.0
 DataStreams 0.0.13 0.2.0
 WeakRefStrings 0.1.3 0.3.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Feather/versions/0.1.5/requires
+++ b/Feather/versions/0.1.5/requires
@@ -5,3 +5,4 @@ CategoricalArrays 0.0.4 0.0.5
 DataFrames 0.0.0 0.11.0
 DataStreams 0.0.13 0.2.0
 WeakRefStrings 0.1.3 0.3.0
+DataArrays 0.0.1 0.7.0

--- a/Feather/versions/0.2.1/requires
+++ b/Feather/versions/0.2.1/requires
@@ -5,4 +5,4 @@ CategoricalArrays 0.0.6 0.2.0
 DataFrames 0.0.0 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Feather/versions/0.2.2/requires
+++ b/Feather/versions/0.2.2/requires
@@ -5,4 +5,4 @@ CategoricalArrays 0.0.6 0.2.0
 DataFrames 0.0.0 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Feather/versions/0.2.3/requires
+++ b/Feather/versions/0.2.3/requires
@@ -5,4 +5,4 @@ CategoricalArrays 0.0.6 0.2.0
 DataFrames 0.0.0 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Feather/versions/0.2.5/requires
+++ b/Feather/versions/0.2.5/requires
@@ -5,4 +5,4 @@ CategoricalArrays 0.0.6 0.2.0
 DataFrames 0.0.0 0.11.0
 DataStreams 0.1.0 0.2.0
 WeakRefStrings 0.1.3 0.3.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/FixedEffectModels/versions/0.0.1/requires
+++ b/FixedEffectModels/versions/0.0.1/requires
@@ -2,6 +2,6 @@ julia 0.3
 Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.7.7
 GLM

--- a/FixedEffectModels/versions/0.0.2/requires
+++ b/FixedEffectModels/versions/0.0.2/requires
@@ -2,6 +2,6 @@ julia 0.3
 Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.7.7
 GLM

--- a/FixedEffectModels/versions/0.0.3/requires
+++ b/FixedEffectModels/versions/0.0.3/requires
@@ -2,6 +2,6 @@ julia 0.3
 Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.7.7
 GLM

--- a/FixedEffectModels/versions/0.1.0/requires
+++ b/FixedEffectModels/versions/0.1.0/requires
@@ -2,5 +2,5 @@ julia 0.3
 Distributions 0.4.6
 Distances 0.1.1
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.1.1/requires
+++ b/FixedEffectModels/versions/0.1.1/requires
@@ -2,5 +2,5 @@ julia 0.3
 Compat
 Distributions 0.4.6
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.2.0/requires
+++ b/FixedEffectModels/versions/0.2.0/requires
@@ -2,5 +2,5 @@ julia 0.4-
 Compat
 Distributions 0.4.6
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.2.1/requires
+++ b/FixedEffectModels/versions/0.2.1/requires
@@ -2,5 +2,5 @@ julia 0.4-
 Compat
 Distributions 0.4.6
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.2.2/requires
+++ b/FixedEffectModels/versions/0.2.2/requires
@@ -2,5 +2,5 @@ julia 0.4-
 Compat
 Distributions 0.4.6
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.7.7

--- a/FixedEffectModels/versions/0.3.0/requires
+++ b/FixedEffectModels/versions/0.3.0/requires
@@ -2,5 +2,5 @@ julia 0.5-
 Compat
 Distributions 0.4.6
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.8.0

--- a/FreqTables/versions/0.0.1/requires
+++ b/FreqTables/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 NamedArrays
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/FreqTables/versions/0.0.2/requires
+++ b/FreqTables/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.4.2
 NamedArrays
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/FreqTables/versions/0.1.0/requires
+++ b/FreqTables/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 NamedArrays
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/Gadfly/versions/0.0.0/requires
+++ b/Gadfly/versions/0.0.0/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.0.0/requires
+++ b/Gadfly/versions/0.0.0/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.0/requires
+++ b/Gadfly/versions/0.1.0/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.0/requires
+++ b/Gadfly/versions/0.1.0/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.1/requires
+++ b/Gadfly/versions/0.1.1/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.1/requires
+++ b/Gadfly/versions/0.1.1/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.10/requires
+++ b/Gadfly/versions/0.1.10/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.10/requires
+++ b/Gadfly/versions/0.1.10/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.11/requires
+++ b/Gadfly/versions/0.1.11/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.11/requires
+++ b/Gadfly/versions/0.1.11/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.12/requires
+++ b/Gadfly/versions/0.1.12/requires
@@ -8,4 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.12/requires
+++ b/Gadfly/versions/0.1.12/requires
@@ -8,3 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.13/requires
+++ b/Gadfly/versions/0.1.13/requires
@@ -8,4 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.13/requires
+++ b/Gadfly/versions/0.1.13/requires
@@ -8,3 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.14/requires
+++ b/Gadfly/versions/0.1.14/requires
@@ -8,4 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.14/requires
+++ b/Gadfly/versions/0.1.14/requires
@@ -8,3 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.15/requires
+++ b/Gadfly/versions/0.1.15/requires
@@ -8,4 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.15/requires
+++ b/Gadfly/versions/0.1.15/requires
@@ -8,3 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.16/requires
+++ b/Gadfly/versions/0.1.16/requires
@@ -8,4 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.16/requires
+++ b/Gadfly/versions/0.1.16/requires
@@ -8,3 +8,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.17/requires
+++ b/Gadfly/versions/0.1.17/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.17/requires
+++ b/Gadfly/versions/0.1.17/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.18/requires
+++ b/Gadfly/versions/0.1.18/requires
@@ -7,3 +7,4 @@ Datetime
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.18/requires
+++ b/Gadfly/versions/0.1.18/requires
@@ -7,4 +7,4 @@ Datetime
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.19/requires
+++ b/Gadfly/versions/0.1.19/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.19/requires
+++ b/Gadfly/versions/0.1.19/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.2/requires
+++ b/Gadfly/versions/0.1.2/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.2/requires
+++ b/Gadfly/versions/0.1.2/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.20/requires
+++ b/Gadfly/versions/0.1.20/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.20/requires
+++ b/Gadfly/versions/0.1.20/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.21/requires
+++ b/Gadfly/versions/0.1.21/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.21/requires
+++ b/Gadfly/versions/0.1.21/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.22/requires
+++ b/Gadfly/versions/0.1.22/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.22/requires
+++ b/Gadfly/versions/0.1.22/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.23/requires
+++ b/Gadfly/versions/0.1.23/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.23/requires
+++ b/Gadfly/versions/0.1.23/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.24/requires
+++ b/Gadfly/versions/0.1.24/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.24/requires
+++ b/Gadfly/versions/0.1.24/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.25/requires
+++ b/Gadfly/versions/0.1.25/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.25/requires
+++ b/Gadfly/versions/0.1.25/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.26/requires
+++ b/Gadfly/versions/0.1.26/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.26/requires
+++ b/Gadfly/versions/0.1.26/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.27/requires
+++ b/Gadfly/versions/0.1.27/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.27/requires
+++ b/Gadfly/versions/0.1.27/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.28/requires
+++ b/Gadfly/versions/0.1.28/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.28/requires
+++ b/Gadfly/versions/0.1.28/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.29/requires
+++ b/Gadfly/versions/0.1.29/requires
@@ -9,3 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.29/requires
+++ b/Gadfly/versions/0.1.29/requires
@@ -9,4 +9,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.3/requires
+++ b/Gadfly/versions/0.1.3/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.3/requires
+++ b/Gadfly/versions/0.1.3/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.30/requires
+++ b/Gadfly/versions/0.1.30/requires
@@ -10,4 +10,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.30/requires
+++ b/Gadfly/versions/0.1.30/requires
@@ -10,3 +10,4 @@ Iterators
 JSON
 Loess
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.31/requires
+++ b/Gadfly/versions/0.1.31/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.31/requires
+++ b/Gadfly/versions/0.1.31/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.4/requires
+++ b/Gadfly/versions/0.1.4/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.4/requires
+++ b/Gadfly/versions/0.1.4/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.5/requires
+++ b/Gadfly/versions/0.1.5/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.5/requires
+++ b/Gadfly/versions/0.1.5/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.6/requires
+++ b/Gadfly/versions/0.1.6/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.6/requires
+++ b/Gadfly/versions/0.1.6/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.7/requires
+++ b/Gadfly/versions/0.1.7/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.7/requires
+++ b/Gadfly/versions/0.1.7/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.8/requires
+++ b/Gadfly/versions/0.1.8/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.8/requires
+++ b/Gadfly/versions/0.1.8/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.1.9/requires
+++ b/Gadfly/versions/0.1.9/requires
@@ -7,4 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.1.9/requires
+++ b/Gadfly/versions/0.1.9/requires
@@ -7,3 +7,4 @@ Distributions
 Iterators
 JSON
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.0/requires
+++ b/Gadfly/versions/0.2.0/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.0/requires
+++ b/Gadfly/versions/0.2.0/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.1/requires
+++ b/Gadfly/versions/0.2.1/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.1/requires
+++ b/Gadfly/versions/0.2.1/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.2/requires
+++ b/Gadfly/versions/0.2.2/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.2/requires
+++ b/Gadfly/versions/0.2.2/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.3/requires
+++ b/Gadfly/versions/0.2.3/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.3/requires
+++ b/Gadfly/versions/0.2.3/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.4/requires
+++ b/Gadfly/versions/0.2.4/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.4/requires
+++ b/Gadfly/versions/0.2.4/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.5/requires
+++ b/Gadfly/versions/0.2.5/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.5/requires
+++ b/Gadfly/versions/0.2.5/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.6/requires
+++ b/Gadfly/versions/0.2.6/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.6/requires
+++ b/Gadfly/versions/0.2.6/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.7/requires
+++ b/Gadfly/versions/0.2.7/requires
@@ -11,4 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.7/requires
+++ b/Gadfly/versions/0.2.7/requires
@@ -11,3 +11,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.8/requires
+++ b/Gadfly/versions/0.2.8/requires
@@ -12,3 +12,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.8/requires
+++ b/Gadfly/versions/0.2.8/requires
@@ -12,4 +12,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.2.9/requires
+++ b/Gadfly/versions/0.2.9/requires
@@ -12,3 +12,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.2.9/requires
+++ b/Gadfly/versions/0.2.9/requires
@@ -12,4 +12,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.0/requires
+++ b/Gadfly/versions/0.3.0/requires
@@ -12,3 +12,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.0/requires
+++ b/Gadfly/versions/0.3.0/requires
@@ -12,4 +12,4 @@ JSON
 Loess
 StatsBase
 Contour 0.0.0 0.2.0-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.1/requires
+++ b/Gadfly/versions/0.3.1/requires
@@ -12,4 +12,4 @@ Iterators
 JSON
 Loess
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.1/requires
+++ b/Gadfly/versions/0.3.1/requires
@@ -12,3 +12,4 @@ Iterators
 JSON
 Loess
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.10/requires
+++ b/Gadfly/versions/0.3.10/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.2
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.10/requires
+++ b/Gadfly/versions/0.3.10/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.2
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.11/requires
+++ b/Gadfly/versions/0.3.11/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.11/requires
+++ b/Gadfly/versions/0.3.11/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.12/requires
+++ b/Gadfly/versions/0.3.12/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.12/requires
+++ b/Gadfly/versions/0.3.12/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.13/requires
+++ b/Gadfly/versions/0.3.13/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.13/requires
+++ b/Gadfly/versions/0.3.13/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.14/requires
+++ b/Gadfly/versions/0.3.14/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.14/requires
+++ b/Gadfly/versions/0.3.14/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.15/requires
+++ b/Gadfly/versions/0.3.15/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.15/requires
+++ b/Gadfly/versions/0.3.15/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.16/requires
+++ b/Gadfly/versions/0.3.16/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.16/requires
+++ b/Gadfly/versions/0.3.16/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.17/requires
+++ b/Gadfly/versions/0.3.17/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.17/requires
+++ b/Gadfly/versions/0.3.17/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.18/requires
+++ b/Gadfly/versions/0.3.18/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.18/requires
+++ b/Gadfly/versions/0.3.18/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.2/requires
+++ b/Gadfly/versions/0.3.2/requires
@@ -12,4 +12,4 @@ Iterators 0.1.5
 JSON
 Loess
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.2/requires
+++ b/Gadfly/versions/0.3.2/requires
@@ -12,3 +12,4 @@ Iterators 0.1.5
 JSON
 Loess
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.3/requires
+++ b/Gadfly/versions/0.3.3/requires
@@ -12,4 +12,4 @@ Iterators 0.1.5
 JSON
 Loess
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.3/requires
+++ b/Gadfly/versions/0.3.3/requires
@@ -12,3 +12,4 @@ Iterators 0.1.5
 JSON
 Loess
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.4/requires
+++ b/Gadfly/versions/0.3.4/requires
@@ -13,3 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.4/requires
+++ b/Gadfly/versions/0.3.4/requires
@@ -13,4 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.5/requires
+++ b/Gadfly/versions/0.3.5/requires
@@ -13,3 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.5/requires
+++ b/Gadfly/versions/0.3.5/requires
@@ -13,4 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.6/requires
+++ b/Gadfly/versions/0.3.6/requires
@@ -13,3 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.6/requires
+++ b/Gadfly/versions/0.3.6/requires
@@ -13,4 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.7/requires
+++ b/Gadfly/versions/0.3.7/requires
@@ -13,3 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.7/requires
+++ b/Gadfly/versions/0.3.7/requires
@@ -13,4 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.8/requires
+++ b/Gadfly/versions/0.3.8/requires
@@ -13,3 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.8/requires
+++ b/Gadfly/versions/0.3.8/requires
@@ -13,4 +13,4 @@ JSON
 KernelDensity
 Loess
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.3.9/requires
+++ b/Gadfly/versions/0.3.9/requires
@@ -14,3 +14,4 @@ KernelDensity
 Loess
 Showoff 0.0.2
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.3.9/requires
+++ b/Gadfly/versions/0.3.9/requires
@@ -14,4 +14,4 @@ KernelDensity
 Loess
 Showoff 0.0.2
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.4.0/requires
+++ b/Gadfly/versions/0.4.0/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.4.0/requires
+++ b/Gadfly/versions/0.4.0/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.4.1/requires
+++ b/Gadfly/versions/0.4.1/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.4.1/requires
+++ b/Gadfly/versions/0.4.1/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.4.2/requires
+++ b/Gadfly/versions/0.4.2/requires
@@ -15,4 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.4.2/requires
+++ b/Gadfly/versions/0.4.2/requires
@@ -15,3 +15,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.4.3/requires
+++ b/Gadfly/versions/0.4.3/requires
@@ -14,3 +14,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.4.3/requires
+++ b/Gadfly/versions/0.4.3/requires
@@ -14,4 +14,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.4.4/requires
+++ b/Gadfly/versions/0.4.4/requires
@@ -14,3 +14,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.4.4/requires
+++ b/Gadfly/versions/0.4.4/requires
@@ -14,4 +14,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.5.0/requires
+++ b/Gadfly/versions/0.5.0/requires
@@ -14,4 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.5.0/requires
+++ b/Gadfly/versions/0.5.0/requires
@@ -14,3 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.5.1/requires
+++ b/Gadfly/versions/0.5.1/requires
@@ -14,4 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.5.1/requires
+++ b/Gadfly/versions/0.5.1/requires
@@ -14,3 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.5.2/requires
+++ b/Gadfly/versions/0.5.2/requires
@@ -14,4 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.5.2/requires
+++ b/Gadfly/versions/0.5.2/requires
@@ -14,3 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.5.3/requires
+++ b/Gadfly/versions/0.5.3/requires
@@ -14,4 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.5.3/requires
+++ b/Gadfly/versions/0.5.3/requires
@@ -14,3 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.6.0/requires
+++ b/Gadfly/versions/0.6.0/requires
@@ -14,4 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.6.0/requires
+++ b/Gadfly/versions/0.6.0/requires
@@ -14,3 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.6.1/requires
+++ b/Gadfly/versions/0.6.1/requires
@@ -14,4 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.6.1/requires
+++ b/Gadfly/versions/0.6.1/requires
@@ -14,3 +14,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.6.2/requires
+++ b/Gadfly/versions/0.6.2/requires
@@ -15,4 +15,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.6.2/requires
+++ b/Gadfly/versions/0.6.2/requires
@@ -15,3 +15,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.6.3/requires
+++ b/Gadfly/versions/0.6.3/requires
@@ -5,7 +5,7 @@ Compose 0.5.2
 Contour 0.1.1
 CoupledFields
 DataFrames 0.4.2 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataStructures
 Distributions
 Hexagons
@@ -16,4 +16,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.6.3/requires
+++ b/Gadfly/versions/0.6.3/requires
@@ -16,3 +16,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/Gadfly/versions/0.6.4/requires
+++ b/Gadfly/versions/0.6.4/requires
@@ -5,7 +5,7 @@ Compose 0.5.2
 Contour 0.1.1
 CoupledFields
 DataFrames 0.4.2 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataStructures
 Distributions
 Hexagons
@@ -16,4 +16,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Gadfly/versions/0.6.4/requires
+++ b/Gadfly/versions/0.6.4/requires
@@ -16,3 +16,4 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+DataArrays 0.0.1 0.7.0

--- a/GeoIP/versions/0.0.0/requires
+++ b/GeoIP/versions/0.0.0/requires
@@ -1,1 +1,2 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/GeoIP/versions/0.0.0/requires
+++ b/GeoIP/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/GeoIP/versions/0.1.0/requires
+++ b/GeoIP/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.3
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/GeoIP/versions/0.2.0/requires
+++ b/GeoIP/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 IPNets
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 ZipFile
 Requests

--- a/GeoIP/versions/0.2.0/requires
+++ b/GeoIP/versions/0.2.0/requires
@@ -1,4 +1,5 @@
 IPNets
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 ZipFile
 Requests

--- a/GeoIP/versions/0.2.1/requires
+++ b/GeoIP/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 IPNets
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 ZipFile 0.2.4
 Requests

--- a/GeoIP/versions/0.2.1/requires
+++ b/GeoIP/versions/0.2.1/requires
@@ -1,4 +1,5 @@
 IPNets
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 ZipFile 0.2.4
 Requests

--- a/GeoIP/versions/0.2.2/requires
+++ b/GeoIP/versions/0.2.2/requires
@@ -1,5 +1,6 @@
 julia 0.3
 IPNets
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 ZipFile 0.2.4
 Requests 0.2.4

--- a/GeoIP/versions/0.2.2/requires
+++ b/GeoIP/versions/0.2.2/requires
@@ -1,6 +1,6 @@
 julia 0.3
 IPNets
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 ZipFile 0.2.4
 Requests 0.2.4

--- a/GoogleCharts/versions/0.0.0/requires
+++ b/GoogleCharts/versions/0.0.0/requires
@@ -2,3 +2,4 @@ Mustache
 DataFrames 0.0.0 0.11.0
 Calendar 
 JSON
+DataArrays 0.0.1 0.7.0

--- a/GoogleCharts/versions/0.0.0/requires
+++ b/GoogleCharts/versions/0.0.0/requires
@@ -2,4 +2,4 @@ Mustache
 DataFrames 0.0.0 0.11.0
 Calendar 
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/GoogleCharts/versions/0.0.1/requires
+++ b/GoogleCharts/versions/0.0.1/requires
@@ -3,4 +3,4 @@ Mustache
 DataFrames 0.0.0 0.11.0
 Datetime
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/GoogleCharts/versions/0.0.1/requires
+++ b/GoogleCharts/versions/0.0.1/requires
@@ -3,3 +3,4 @@ Mustache
 DataFrames 0.0.0 0.11.0
 Datetime
 JSON
+DataArrays 0.0.1 0.7.0

--- a/GoogleCharts/versions/0.0.2/requires
+++ b/GoogleCharts/versions/0.0.2/requires
@@ -1,6 +1,6 @@
 julia 0.2-
 Mustache
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Datetime
 JSON

--- a/GoogleCharts/versions/0.0.3/requires
+++ b/GoogleCharts/versions/0.0.3/requires
@@ -1,6 +1,6 @@
 julia 0.3-
 Mustache
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Datetime
 JSON

--- a/GoogleCharts/versions/0.0.4/requires
+++ b/GoogleCharts/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 julia 0.4-
 Mustache
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 JSON

--- a/GoogleCharts/versions/0.0.5/requires
+++ b/GoogleCharts/versions/0.0.5/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Mustache
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 JSON

--- a/GoogleCharts/versions/0.0.6/requires
+++ b/GoogleCharts/versions/0.0.6/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Mustache
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 JSON

--- a/GoogleCharts/versions/0.0.7/requires
+++ b/GoogleCharts/versions/0.0.7/requires
@@ -1,6 +1,6 @@
 julia 0.3
 Mustache
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Dates
 JSON

--- a/GraphGLRM/versions/0.2.1/requires
+++ b/GraphGLRM/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 LowRankModels
 LightGraphs
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 StatsBase

--- a/InteractiveFixedEffectModels/versions/0.1.0/requires
+++ b/InteractiveFixedEffectModels/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.5-
 Distances  0.1.1
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.11.0
 LeastSquaresOptim 0.2.0
 Reexport

--- a/InteractiveFixedEffectModels/versions/0.1.1/requires
+++ b/InteractiveFixedEffectModels/versions/0.1.1/requires
@@ -1,7 +1,7 @@
 julia 0.5
 Distances  0.1.1
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.11.0
 LeastSquaresOptim 0.2.0
 Reexport

--- a/InteractiveFixedEffectModels/versions/0.2.0/requires
+++ b/InteractiveFixedEffectModels/versions/0.2.0/requires
@@ -1,7 +1,7 @@
 julia 0.6.0-pre
 Distances  0.1.1
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.11.0
 LeastSquaresOptim 0.3.0
 Reexport

--- a/InteractiveFixedEffectModels/versions/0.2.1/requires
+++ b/InteractiveFixedEffectModels/versions/0.2.1/requires
@@ -1,7 +1,7 @@
 julia 0.6.0-pre
 Distances  0.1.1
 StatsBase 0.7.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.6 0.11.0
 LeastSquaresOptim 0.4.0
 Reexport

--- a/Jags/versions/0.1.0/requires
+++ b/Jags/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.3 0.4-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba

--- a/Jags/versions/0.1.1/requires
+++ b/Jags/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.3 0.4-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba

--- a/Jags/versions/0.1.2/requires
+++ b/Jags/versions/0.1.2/requires
@@ -1,3 +1,3 @@
 julia 0.3 0.4-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba

--- a/Jags/versions/0.1.3/requires
+++ b/Jags/versions/0.1.3/requires
@@ -1,3 +1,3 @@
 julia 0.3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba

--- a/Jags/versions/0.1.4/requires
+++ b/Jags/versions/0.1.4/requires
@@ -1,3 +1,3 @@
 julia 0.3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba

--- a/Jags/versions/0.1.5/requires
+++ b/Jags/versions/0.1.5/requires
@@ -1,3 +1,3 @@
 julia 0.3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba

--- a/Jags/versions/0.2.0/requires
+++ b/Jags/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba

--- a/Jags/versions/1.0.0/requires
+++ b/Jags/versions/1.0.0/requires
@@ -1,3 +1,3 @@
 julia 0.5.0-rc3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba 0.10.0

--- a/Jags/versions/1.0.1/requires
+++ b/Jags/versions/1.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5.0-rc3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba 0.10.0

--- a/Jags/versions/1.0.2/requires
+++ b/Jags/versions/1.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5.0-rc3
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Mamba 0.10.0

--- a/LazyQuery/versions/0.0.1/requires
+++ b/LazyQuery/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 MacroTools
 LazyContext 0.0.1 0.1.0
 Query 0.0.0 0.7.0

--- a/LazyQuery/versions/0.0.1/requires
+++ b/LazyQuery/versions/0.0.1/requires
@@ -1,5 +1,6 @@
 julia 0.5
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 MacroTools
 LazyContext 0.0.1 0.1.0
 Query 0.0.0 0.7.0

--- a/LazyQuery/versions/0.1.0/requires
+++ b/LazyQuery/versions/0.1.0/requires
@@ -1,6 +1,7 @@
 julia 0.6
 LazyContext 0.1.1
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 MacroTools 0.3.3
 Query 0.0.1 0.7.0
 NamedTuples

--- a/LazyQuery/versions/0.1.0/requires
+++ b/LazyQuery/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 LazyContext 0.1.1
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 MacroTools 0.3.3
 Query 0.0.1 0.7.0
 NamedTuples

--- a/LazyQuery/versions/0.1.1/requires
+++ b/LazyQuery/versions/0.1.1/requires
@@ -6,4 +6,4 @@ Query 0.0.1 0.7.0
 NamedTuples
 ChainRecursive 0.0.3
 LazyCall 0.1.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/LazyQuery/versions/0.1.2/requires
+++ b/LazyQuery/versions/0.1.2/requires
@@ -6,4 +6,4 @@ Query 0.0.0 0.8.0
 NamedTuples
 ChainRecursive 0.0.3
 LazyCall 0.1.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/LazyQuery/versions/0.1.3/requires
+++ b/LazyQuery/versions/0.1.3/requires
@@ -6,4 +6,4 @@ Query 0.0.0 0.8.0
 NamedTuples
 ChainRecursive 0.0.3
 LazyCall 0.1.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MarketTechnicals/versions/0.0.0/requires
+++ b/MarketTechnicals/versions/0.0.0/requires
@@ -3,3 +3,4 @@ DataFrames 0.0.0 0.11.0
 Calendar
 UTF16
 TimeSeries
+DataArrays 0.0.1 0.7.0

--- a/MarketTechnicals/versions/0.0.0/requires
+++ b/MarketTechnicals/versions/0.0.0/requires
@@ -3,4 +3,4 @@ DataFrames 0.0.0 0.11.0
 Calendar
 UTF16
 TimeSeries
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MarketTechnicals/versions/0.1.1/requires
+++ b/MarketTechnicals/versions/0.1.1/requires
@@ -1,4 +1,4 @@
 TimeSeries
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/MarketTechnicals/versions/0.1.2/requires
+++ b/MarketTechnicals/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 TimeSeries
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/MarketTechnicals/versions/0.1.3/requires
+++ b/MarketTechnicals/versions/0.1.3/requires
@@ -1,4 +1,4 @@
 TimeSeries
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/MarketTechnicals/versions/0.1.4/requires
+++ b/MarketTechnicals/versions/0.1.4/requires
@@ -1,4 +1,4 @@
 TimeSeries
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/MarketTechnicals/versions/0.1.5/requires
+++ b/MarketTechnicals/versions/0.1.5/requires
@@ -1,4 +1,4 @@
 TimeSeries
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/MixedModels/versions/0.10.0/requires
+++ b/MixedModels/versions/0.10.0/requires
@@ -3,7 +3,7 @@ ArgCheck
 BlockArrays
 CategoricalArrays 0.0.1 0.2.0
 Compat 0.19.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataStructures
 DataFrames 0.9 0.11.0
 Distributions 0.11

--- a/MixedModels/versions/0.11.0/requires
+++ b/MixedModels/versions/0.11.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ArgCheck
 BlockArrays
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.9 0.11.0
 Distributions 0.11
 GLM 0.7

--- a/MixedModels/versions/0.12.0/requires
+++ b/MixedModels/versions/0.12.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ArgCheck
 BlockArrays
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.9 0.11.0
 Distributions 0.11
 GLM 0.7

--- a/MixedModels/versions/0.3.0/requires
+++ b/MixedModels/versions/0.3.0/requires
@@ -2,4 +2,4 @@ julia 0.3- 0.6
 GLM 0.3-
 NLopt 0.0.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.0/requires
+++ b/MixedModels/versions/0.3.0/requires
@@ -2,3 +2,4 @@ julia 0.3- 0.6
 GLM 0.3-
 NLopt 0.0.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.1/requires
+++ b/MixedModels/versions/0.3.1/requires
@@ -4,4 +4,4 @@ DataFrames 0.5- 0.11.0
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.1/requires
+++ b/MixedModels/versions/0.3.1/requires
@@ -4,3 +4,4 @@ DataFrames 0.5- 0.11.0
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.10/requires
+++ b/MixedModels/versions/0.3.10/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.10/requires
+++ b/MixedModels/versions/0.3.10/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.12/requires
+++ b/MixedModels/versions/0.3.12/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.12/requires
+++ b/MixedModels/versions/0.3.12/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.13/requires
+++ b/MixedModels/versions/0.3.13/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.13/requires
+++ b/MixedModels/versions/0.3.13/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.14/requires
+++ b/MixedModels/versions/0.3.14/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.14/requires
+++ b/MixedModels/versions/0.3.14/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.15/requires
+++ b/MixedModels/versions/0.3.15/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.15/requires
+++ b/MixedModels/versions/0.3.15/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.16/requires
+++ b/MixedModels/versions/0.3.16/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.16/requires
+++ b/MixedModels/versions/0.3.16/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.17/requires
+++ b/MixedModels/versions/0.3.17/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.17/requires
+++ b/MixedModels/versions/0.3.17/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.18/requires
+++ b/MixedModels/versions/0.3.18/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.18/requires
+++ b/MixedModels/versions/0.3.18/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.19/requires
+++ b/MixedModels/versions/0.3.19/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.19/requires
+++ b/MixedModels/versions/0.3.19/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.2/requires
+++ b/MixedModels/versions/0.3.2/requires
@@ -4,3 +4,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.2/requires
+++ b/MixedModels/versions/0.3.2/requires
@@ -4,4 +4,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.20/requires
+++ b/MixedModels/versions/0.3.20/requires
@@ -4,4 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.20/requires
+++ b/MixedModels/versions/0.3.20/requires
@@ -4,3 +4,4 @@ Distributions
 NLopt 0.1-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.21/requires
+++ b/MixedModels/versions/0.3.21/requires
@@ -7,4 +7,4 @@ NLopt 0.2-
 PDMats 0.3-
 Showoff
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.21/requires
+++ b/MixedModels/versions/0.3.21/requires
@@ -7,3 +7,4 @@ NLopt 0.2-
 PDMats 0.3-
 Showoff
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.22/requires
+++ b/MixedModels/versions/0.3.22/requires
@@ -7,4 +7,4 @@ NLopt 0.2-
 PDMats 0.3-
 Showoff
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.22/requires
+++ b/MixedModels/versions/0.3.22/requires
@@ -7,3 +7,4 @@ NLopt 0.2-
 PDMats 0.3-
 Showoff
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.3/requires
+++ b/MixedModels/versions/0.3.3/requires
@@ -5,4 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.3/requires
+++ b/MixedModels/versions/0.3.3/requires
@@ -5,3 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.4/requires
+++ b/MixedModels/versions/0.3.4/requires
@@ -5,4 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.4/requires
+++ b/MixedModels/versions/0.3.4/requires
@@ -5,3 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.5/requires
+++ b/MixedModels/versions/0.3.5/requires
@@ -5,4 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.5/requires
+++ b/MixedModels/versions/0.3.5/requires
@@ -5,3 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.6/requires
+++ b/MixedModels/versions/0.3.6/requires
@@ -5,4 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.6/requires
+++ b/MixedModels/versions/0.3.6/requires
@@ -5,3 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.7/requires
+++ b/MixedModels/versions/0.3.7/requires
@@ -5,4 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.7/requires
+++ b/MixedModels/versions/0.3.7/requires
@@ -5,3 +5,4 @@ NLopt 0.0.3-
 NumericExtensions 0.6-
 NumericFuns 0.2-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.8/requires
+++ b/MixedModels/versions/0.3.8/requires
@@ -6,3 +6,4 @@ NumericExtensions 0.6-
 NumericFuns 0.2-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.8/requires
+++ b/MixedModels/versions/0.3.8/requires
@@ -6,4 +6,4 @@ NumericExtensions 0.6-
 NumericFuns 0.2-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.3.9/requires
+++ b/MixedModels/versions/0.3.9/requires
@@ -6,3 +6,4 @@ NumericExtensions 0.6-
 NumericFuns 0.2-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.3.9/requires
+++ b/MixedModels/versions/0.3.9/requires
@@ -6,4 +6,4 @@ NumericExtensions 0.6-
 NumericFuns 0.2-
 PDMats 0.2.3-
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.4.0/requires
+++ b/MixedModels/versions/0.4.0/requires
@@ -4,4 +4,4 @@ Distributions 0.6+
 NLopt 0.2+
 Showoff
 StatsBase 0 0.8.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.4.0/requires
+++ b/MixedModels/versions/0.4.0/requires
@@ -4,3 +4,4 @@ Distributions 0.6+
 NLopt 0.2+
 Showoff
 StatsBase 0 0.8.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.4.1/requires
+++ b/MixedModels/versions/0.4.1/requires
@@ -5,3 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0 0.8.0
 CategoricalArrays 0.0.1 0.2.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.4.1/requires
+++ b/MixedModels/versions/0.4.1/requires
@@ -5,4 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0 0.8.0
 CategoricalArrays 0.0.1 0.2.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.4.2/requires
+++ b/MixedModels/versions/0.4.2/requires
@@ -5,3 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0 0.8.0
 CategoricalArrays 0.0.1 0.2.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.4.2/requires
+++ b/MixedModels/versions/0.4.2/requires
@@ -5,4 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0 0.8.0
 CategoricalArrays 0.0.1 0.2.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.4.3/requires
+++ b/MixedModels/versions/0.4.3/requires
@@ -5,3 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0 0.8.0
 CategoricalArrays 0.0.1 0.2.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.4.3/requires
+++ b/MixedModels/versions/0.4.3/requires
@@ -5,4 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0 0.8.0
 CategoricalArrays 0.0.1 0.2.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.4.4/requires
+++ b/MixedModels/versions/0.4.4/requires
@@ -5,3 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0 0.8.0
 CategoricalArrays 0.0.1 0.2.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.4.4/requires
+++ b/MixedModels/versions/0.4.4/requires
@@ -5,4 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0 0.8.0
 CategoricalArrays 0.0.1 0.2.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.4.5/requires
+++ b/MixedModels/versions/0.4.5/requires
@@ -5,3 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0.8.0
 CategoricalArrays 0.0.1 0.2.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.4.5/requires
+++ b/MixedModels/versions/0.4.5/requires
@@ -5,4 +5,4 @@ NLopt 0.2
 Showoff
 StatsBase 0.8.0
 CategoricalArrays 0.0.1 0.2.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.5.0/requires
+++ b/MixedModels/versions/0.5.0/requires
@@ -6,4 +6,4 @@ NLopt 0.2
 Showoff
 StatsBase 0.8.0
 CategoricalArrays 0.0.1 0.2.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.5.0/requires
+++ b/MixedModels/versions/0.5.0/requires
@@ -6,3 +6,4 @@ NLopt 0.2
 Showoff
 StatsBase 0.8.0
 CategoricalArrays 0.0.1 0.2.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.5.1/requires
+++ b/MixedModels/versions/0.5.1/requires
@@ -6,4 +6,4 @@ NLopt 0.2
 Showoff
 StatsBase 0.8.0
 CategoricalArrays 0.0.1 0.2.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/MixedModels/versions/0.5.1/requires
+++ b/MixedModels/versions/0.5.1/requires
@@ -6,3 +6,4 @@ NLopt 0.2
 Showoff
 StatsBase 0.8.0
 CategoricalArrays 0.0.1 0.2.0
+DataArrays 0.0.1 0.7.0

--- a/MixedModels/versions/0.5.2/requires
+++ b/MixedModels/versions/0.5.2/requires
@@ -6,5 +6,5 @@ NLopt 0.3
 Showoff
 StatsBase 0.8.0
 Compat 0.7.17
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 CategoricalArrays 0.0.1 0.2.0

--- a/MixedModels/versions/0.5.3/requires
+++ b/MixedModels/versions/0.5.3/requires
@@ -6,5 +6,5 @@ NLopt 0.3
 Showoff
 StatsBase 0.8.0
 Compat 0.7.17
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 CategoricalArrays 0.0.1 0.2.0

--- a/MixedModels/versions/0.5.4/requires
+++ b/MixedModels/versions/0.5.4/requires
@@ -7,5 +7,5 @@ Showoff
 StatsBase 0.8.0
 StatsFuns 0.2.0
 Compat 0.7.20
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 CategoricalArrays 0.0.1 0.2.0

--- a/MixedModels/versions/0.5.5/requires
+++ b/MixedModels/versions/0.5.5/requires
@@ -7,5 +7,5 @@ Showoff
 StatsBase 0.8.2
 StatsFuns 0.2.0
 Compat 0.8.4
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 CategoricalArrays 0.0.1 0.2.0

--- a/MixedModels/versions/0.5.6/requires
+++ b/MixedModels/versions/0.5.6/requires
@@ -7,5 +7,5 @@ Showoff
 StatsBase 0.8.2
 StatsFuns 0.2.0
 Compat 0.8.4
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 CategoricalArrays 0.0.1 0.2.0

--- a/MixedModels/versions/0.5.7/requires
+++ b/MixedModels/versions/0.5.7/requires
@@ -7,5 +7,5 @@ Showoff
 StatsBase 0.8.2
 StatsFuns 0.2.0
 Compat 0.8.4
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 CategoricalArrays 0.0.1 0.2.0

--- a/MixedModels/versions/0.5.8/requires
+++ b/MixedModels/versions/0.5.8/requires
@@ -7,5 +7,5 @@ Showoff
 StatsBase 0.11
 StatsFuns 0.2.0
 Compat 0.8.4
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 CategoricalArrays 0.0.1 0.2.0

--- a/MixedModels/versions/0.6.0/requires
+++ b/MixedModels/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6

--- a/MixedModels/versions/0.6.1/requires
+++ b/MixedModels/versions/0.6.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6

--- a/MixedModels/versions/0.6.2/requires
+++ b/MixedModels/versions/0.6.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.6.3/requires
+++ b/MixedModels/versions/0.6.3/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.7.0/requires
+++ b/MixedModels/versions/0.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.7.2/requires
+++ b/MixedModels/versions/0.7.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.7.3/requires
+++ b/MixedModels/versions/0.7.3/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.7.4/requires
+++ b/MixedModels/versions/0.7.4/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.7.5/requires
+++ b/MixedModels/versions/0.7.5/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.7.6/requires
+++ b/MixedModels/versions/0.7.6/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.7.7/requires
+++ b/MixedModels/versions/0.7.7/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.8.4 0.11.0
 Distributions 0.11
 GLM 0.6.1

--- a/MixedModels/versions/0.8.0/requires
+++ b/MixedModels/versions/0.8.0/requires
@@ -2,7 +2,7 @@ julia 0.5
 ArgCheck
 CategoricalArrays 0.0.1 0.2.0
 Compat 0.19.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataStructures
 DataFrames 0.9 0.11.0
 Distributions 0.11

--- a/MixedModels/versions/0.9.0/requires
+++ b/MixedModels/versions/0.9.0/requires
@@ -3,7 +3,7 @@ ArgCheck
 BlockArrays
 CategoricalArrays 0.0.1 0.2.0
 Compat 0.19.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataStructures
 DataFrames 0.9 0.11.0
 Distributions 0.11

--- a/RCall/versions/0.0.1/requires
+++ b/RCall/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.0.2/requires
+++ b/RCall/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.0.3/requires
+++ b/RCall/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.1.0/requires
+++ b/RCall/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.1.1/requires
+++ b/RCall/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.1 0.6
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.1.2/requires
+++ b/RCall/versions/0.1.2/requires
@@ -1,6 +1,6 @@
 julia 0.1 0.6
 BinDeps
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.2.0/requires
+++ b/RCall/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.1 0.6
 BinDeps
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.2.1/requires
+++ b/RCall/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.1 0.6
 BinDeps
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.3.0/requires
+++ b/RCall/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.3 0.6
 BinDeps
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.3.1/requires
+++ b/RCall/versions/0.3.1/requires
@@ -1,6 +1,6 @@
 julia 0.3 0.6
 BinDeps
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.3.2/requires
+++ b/RCall/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.3 0.6
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Docile

--- a/RCall/versions/0.4.0/requires
+++ b/RCall/versions/0.4.0/requires
@@ -1,3 +1,3 @@
 julia 0.4 0.6
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/RCall/versions/0.4.1/requires
+++ b/RCall/versions/0.4.1/requires
@@ -1,4 +1,4 @@
 julia 0.4 0.6
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 @windows WinReg

--- a/RCall/versions/0.5.0/requires
+++ b/RCall/versions/0.5.0/requires
@@ -1,6 +1,6 @@
 julia 0.4
 DataStructures
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Compat
 @windows WinReg

--- a/RData/versions/0.0.1/requires
+++ b/RData/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.4
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 FileIO
 GZip
 Compat

--- a/RDatasets/versions/0.0.0/requires
+++ b/RDatasets/versions/0.0.0/requires
@@ -1,1 +1,2 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/RDatasets/versions/0.0.0/requires
+++ b/RDatasets/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/RDatasets/versions/0.0.1/requires
+++ b/RDatasets/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/RDatasets/versions/0.0.1/requires
+++ b/RDatasets/versions/0.0.1/requires
@@ -1,2 +1,3 @@
 julia 0.2-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/RDatasets/versions/0.0.2/requires
+++ b/RDatasets/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/RDatasets/versions/0.0.2/requires
+++ b/RDatasets/versions/0.0.2/requires
@@ -1,2 +1,3 @@
 julia 0.2-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/RDatasets/versions/0.1.0/requires
+++ b/RDatasets/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.2-
 DataArrays 0.1- 0.7.0
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/RDatasets/versions/0.1.0/requires
+++ b/RDatasets/versions/0.1.0/requires
@@ -1,3 +1,4 @@
 julia 0.2-
 DataArrays 0.1- 0.7.0
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/RDatasets/versions/0.1.1/requires
+++ b/RDatasets/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/RDatasets/versions/0.1.2/requires
+++ b/RDatasets/versions/0.1.2/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
 Reexport
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/RDatasets/versions/0.1.2/requires
+++ b/RDatasets/versions/0.1.2/requires
@@ -1,2 +1,3 @@
 DataFrames 0.0.0 0.11.0
 Reexport
+DataArrays 0.0.1 0.7.0

--- a/RDatasets/versions/0.1.3/requires
+++ b/RDatasets/versions/0.1.3/requires
@@ -2,3 +2,4 @@ julia 0.3
 DataFrames 0.0.0 0.11.0
 Reexport
 Compat
+DataArrays 0.0.1 0.7.0

--- a/RDatasets/versions/0.1.3/requires
+++ b/RDatasets/versions/0.1.3/requires
@@ -2,4 +2,4 @@ julia 0.3
 DataFrames 0.0.0 0.11.0
 Reexport
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/RDatasets/versions/0.2.0/requires
+++ b/RDatasets/versions/0.2.0/requires
@@ -4,4 +4,4 @@ Reexport
 Compat
 RData
 FileIO
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/RDatasets/versions/0.2.0/requires
+++ b/RDatasets/versions/0.2.0/requires
@@ -4,3 +4,4 @@ Reexport
 Compat
 RData
 FileIO
+DataArrays 0.0.1 0.7.0

--- a/ReadStat/versions/0.1.0/requires
+++ b/ReadStat/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 NullableArrays
 DataFrames 0.0.0 0.11.0
 DataTables

--- a/ReadStat/versions/0.1.1/requires
+++ b/ReadStat/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 NullableArrays
 DataFrames 0.0.0 0.11.0
 DataTables

--- a/Robotlib/versions/0.0.1/requires
+++ b/Robotlib/versions/0.0.1/requires
@@ -1,7 +1,7 @@
 julia 0.4
 MAT
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Plots
 StatsBase
 Quaternions

--- a/Robotlib/versions/0.0.2/requires
+++ b/Robotlib/versions/0.0.2/requires
@@ -1,7 +1,7 @@
 julia 0.4
 MAT
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Plots
 StatsBase
 Quaternions

--- a/Robotlib/versions/0.1.0/requires
+++ b/Robotlib/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 MAT
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 RecipesBase
 Plots
 StatsBase

--- a/Robotlib/versions/0.2.0/requires
+++ b/Robotlib/versions/0.2.0/requires
@@ -1,7 +1,7 @@
 julia 0.6.0-pre
 MAT
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 RecipesBase
 Plots
 StatsBase

--- a/Robotlib/versions/0.2.1/requires
+++ b/Robotlib/versions/0.2.1/requires
@@ -1,7 +1,7 @@
 julia 0.6.0-pre
 MAT
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 RecipesBase
 Plots
 StatsBase

--- a/Robotlib/versions/0.2.2/requires
+++ b/Robotlib/versions/0.2.2/requires
@@ -1,7 +1,7 @@
 julia 0.6.0
 MAT
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 RecipesBase
 StatsBase
 Quaternions

--- a/RobustStats/versions/0.0.0/requires
+++ b/RobustStats/versions/0.0.0/requires
@@ -1,6 +1,6 @@
 julia 0.1 0.4
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Rmath
 StatsBase
 Distributions

--- a/RobustStats/versions/0.0.0/requires
+++ b/RobustStats/versions/0.0.0/requires
@@ -1,5 +1,6 @@
 julia 0.1 0.4
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 Rmath
 StatsBase
 Distributions

--- a/RobustStats/versions/0.0.1/requires
+++ b/RobustStats/versions/0.0.1/requires
@@ -1,7 +1,7 @@
 julia 0.3- 0.4
 
 DataFrames 0.5- 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Rmath
 StatsBase 0.3.7-
 Distributions 0.4-

--- a/SALSA/versions/0.0.1/requires
+++ b/SALSA/versions/0.0.1/requires
@@ -5,6 +5,6 @@ Compat
 StatsBase
 Distances
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Clustering

--- a/SALSA/versions/0.0.2/requires
+++ b/SALSA/versions/0.0.2/requires
@@ -5,6 +5,6 @@ Compat
 StatsBase
 Distances
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Clustering

--- a/SALSA/versions/0.0.3/requires
+++ b/SALSA/versions/0.0.3/requires
@@ -5,6 +5,6 @@ Compat
 StatsBase
 Distances
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Clustering

--- a/SALSA/versions/0.0.4/requires
+++ b/SALSA/versions/0.0.4/requires
@@ -5,6 +5,6 @@ Compat
 StatsBase
 Distances
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Clustering

--- a/SQLite/versions/0.1.1/requires
+++ b/SQLite/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.2- 0.4
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/SQLite/versions/0.1.2/requires
+++ b/SQLite/versions/0.1.2/requires
@@ -1,4 +1,4 @@
 julia 0.2- 0.4
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 BinDeps

--- a/SQLite/versions/0.1.3/requires
+++ b/SQLite/versions/0.1.3/requires
@@ -1,6 +1,6 @@
 julia 0.2- 0.4
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 BinDeps
 @osx Homebrew
 @windows WinRPM

--- a/SQLite/versions/0.1.4/requires
+++ b/SQLite/versions/0.1.4/requires
@@ -1,6 +1,6 @@
 julia 0.2- 0.4
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 BinDeps
 @osx Homebrew
 @windows WinRPM

--- a/SQLite/versions/0.1.5/requires
+++ b/SQLite/versions/0.1.5/requires
@@ -1,6 +1,6 @@
 julia 0.2- 0.4
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 BinDeps
 @osx Homebrew
 @windows WinRPM

--- a/SQLite/versions/0.1.6/requires
+++ b/SQLite/versions/0.1.6/requires
@@ -1,6 +1,6 @@
 julia 0.2- 0.4
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 BinDeps
 @osx Homebrew
 @windows WinRPM

--- a/Taro/versions/0.1.0/requires
+++ b/Taro/versions/0.1.0/requires
@@ -1,2 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Taro/versions/0.1.0/requires
+++ b/Taro/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Taro/versions/0.1.1/requires
+++ b/Taro/versions/0.1.1/requires
@@ -1,2 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Taro/versions/0.1.1/requires
+++ b/Taro/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Taro/versions/0.1.2/requires
+++ b/Taro/versions/0.1.2/requires
@@ -1,2 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Taro/versions/0.1.2/requires
+++ b/Taro/versions/0.1.2/requires
@@ -1,3 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Taro/versions/0.1.3/requires
+++ b/Taro/versions/0.1.3/requires
@@ -1,2 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Taro/versions/0.1.3/requires
+++ b/Taro/versions/0.1.3/requires
@@ -1,3 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Taro/versions/0.1.4/requires
+++ b/Taro/versions/0.1.4/requires
@@ -1,2 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Taro/versions/0.1.4/requires
+++ b/Taro/versions/0.1.4/requires
@@ -1,3 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Taro/versions/0.2.0/requires
+++ b/Taro/versions/0.2.0/requires
@@ -1,2 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0

--- a/Taro/versions/0.2.0/requires
+++ b/Taro/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Taro/versions/0.2.1/requires
+++ b/Taro/versions/0.2.1/requires
@@ -2,3 +2,4 @@ julia 0.3
 JavaCall
 DataFrames 0.0.0 0.11.0
 Compat
+DataArrays 0.0.1 0.7.0

--- a/Taro/versions/0.2.1/requires
+++ b/Taro/versions/0.2.1/requires
@@ -2,4 +2,4 @@ julia 0.3
 JavaCall
 DataFrames 0.0.0 0.11.0
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Taro/versions/0.3.0/requires
+++ b/Taro/versions/0.3.0/requires
@@ -2,4 +2,4 @@ julia 0.4
 JavaCall
 DataFrames 0.0.0 0.11.0
 Compat
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0

--- a/Taro/versions/0.3.0/requires
+++ b/Taro/versions/0.3.0/requires
@@ -2,3 +2,4 @@ julia 0.4
 JavaCall
 DataFrames 0.0.0 0.11.0
 Compat
+DataArrays 0.0.1 0.7.0

--- a/Taro/versions/0.3.1/requires
+++ b/Taro/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.4
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Compat

--- a/Taro/versions/0.4.0/requires
+++ b/Taro/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.4
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Compat 0.8

--- a/Taro/versions/0.5.0/requires
+++ b/Taro/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 JavaCall
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Compat 0.8

--- a/TermWin/versions/0.0.1/requires
+++ b/TermWin/versions/0.0.1/requires
@@ -1,1 +1,2 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.10/requires
+++ b/TermWin/versions/0.0.10/requires
@@ -1,3 +1,4 @@
 Lint
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.11/requires
+++ b/TermWin/versions/0.0.11/requires
@@ -2,3 +2,4 @@ Lint
 Dates
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.12/requires
+++ b/TermWin/versions/0.0.12/requires
@@ -2,3 +2,4 @@ Lint
 Dates
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.13/requires
+++ b/TermWin/versions/0.0.13/requires
@@ -1,3 +1,4 @@
 Lint
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.14/requires
+++ b/TermWin/versions/0.0.14/requires
@@ -1,3 +1,4 @@
 Lint 0.1.17
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.15/requires
+++ b/TermWin/versions/0.0.15/requires
@@ -1,3 +1,4 @@
 Lint 0.1.17
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.16/requires
+++ b/TermWin/versions/0.0.16/requires
@@ -1,3 +1,4 @@
 Lint 0.1.17
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.17/requires
+++ b/TermWin/versions/0.0.17/requires
@@ -2,3 +2,4 @@ Lint 0.1.17
 julia 0.3-
 Compat 0.1
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.18/requires
+++ b/TermWin/versions/0.0.18/requires
@@ -2,3 +2,4 @@ Lint 0.1.17
 julia 0.3-
 Compat 0.1
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.19/requires
+++ b/TermWin/versions/0.0.19/requires
@@ -2,3 +2,4 @@ Lint 0.1.17
 julia 0.3-
 Compat 0.1
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.2/requires
+++ b/TermWin/versions/0.0.2/requires
@@ -1,1 +1,2 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.20/requires
+++ b/TermWin/versions/0.0.20/requires
@@ -2,3 +2,4 @@ Lint 0.1.17
 julia 0.3-
 Compat 0.1
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.21/requires
+++ b/TermWin/versions/0.0.21/requires
@@ -3,3 +3,4 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.1
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.22/requires
+++ b/TermWin/versions/0.0.22/requires
@@ -3,3 +3,4 @@ julia 0.3-
 Compat 0.1
 Formatting 0.1.1
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.23/requires
+++ b/TermWin/versions/0.0.23/requires
@@ -2,5 +2,5 @@ Lint 0.1.55
 julia 0.3-
 Compat 0.1
 Formatting 0.1.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/TermWin/versions/0.0.24/requires
+++ b/TermWin/versions/0.0.24/requires
@@ -2,5 +2,5 @@ Lint 0.1.55
 julia 0.3-
 Compat 0.1
 Formatting 0.1.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/TermWin/versions/0.0.25/requires
+++ b/TermWin/versions/0.0.25/requires
@@ -2,6 +2,6 @@ Lint 0.1.55
 julia 0.3-
 Compat 0.1
 Formatting 0.1.1
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.26/requires
+++ b/TermWin/versions/0.0.26/requires
@@ -2,6 +2,6 @@ Lint 0.1.58
 julia 0.3-
 Compat 0.1
 Formatting 0.1.2
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.27/requires
+++ b/TermWin/versions/0.0.27/requires
@@ -2,6 +2,6 @@ Lint 0.1.58
 julia 0.3-
 Compat 0.1
 Formatting 0.1.2
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.28/requires
+++ b/TermWin/versions/0.0.28/requires
@@ -2,6 +2,6 @@ Lint 0.1.58
 julia 0.3-
 Compat 0.1
 Formatting 0.1.2
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.29/requires
+++ b/TermWin/versions/0.0.29/requires
@@ -2,6 +2,6 @@ Lint 0.1.58
 julia 0.3-
 Compat 0.1
 Formatting 0.1.2
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.3/requires
+++ b/TermWin/versions/0.0.3/requires
@@ -1,1 +1,2 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.30/requires
+++ b/TermWin/versions/0.0.30/requires
@@ -2,6 +2,6 @@ Lint 0.1.58
 julia 0.3-
 Compat 0.1
 Formatting 0.1.2
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 DataFramesMeta

--- a/TermWin/versions/0.0.31/requires
+++ b/TermWin/versions/0.0.31/requires
@@ -2,7 +2,7 @@ Lint 0.1.60
 julia 0.3-
 Compat 0.1
 Formatting 0.1.2
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 DataFramesMeta
 Lazy

--- a/TermWin/versions/0.0.4/requires
+++ b/TermWin/versions/0.0.4/requires
@@ -1,1 +1,2 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.5/requires
+++ b/TermWin/versions/0.0.5/requires
@@ -1,1 +1,2 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.6/requires
+++ b/TermWin/versions/0.0.6/requires
@@ -1,3 +1,4 @@
 Lint
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.7/requires
+++ b/TermWin/versions/0.0.7/requires
@@ -1,3 +1,4 @@
 Lint
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.8/requires
+++ b/TermWin/versions/0.0.8/requires
@@ -1,3 +1,4 @@
 Lint
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TermWin/versions/0.0.9/requires
+++ b/TermWin/versions/0.0.9/requires
@@ -1,3 +1,4 @@
 Lint
 julia 0.3-
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.0 0.7.0

--- a/TimeData/versions/0.0.1/requires
+++ b/TimeData/versions/0.0.1/requires
@@ -1,3 +1,4 @@
 julia 0.2-
 DataFrames 0.4.1 0.11.0
+DataArrays 0.0.1 0.7.0
 Datetime 0.1.2

--- a/TimeData/versions/0.0.1/requires
+++ b/TimeData/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.2-
 DataFrames 0.4.1 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime 0.1.2

--- a/TimeSeries/versions/0.0.0/requires
+++ b/TimeSeries/versions/0.0.0/requires
@@ -1,5 +1,5 @@
 StatsBase
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Calendar
 UTF16

--- a/TimeSeries/versions/0.0.0/requires
+++ b/TimeSeries/versions/0.0.0/requires
@@ -1,4 +1,5 @@
 StatsBase
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 Calendar
 UTF16

--- a/TimeSeries/versions/0.0.1/requires
+++ b/TimeSeries/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 StatsBase
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Calendar
 UTF16

--- a/TimeSeries/versions/0.0.1/requires
+++ b/TimeSeries/versions/0.0.1/requires
@@ -1,4 +1,5 @@
 StatsBase
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 Calendar
 UTF16

--- a/TimeSeries/versions/0.1.0/requires
+++ b/TimeSeries/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.0/requires
+++ b/TimeSeries/versions/0.1.0/requires
@@ -1,2 +1,3 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.1/requires
+++ b/TimeSeries/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.1/requires
+++ b/TimeSeries/versions/0.1.1/requires
@@ -1,2 +1,3 @@
 DataFrames 0.0.0 0.11.0
+DataArrays 0.0.1 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.2/requires
+++ b/TimeSeries/versions/0.1.2/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.3/requires
+++ b/TimeSeries/versions/0.1.3/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.4/requires
+++ b/TimeSeries/versions/0.1.4/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.5/requires
+++ b/TimeSeries/versions/0.1.5/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.6/requires
+++ b/TimeSeries/versions/0.1.6/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/TimeSeries/versions/0.1.7/requires
+++ b/TimeSeries/versions/0.1.7/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/TimeSeries/versions/0.2.0/requires
+++ b/TimeSeries/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 DataFrames 0.0.0 0.11.0
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 Datetime

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.1/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.2/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.3/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.4/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.4/requires
@@ -1,4 +1,4 @@
 julia 0.4
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.0.5/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.0.5/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/ValueOrientedRiskManagementInsurance/versions/0.1.0/requires
+++ b/ValueOrientedRiskManagementInsurance/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 Distributions
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/WorldBankData/versions/0.0.1/requires
+++ b/WorldBankData/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 HTTPClient
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/WorldBankData/versions/0.0.2/requires
+++ b/WorldBankData/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 HTTPClient
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/WorldBankData/versions/0.0.3/requires
+++ b/WorldBankData/versions/0.0.3/requires
@@ -1,4 +1,4 @@
 HTTPClient
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/WorldBankData/versions/0.0.4/requires
+++ b/WorldBankData/versions/0.0.4/requires
@@ -1,5 +1,5 @@
 HTTPClient
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Compat

--- a/WorldBankData/versions/0.0.5/requires
+++ b/WorldBankData/versions/0.0.5/requires
@@ -1,6 +1,6 @@
 julia 0.3
 HTTPClient
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0
 Compat

--- a/WorldBankData/versions/0.0.6/requires
+++ b/WorldBankData/versions/0.0.6/requires
@@ -1,5 +1,5 @@
 julia 0.6
 HTTP
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0

--- a/WorldBankData/versions/0.1.0/requires
+++ b/WorldBankData/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 HTTP
 JSON
-DataArrays 0.0.1 0.7.0
+DataArrays 0.0.0 0.7.0
 DataFrames 0.0.0 0.11.0


### PR DESCRIPTION
@tkelman noted at https://github.com/JuliaLang/METADATA.jl/pull/12189 that I forgot to add upper bounds to older releases of DataArrays dependencies which did not depend on it yet, which means that the package manager may downgrade these packages. The check was quite tedious, but overall there aren't many problematic situations, since almost all packages either also depended on DataFrames (which itself depended on DataArrays, so adding the dependency is OK) or were very old (so that an upper bounds on Julia 0.6 is fine). The only case where I added an upper bound on Julia 0.6 to a relatively recent package is EasyPhys 0.1.3, but well...

For reference, the command I found to identify packages which depended on DataArrays in some but not all releases:
```sh
grep -Rl DataArrays | sed "s/\/.*$//g" | uniq | xargs grep -RL DataArrays | grep requires | sed "s/\/.*$//g" | uniq
```
(By removing the last two commands, you get the list of releases which do not depend on DataArrays. That's only a problem if there are more recent releases which do depend on it.)

This gives:
```
Benchmarks: added DataArrays bounds since it also depended on DataFrames
DataArrays: ...
DataFrames: added julia 0.6 upper bound since only old releases did not depend on DataArrays
Discretizers: only old versions depended on DataArrays, so OK
FactorModels: already has an upper bound on julia 0.6
Feather: added DataArrays bounds since it also depended on DataFrames
Gadfly: added DataArrays bounds since it also depended on DataFrames
GeoIP: added DataArrays bounds since it also depended on DataFrames
GoogleCharts: added DataArrays bounds since it also depended on DataFrames
MarketTechnicals: added DataArrays bounds since it also depended on DataFrames (version 0.0.0 only)
MixedModels:  added DataArrays bounds to  since it also depended on DataFrames (versions 0.3.0 to 0.5.1, since others are OK or have an upper bound on julia 0.6)
NormalizeQuantiles: only older releases depended on DataArrays
RCall: only older releases depended on DataArrays
RDatasets: added DataArrays bounds since it also depended on DataFrames
RobustStats: added DataArrays bounds since it also depended on DataFrames
SALSA: only older releases depended on DataArrays
SQLite: only older releases depended on DataArrays, except one release which has julia 0.4 upper bound
Taro: added DataArrays bounds since it also depended on DataFrames
TermWin: added julia 0.6 upper bound since only old releases did not depend on DataArrays
TimeData: added DataArrays bounds since it also depended on DataFrames (only old releases)
TimeSeries: added DataArrays bounds since it also depended on DataFrames (only old releases) 
EasyPhys: added julia 0.6 upper bound to version 0.1.3 since it was the only release not to depend on DataArrays
LazyQuery: added DataArrays bounds since it also depended on DataFrames
```