### PR TITLE
Tag MFCC v0.2.0 [https://github.com/davidavdav/MFCC.jl]

### DIFF
--- a/MFCC/versions/0.2.0/requires
+++ b/MFCC/versions/0.2.0/requires
@@ -1,0 +1,7 @@
+julia 0.6
+DSP
+HDF5
+JLD
+WAV
+FileIO
+SpecialFunctions

--- a/MFCC/versions/0.2.0/sha1
+++ b/MFCC/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+e1adfaa57a730f9efa5c9245ada3e863ff2f702a


### PR DESCRIPTION
This PR makes MFCC compatible with Julia-0.6 again.   Code has not changed much, but we're dropping support for Julia-0.5 and earlier. 

Diff vs v0.1.1: https://github.com/davidavdav/MFCC.jl/compare/0b7cbdd56a10987f62e6e1f8e2864824f98e9ec8...e1adfaa57a730f9efa5c9245ada3e863ff2f702a