### PR TITLE
Tag ROCAnalysis v0.2.0 [https://github.com/davidavdav/ROCAnalysis.jl]

### DIFF
--- a/ROCAnalysis/versions/0.2.0/requires
+++ b/ROCAnalysis/versions/0.2.0/requires
@@ -1,0 +1,8 @@
+julia 0.6
+Requires 0.4
+Missings 0.2
+DataArrays 0.7
+DataFrames 0.11
+## only for testing
+CSV 0.2
+GZip 0.3

--- a/ROCAnalysis/versions/0.2.0/sha1
+++ b/ROCAnalysis/versions/0.2.0/sha1
@@ -1,0 +1,1 @@
+21aef7e498ed9210aa96ebcfdbd481d0cc117df0


### PR DESCRIPTION
This brings this package up to date with julia-0.6, and drops support for 0.5. 

Diff vs v0.1.0: https://github.com/davidavdav/ROCAnalysis.jl/compare/487dd1fd9fcb6959b400f6013edde1adde2b5834...21aef7e498ed9210aa96ebcfdbd481d0cc117df0