### PR TITLE
Add AutoGrad v0.0.10 to the grandfather list

### DIFF
--- a/.test/list_3582.jl
+++ b/.test/list_3582.jl
@@ -44,7 +44,7 @@ maxver_list_3582 = Dict([ # List of grandfathered packages
     ("Atom", v"0.6.5"),
     ("AudioIO", v"0.1.1"),
     ("Augur", v"0.1.1"),
-    ("AutoGrad", v"0.0.9"),
+    ("AutoGrad", v"0.0.10"),
     ("AutoHashEquals", v"0.0.10"),
     ("AutoTypeParameters", v"0.0.3"),
     ("Autoreload", v"0.2.0"),


### PR DESCRIPTION
Addresses issue introduced in https://github.com/JuliaLang/METADATA.jl/pull/12489