### PR TITLE
Support testing on private METADATA again

### DIFF
--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -74,7 +74,7 @@ changed, added = cd(BUILD_DIR) do
     (filter_diff("M"), filter_diff("A"))
 end
 
-if isempty(changed) && isempty(added) && ENV["TRAVIS_EVENT_TYPE"] == "pull_request"
+if isempty(changed) && isempty(added) && get(ENV, "TRAVIS_EVENT_TYPE", "unknown") == "pull_request"
     warn("No changes between the PR and the base branch have been detected, which is " *
          "probably wrong.")
 else

--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -1,6 +1,10 @@
 # The full path where the repository is cloned and where the job is run
 const BUILD_DIR = ENV["BUILD_DIR"]
 
+# Avoid using the merge commit when checking for changes as sometimes this can result
+# in extra changes being found during the diff.
+const HEAD = get(ENV, "TRAVIS_PULL_REQUEST_SHA", "HEAD")
+
 function get_remote_tags(url)
     ls = try
         readchomp(`git ls-remote --tags -q $url`)
@@ -64,7 +68,7 @@ function get_local_tags(dir)
     return localtags
 end
 
-function filter_diff(filt, commit1="origin/HEAD", commit2="HEAD")
+function filter_diff(filt, commit1="origin/HEAD", commit2=HEAD)
     split(readchomp(`git diff --name-only --diff-filter=$filt $commit1 $commit2`), '\n')
 end
 

--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -64,8 +64,9 @@ function get_local_tags(dir)
     return localtags
 end
 
-filter_diff(commit1, commit2, filt) =
-    readchomp(`git diff --name-only --diff-filter=$filt $commit1 $commit2`)
+function filter_diff(commit1, commit2, filt)
+    split(readchomp(`git diff --name-only --diff-filter=$filt $commit1 $commit2`), '\n')
+end
 
 changed, added = cd(ENV["TRAVIS_BUILD_DIR"]) do
     # Ensure that JuliaLang/METADATA.jl is a registered remote by adding it
@@ -80,8 +81,7 @@ changed, added = cd(ENV["TRAVIS_BUILD_DIR"]) do
     _changed = filter_diff(upstream_commit, PR_COMMIT_SHA, "M")
     _added = filter_diff(upstream_commit, PR_COMMIT_SHA, "A")
 
-    # Separate each list into a vector and return both changed and added
-    (split(_changed, '\n'), split(_added, '\n'))
+    (_changed, _added)
 end
 
 if isempty(changed) && isempty(added) && ENV["TRAVIS_EVENT_TYPE"] == "pull_request"

--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -1,4 +1,6 @@
+# The full path where the repository is cloned and where the job is run
 const BUILD_DIR = ENV["BUILD_DIR"]
+
 const PR_COMMIT_SHA = ENV["TRAVIS_PULL_REQUEST_SHA"]
 
 function get_remote_tags(url)
@@ -68,7 +70,7 @@ function filter_diff(commit1, commit2, filt)
     split(readchomp(`git diff --name-only --diff-filter=$filt $commit1 $commit2`), '\n')
 end
 
-changed, added = cd(ENV["TRAVIS_BUILD_DIR"]) do
+changed, added = cd(BUILD_DIR) do
     # Ensure that JuliaLang/METADATA.jl is a registered remote by adding it
     # explicitly (this is okay even if it's the same as an existing remote)
     run(`git remote add _upstream https://github.com/JuliaLang/METADATA.jl.git`)

--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -78,8 +78,8 @@ if isempty(changed) && isempty(added) && ENV["TRAVIS_EVENT_TYPE"] == "pull_reque
     warn("No changes between the PR and the base branch have been detected, which is " *
          "probably wrong.")
 else
-    info("Files modified in this PR: $changed")
-    info("Files added in this PR: $added")
+    info("Files modified in this PR:\n$(join(changed, '\n'))")
+    info("Files added in this PR:\n$(join(added, '\n'))")
     for file in changed
         if endswith(file, "sha1")
             # policy 8, do not modify existing published tag sha1's

--- a/.test/ci.sh
+++ b/.test/ci.sh
@@ -6,6 +6,9 @@ BUILD_DIR=$PWD
 [ -z "$JULIA_PKGDIR" ] && JULIA_PKGDIR=$HOME/.julia
 export BUILD_DIR JULIA_PKGDIR
 
+# Ensure that "origin/HEAD" is present (typically set to "origin/metadata-v2")
+git fetch origin +:refs/remotes/origin/HEAD
+
 # Need to be on a local or remote branch for check_metadata
 git checkout -q --detach HEAD && git branch -D localbranch 2>/dev/null || true
 git checkout -b localbranch


### PR DESCRIPTION
The changes introduced in https://github.com/JuliaLang/METADATA.jl/pull/12891 break support for private METADATA which run tests on other CI systems (GitLab CI for example).

Key take aways for maintaining support for alternative CI testing:
- Avoid requiring Travis CI specific environment variables "TRAVIS_*"
- Avoid interacting with "https://github.com/JuliaLang/METADATA.jl.git" and instead use `origin`
- Use `origin/HEAD` instead of `origin/metadata-v2` as private METADATAs may use a different remote head name