### PR TITLE
Revert "bound OrdinaryDiffEq for DiffEqDiffTools"

### DIFF
--- a/OrdinaryDiffEq/versions/3.0.0/requires
+++ b/OrdinaryDiffEq/versions/3.0.0/requires
@@ -6,7 +6,7 @@ GenericSVD 0.0.2
 NLsolve 0.12.1
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.3.0 0.4.0
+DiffEqDiffTools 0.3.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/3.0.1/requires
+++ b/OrdinaryDiffEq/versions/3.0.1/requires
@@ -6,7 +6,7 @@ GenericSVD 0.0.2
 NLsolve 0.14.1
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.3.0 0.4.0
+DiffEqDiffTools 0.3.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/3.0.2/requires
+++ b/OrdinaryDiffEq/versions/3.0.2/requires
@@ -6,7 +6,7 @@ GenericSVD 0.0.2
 NLsolve 0.14.1
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.3.0 0.4.0
+DiffEqDiffTools 0.3.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/3.0.3/requires
+++ b/OrdinaryDiffEq/versions/3.0.3/requires
@@ -6,7 +6,7 @@ GenericSVD 0.0.2
 NLsolve 0.14.1
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.3.0 0.4.0
+DiffEqDiffTools 0.3.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/3.1.0/requires
+++ b/OrdinaryDiffEq/versions/3.1.0/requires
@@ -6,7 +6,7 @@ GenericSVD 0.0.2
 NLsolve 0.14.1
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.3.0 0.4.0
+DiffEqDiffTools 0.3.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/3.1.1/requires
+++ b/OrdinaryDiffEq/versions/3.1.1/requires
@@ -6,7 +6,7 @@ GenericSVD 0.0.2
 NLsolve 0.14.1
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.3.0 0.4.0
+DiffEqDiffTools 0.3.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0


### PR DESCRIPTION
Reverts JuliaLang/METADATA.jl#13371 . While technically this upper bound is needed to stop breakage in the Rosenbrock algorithms, it seems that the resolver has problems with more upper bounds so we should just allow it to happen. 