### PR TITLE
Improve the PR check for changing SHAs

### DIFF
--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -77,8 +77,8 @@ changed, added = cd(ENV["TRAVIS_BUILD_DIR"]) do
     # Compare the current commit with the default branch upstream, returning
     # a string containing a newline-delimited list of files changed. We only
     # care about additions (A) and modifications (M).
-    _changed = filter_diff(PR_COMMIT_SHA, upstream_commit, "AM")
-    _added = filter_diff(PR_COMMIT_SHA, upstream_commit, "A")
+    _changed = filter_diff(upstream_commit, PR_COMMIT_SHA, "AM")
+    _added = filter_diff(upstream_commit, PR_COMMIT_SHA, "A")
 
     # Separate each list into a vector and return both changed and added
     (split(_changed, '\n'), split(_added, '\n'))


### PR DESCRIPTION
This adjusts the logic for checking whether policy 8 (don't change the SHA of an existing tag) is violated. In particular, it explicitly adds JuliaLang/METADATA.jl as a remote, fetches from it, and compares its head commit against the current commit SHA in the PR, as given by Travis. Hopefully this will improve the reliability of this sporadically incorrect check.