### PR TITLE
Clean up the log

### DIFF
--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -153,7 +153,9 @@ for (pkg, versions) in Pkg.Read.available()
                     same_minor(x::VersionNumber) = (majmin(x) == majmin(ver) &&
                         juliaver_in_require(pkg, x; check=false) < juliaver)
                     ind_same_minor = findfirst(same_minor, sortedversions)
-                    ind_same_minor == 0 && continue
+                    if ind_same_minor == (VERSION < v"0.7.0-DEV.3399" ? 0 : nothing)
+                        continue
+                    end
                     first_same_minor = sortedversions[ind_same_minor]
                     juliaver_prev = juliaver_in_require(pkg, first_same_minor; check=false)
                     if majmin(juliaver) > majmin(juliaver_prev)

--- a/.test/METADATA.jl
+++ b/.test/METADATA.jl
@@ -1,3 +1,9 @@
+@static if VERSION < v"0.7.0-DEV.3656"
+    const Pkg = Base.Pkg
+else
+    import Pkg
+end
+
 cd(Pkg.dir()) # Required by some Pkg functions
 
 const url_reg = r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?"

--- a/.test/ci.sh
+++ b/.test/ci.sh
@@ -27,7 +27,7 @@ for ver in 0.5 0.6 nightly; do
   curl -A "$CI_NAME for METADATA tests $(curl --version | head -n 1)" -L --retry 5 $url | \
     tar -C julia-$ver --strip-components=1 -xzf - && \
     julia-$ver/bin/julia -e 'versioninfo(); include("$(ENV["BUILD_DIR"])/.test/METADATA.jl")' && \
-    touch success-$ver &
+    touch success-$ver
 done
 wait
 if ! [ -e success-0.5 -a -e success-0.6 ]; then # nightly allowed to fail


### PR DESCRIPTION
Merging ~~https://github.com/JuliaLang/julia/pull/25662~~ https://github.com/JuliaLang/julia/pull/25472 ~~broke the version testing here~~ printed an error in the log which is confusing when the tests fail for some other reason or because of timeout.

The `Pkg` deprecation warning also added a lot of noise. Finally, I've disabled running the tests in parallel. It completely messes up the log and was the original reason why I missed an error. It will make each build slower but I guess it shouldn't have an effect on the overall throughput since we can just run more builds concurrently. Is that a correct interpretation of Travis?