### PR TITLE
Tag CUDAdrv.jl v0.7.0

### DIFF
--- a/CUBLAS/versions/0.2.0/requires
+++ b/CUBLAS/versions/0.2.0/requires
@@ -1,2 +1,2 @@
 julia 0.6
-CUDAdrv 0.5.0
+CUDAdrv 0.5.0 0.7.0

--- a/CUBLAS/versions/0.2.1/requires
+++ b/CUBLAS/versions/0.2.1/requires
@@ -1,2 +1,2 @@
 julia 0.6
-CUDAdrv 0.5.0
+CUDAdrv 0.5.0 0.7.0

--- a/CUBLAS/versions/0.2.2/requires
+++ b/CUBLAS/versions/0.2.2/requires
@@ -1,2 +1,2 @@
 julia 0.6
-CUDAdrv 0.5.0
+CUDAdrv 0.5.0 0.7.0

--- a/CUDAdrv/versions/0.7.0/requires
+++ b/CUDAdrv/versions/0.7.0/requires
@@ -1,0 +1,3 @@
+julia 0.6
+Compat 0.33.0
+CUDAapi 0.1.1

--- a/CUDAdrv/versions/0.7.0/sha1
+++ b/CUDAdrv/versions/0.7.0/sha1
@@ -1,0 +1,1 @@
+9dc229600e70223b4ab4cfab7bc23e4b36da7bf0

--- a/CUDAnative/versions/0.5.1/requires
+++ b/CUDAnative/versions/0.5.1/requires
@@ -1,4 +1,4 @@
 julia 0.6
-CUDAdrv 0.5.0
+CUDAdrv 0.5.0 0.7.0
 LLVM 0.3.11
 CUDAapi

--- a/CUDAnative/versions/0.5.2/requires
+++ b/CUDAnative/versions/0.5.2/requires
@@ -1,4 +1,4 @@
 julia 0.6
-CUDAdrv 0.5.0
+CUDAdrv 0.5.0 0.7.0
 LLVM 0.3.11
 CUDAapi 0.1.3

--- a/CUDAnative/versions/0.5.3/requires
+++ b/CUDAnative/versions/0.5.3/requires
@@ -1,4 +1,4 @@
 julia 0.6
-CUDAdrv 0.5.0
+CUDAdrv 0.5.0 0.7.0
 LLVM 0.3.11
 CUDAapi 0.1.3

--- a/CUDAnativelib/versions/0.0.1/requires
+++ b/CUDAnativelib/versions/0.0.1/requires
@@ -2,4 +2,4 @@ julia 0.6-
 CUDAnative
 Reexport
 Cxx
-CUDAdrv
+CUDAdrv 0.1.0 0.7.0

--- a/CUDArt/versions/0.3.0/requires
+++ b/CUDArt/versions/0.3.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
 Compat 0.18.0
-CUDAdrv 0.2.4
+CUDAdrv 0.2.4 0.7.0

--- a/CUDArt/versions/0.3.1/requires
+++ b/CUDArt/versions/0.3.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
 Compat 0.18.0
-CUDAdrv 0.2.4
+CUDAdrv 0.2.4 0.7.0

--- a/CUDArt/versions/0.3.2/requires
+++ b/CUDArt/versions/0.3.2/requires
@@ -1,3 +1,3 @@
 julia 0.5
 Compat 0.18.0
-CUDAdrv 0.4.1
+CUDAdrv 0.4.1 0.7.0

--- a/CUDArt/versions/0.4.0/requires
+++ b/CUDArt/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Compat 0.18.0
-CUDAdrv 0.4.1
+CUDAdrv 0.4.1 0.7.0
 CUDAapi

--- a/CUDArt/versions/0.4.1/requires
+++ b/CUDArt/versions/0.4.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Compat 0.18.0
-CUDAdrv 0.4.1
+CUDAdrv 0.4.1 0.7.0
 CUDAapi

--- a/CUDNN/versions/0.4.0/requires
+++ b/CUDNN/versions/0.4.0/requires
@@ -1,3 +1,3 @@
 Compat
-CUDAdrv
+CUDAdrv 0.1.0 0.7.0
 julia 0.6

--- a/CURAND/versions/0.1.0/requires
+++ b/CURAND/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.6
-CUDAdrv 0.5.0
+CUDAdrv 0.5.0 0.7.0

--- a/CuArrays/versions/0.1.0/requires
+++ b/CuArrays/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 CUDAnative 0.4
-CUDAdrv 0.5
+CUDAdrv 0.5 0.7.0
 CUBLAS

--- a/CuArrays/versions/0.1.1/requires
+++ b/CuArrays/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 CUDAnative 0.5
-CUDAdrv 0.5
+CUDAdrv 0.5 0.7.0
 CUBLAS 0.2.2
 CUDNN 0.4.0
 NNlib

--- a/CuArrays/versions/0.2.0/requires
+++ b/CuArrays/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 CUDAnative 0.5
-CUDAdrv 0.5
+CUDAdrv 0.5 0.7.0
 CUDAapi
 CUDNN 0.4.0
 NNlib

--- a/CuArrays/versions/0.2.1/requires
+++ b/CuArrays/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
 CUDAnative 0.5
-CUDAdrv 0.5
+CUDAdrv 0.5 0.7.0
 CUDAapi
 NNlib

--- a/CuArrays/versions/0.3.0/requires
+++ b/CuArrays/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 CUDAnative 0.5
-CUDAdrv 0.5
+CUDAdrv 0.5 0.7.0
 CUDAapi
 NNlib
 GPUArrays

--- a/GPUArrays/versions/0.1.0/requires
+++ b/GPUArrays/versions/0.1.0/requires
@@ -7,7 +7,7 @@ Sugar 0.3 0.4
 Matcha 0.0.2
 
 CUDAnative 0.4.1 # llvm codegen fix
-CUDAdrv 0.5.1
+CUDAdrv 0.5.1 0.7.0
 CUDArt 0.4.0 # for cuda c compiler support
 CUBLAS 0.2.0 # for CUDAdrv support
 CUFFT


### PR DESCRIPTION
Same as #12179, with additional commit for changing bounds on other packages.

Repository: [JuliaGPU/CUDAdrv.jl](https://github.com/JuliaGPU/CUDAdrv.jl)
Release: [v0.7.0](https://github.com/JuliaGPU/CUDAdrv.jl/releases/tag/v0.7.0)
Diff: [vs v0.6.1](https://github.com/JuliaGPU/CUDAdrv.jl/compare/dccdaa0f39477e9570b5c24d0b15ac849e93582f...9dc229600e70223b4ab4cfab7bc23e4b36da7bf0)
`requires` vs v0.6.1: no changes

I plan on using the 0.7.x versions of CUDAdrv to remove CuArray in favor of CuArrays.jl.
This is a breaking change, hard to deprecate (as CuArrays.CuArray isn't meant to be identical to CUDAdrv.CuArray), so I've just added upper bounds to all packages using CUDAdrv.
Not sure whether that's the best approach though.
