### PR TITLE
Reverts https://github.com/JuliaLang/METADATA.jl/pull/12106/

### DIFF
--- a/Gallium/versions/0.0.1/requires
+++ b/Gallium/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.5- 0.6
+julia 0.5-
 TerminalUI
 DWARF
 ELF

--- a/Gallium/versions/0.0.2/requires
+++ b/Gallium/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.5- 0.6
+julia 0.5-
 TerminalUI
 DWARF
 ObjFileBase

--- a/Gallium/versions/0.0.3/requires
+++ b/Gallium/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.5- 0.6
+julia 0.5-
 TerminalUI
 DWARF
 ObjFileBase

--- a/Gallium/versions/0.0.4/requires
+++ b/Gallium/versions/0.0.4/requires
@@ -1,4 +1,4 @@
-julia 0.5- 0.6
+julia 0.5-
 TerminalUI
 DWARF
 ObjFileBase


### PR DESCRIPTION
The user's who have already installed older versions of Gallium and pinned it's version, are now unable to perform `Pkg.add()` operations because of this change, reverting this PR will avoid user's from encountering this issue in future.