### PR TITLE
Use common ancestor for git diff

### DIFF
--- a/.test/check-pr.jl
+++ b/.test/check-pr.jl
@@ -3,7 +3,7 @@ const BUILD_DIR = ENV["BUILD_DIR"]
 
 # Avoid using the merge commit when checking for changes as sometimes this can result
 # in extra changes being found during the diff.
-const HEAD = get(ENV, "TRAVIS_PULL_REQUEST_SHA", "HEAD")
+const DIFF_HEAD = get(ENV, "TRAVIS_PULL_REQUEST_SHA", "HEAD")
 
 function get_remote_tags(url)
     ls = try
@@ -68,8 +68,12 @@ function get_local_tags(dir)
     return localtags
 end
 
-function filter_diff(filt, commit1="origin/HEAD", commit2=HEAD)
-    split(readchomp(`git diff --name-only --diff-filter=$filt $commit1 $commit2`), '\n')
+function filter_diff(filt, commit1="origin/HEAD", commit2=DIFF_HEAD)
+    # Determine what files have changed between `commit2` and the common ancestor of
+    # `commit1` and `commit2`. The common ancestor is used avoid returning extra files
+    # when `commit1` is ahead of `commit2`.
+    # See: https://git-scm.com/docs/git-diff#git-diff-emgitdiffem--optionsltcommitgtltcommitgt--ltpathgt82308203
+    split(readchomp(`git diff --name-only --diff-filter=$filt $commit1...$commit2`), '\n')
 end
 
 # Compare the current commit with the default branch upstream, returning a list of files


### PR DESCRIPTION
> "git diff A...B" is equivalent to "git diff $(git-merge-base A B) B"

When running the "check-pr.jl" tests we use `git diff` to verify that no METADATA files were modified which should remain constant. When we use `git diff A B` we can potentially see changes which occurred outside of the scope of the PR.

I believe (I haven't fully validated this) that it's caused from the `origin/HEAD` being updated and being newer than the HEAD.