### PR TITLE
Update FourierFlows url

### DIFF
--- a/FourierFlows/url
+++ b/FourierFlows/url
@@ -1,1 +1,1 @@
-https://github.com/navidcy/FourierFlows.jl.git
+https://github.com/FourierFlows/FourierFlows.jl.git


### PR DESCRIPTION
The repository was moved from my personal GitHub account to an organization named "FourierFlows".