### PR TITLE
Remove unnecessary upper bounds on NLSolversBase in LineSearches.

### DIFF
--- a/LineSearches/versions/3.0.0/requires
+++ b/LineSearches/versions/3.0.0/requires
@@ -1,3 +1,3 @@
 julia 0.6
-NLSolversBase 3.0 4.0
+NLSolversBase 3.0
 Parameters

--- a/LineSearches/versions/3.0.1/requires
+++ b/LineSearches/versions/3.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.6
-NLSolversBase 3.0 4.0
+NLSolversBase 3.0
 Parameters

--- a/LineSearches/versions/3.1.0/requires
+++ b/LineSearches/versions/3.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.6
-NLSolversBase 3.0 4.0
+NLSolversBase 3.0
 Parameters

--- a/LineSearches/versions/3.2.0/requires
+++ b/LineSearches/versions/3.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
-NLSolversBase 3.0 4.0
+NLSolversBase 3.0
 Parameters
 NaNMath

--- a/LineSearches/versions/3.2.1/requires
+++ b/LineSearches/versions/3.2.1/requires
@@ -1,4 +1,4 @@
 julia 0.6
-NLSolversBase 3.0 4.0
+NLSolversBase 3.0
 Parameters
 NaNMath

--- a/LineSearches/versions/3.2.2/requires
+++ b/LineSearches/versions/3.2.2/requires
@@ -1,4 +1,4 @@
 julia 0.6
-NLSolversBase 3.0 4.0
+NLSolversBase 3.0
 Parameters
 NaNMath

--- a/LineSearches/versions/3.2.3/requires
+++ b/LineSearches/versions/3.2.3/requires
@@ -1,4 +1,4 @@
 julia 0.6
-NLSolversBase 3.0 4.0
+NLSolversBase 3.0
 Parameters
 NaNMath


### PR DESCRIPTION
These weren't necessary after all, so no need to have them, as it'll just force us to tag a new LineSearches.jl