### PR TITLE
Restrict CUDAdrv 0.8+ to Julia 0.7

### DIFF
--- a/CUDAdrv/versions/0.8.0/requires
+++ b/CUDAdrv/versions/0.8.0/requires
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7-
 Compat 0.50.0
 CUDAapi 0.4.0


### PR DESCRIPTION
Not sure if its OK to retroactively change REQUIRES like that. But there's incompatibilities between CUDAdrv 0.8.0 and CUDAnative for Julia 0.6, so I'd rather bake this in METADATA. It also keeps the breaking API changes to Julia 0.7 users.