### PR TITLE
undo the DiffEq 4.0 upper bounds

### DIFF
--- a/AlgebraicDiffEq/versions/0.0.1/requires
+++ b/AlgebraicDiffEq/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Parameters 0.5.0
 Sundials 0.3.0
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/AlgebraicDiffEq/versions/0.0.2/requires
+++ b/AlgebraicDiffEq/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Parameters 0.5.0
 Sundials 0.3.0
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/AlgebraicDiffEq/versions/0.1.0/requires
+++ b/AlgebraicDiffEq/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
 Parameters 0.5.0
-DiffEqBase 0.2.0 3.0.0
+DiffEqBase 0.2.0

--- a/BoundaryValueDiffEq/versions/0.0.1/requires
+++ b/BoundaryValueDiffEq/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1
 Reexport
 NLsolve 0.1 0.14
 DiffEqDiffTools 0.0.2 0.1.0

--- a/BoundaryValueDiffEq/versions/0.1.0/requires
+++ b/BoundaryValueDiffEq/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1
 Reexport
 NLsolve 0.1 0.14
 DiffEqDiffTools 0.0.2 0.1.0

--- a/BoundaryValueDiffEq/versions/0.2.0/requires
+++ b/BoundaryValueDiffEq/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1
 Reexport
 NLsolve 0.1 0.14
 DiffEqDiffTools 0.1.0 0.2.0

--- a/BoundaryValueDiffEq/versions/0.3.0/requires
+++ b/BoundaryValueDiffEq/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1
 Reexport
 NLsolve 0.1 0.14
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 BandedMatrices

--- a/ChaosTools/versions/0.1.0/requires
+++ b/ChaosTools/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DynamicalSystemsBase 0.1.0 0.1.1
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 LsqFit 0.3.0

--- a/ChaosTools/versions/0.2.0/requires
+++ b/ChaosTools/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DynamicalSystemsBase 0.2.0 0.2.1
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 LsqFit 0.3.0

--- a/ChaosTools/versions/0.2.1/requires
+++ b/ChaosTools/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DynamicalSystemsBase 0.2.0 0.2.1
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 LsqFit 0.3.0

--- a/ChaosTools/versions/0.3.0/requires
+++ b/ChaosTools/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DynamicalSystemsBase 0.2.1 0.2.2
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 LsqFit 0.3.0

--- a/ChaosTools/versions/0.4.0/requires
+++ b/ChaosTools/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DynamicalSystemsBase 0.3.1 0.4
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 LsqFit 0.3.0

--- a/ChaosTools/versions/0.4.1/requires
+++ b/ChaosTools/versions/0.4.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DynamicalSystemsBase 0.4 0.5
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 LsqFit 0.3.0

--- a/ChaosTools/versions/0.4.2/requires
+++ b/ChaosTools/versions/0.4.2/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DynamicalSystemsBase 0.4 0.5
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 LsqFit 0.3.0

--- a/DASKR/versions/0.1.0/requires
+++ b/DASKR/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.5
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/DASKR/versions/0.1.1/requires
+++ b/DASKR/versions/0.1.1/requires
@@ -1,2 +1,2 @@
 julia 0.5
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/DASKR/versions/0.2.0/requires
+++ b/DASKR/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Compat 0.17.0

--- a/DASKR/versions/0.3.0/requires
+++ b/DASKR/versions/0.3.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Compat 0.17.0

--- a/DASKR/versions/0.4.0/requires
+++ b/DASKR/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Compat 0.17.0
 Reexport

--- a/DASKR/versions/0.5.0/requires
+++ b/DASKR/versions/0.5.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Compat 0.17.0
 Reexport

--- a/DASSL/versions/0.0.1/requires
+++ b/DASSL/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/DASSL/versions/0.0.2/requires
+++ b/DASSL/versions/0.0.2/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/DASSL/versions/0.0.3/requires
+++ b/DASSL/versions/0.0.3/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/DASSL/versions/0.0.4/requires
+++ b/DASSL/versions/0.0.4/requires
@@ -1,2 +1,2 @@
 julia 0.3-
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/DASSL/versions/0.1.0/requires
+++ b/DASSL/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.4
 FactCheck
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/DASSL/versions/0.2.0/requires
+++ b/DASSL/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
 FactCheck
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/DASSL/versions/0.2.1/requires
+++ b/DASSL/versions/0.2.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
 FactCheck
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/DASSL/versions/0.3.0/requires
+++ b/DASSL/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 FactCheck
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Reexport

--- a/DelayDiffEq/versions/0.0.1/requires
+++ b/DelayDiffEq/versions/0.0.1/requires
@@ -4,4 +4,4 @@ OrdinaryDiffEq 1.0.0 1.2.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.1.2
 Combinatorics
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.1.0/requires
+++ b/DelayDiffEq/versions/0.1.0/requires
@@ -4,4 +4,4 @@ OrdinaryDiffEq 1.2.0 2.15.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.10.0/requires
+++ b/DelayDiffEq/versions/0.10.0/requires
@@ -7,4 +7,4 @@ Combinatorics
 Compat 0.17.0
 Reexport
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.2.0/requires
+++ b/DelayDiffEq/versions/0.2.0/requires
@@ -4,4 +4,4 @@ OrdinaryDiffEq 1.6.0 2.15.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.3.0/requires
+++ b/DelayDiffEq/versions/0.3.0/requires
@@ -4,4 +4,4 @@ OrdinaryDiffEq 1.6.0 2.15.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.4.0/requires
+++ b/DelayDiffEq/versions/0.4.0/requires
@@ -5,4 +5,4 @@ DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics
 Compat 0.17.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.5.0/requires
+++ b/DelayDiffEq/versions/0.5.0/requires
@@ -6,4 +6,4 @@ RecursiveArrayTools 0.2.0
 Combinatorics
 Compat 0.17.0
 Reexport
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.5.1/requires
+++ b/DelayDiffEq/versions/0.5.1/requires
@@ -6,4 +6,4 @@ RecursiveArrayTools 0.2.0
 Combinatorics
 Compat 0.17.0
 Reexport
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.5.2/requires
+++ b/DelayDiffEq/versions/0.5.2/requires
@@ -6,4 +6,4 @@ RecursiveArrayTools 0.2.0
 Combinatorics
 Compat 0.17.0
 Reexport
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.6.0/requires
+++ b/DelayDiffEq/versions/0.6.0/requires
@@ -7,4 +7,4 @@ Combinatorics
 Compat 0.17.0
 Reexport
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.7.0/requires
+++ b/DelayDiffEq/versions/0.7.0/requires
@@ -7,4 +7,4 @@ Combinatorics
 Compat 0.17.0
 Reexport
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.8.0/requires
+++ b/DelayDiffEq/versions/0.8.0/requires
@@ -7,4 +7,4 @@ Combinatorics
 Compat 0.17.0
 Reexport
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.9.0/requires
+++ b/DelayDiffEq/versions/0.9.0/requires
@@ -7,4 +7,4 @@ Combinatorics
 Compat 0.17.0
 Reexport
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/0.9.1/requires
+++ b/DelayDiffEq/versions/0.9.1/requires
@@ -7,4 +7,4 @@ Combinatorics
 Compat 0.17.0
 Reexport
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.0.0/requires
+++ b/DelayDiffEq/versions/1.0.0/requires
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.0.1/requires
+++ b/DelayDiffEq/versions/1.0.1/requires
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.1.0/requires
+++ b/DelayDiffEq/versions/1.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.21.0 2.23.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.10.0/requires
+++ b/DelayDiffEq/versions/1.10.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 OrdinaryDiffEq 2.31.0 2.36.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/DelayDiffEq/versions/1.11.0/requires
+++ b/DelayDiffEq/versions/1.11.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 OrdinaryDiffEq 2.35.0 2.36.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/DelayDiffEq/versions/1.11.1/requires
+++ b/DelayDiffEq/versions/1.11.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 OrdinaryDiffEq 2.35.0 2.36.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/DelayDiffEq/versions/1.12.0/requires
+++ b/DelayDiffEq/versions/1.12.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
-DiffEqBase 2.8.0 3.0.0
-OrdinaryDiffEq 2.36.0 3.0.0
+DiffEqBase 2.8.0
+OrdinaryDiffEq 2.36.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Reexport
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/DelayDiffEq/versions/1.2.0/requires
+++ b/DelayDiffEq/versions/1.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.21.0 2.23.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.2.1/requires
+++ b/DelayDiffEq/versions/1.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.21.0 2.23.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.3.0/requires
+++ b/DelayDiffEq/versions/1.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.22.0 2.24.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.4.0/requires
+++ b/DelayDiffEq/versions/1.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.24.0 2.30.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.5.0/requires
+++ b/DelayDiffEq/versions/1.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.24.0 2.30.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.6.0/requires
+++ b/DelayDiffEq/versions/1.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.24.0 2.30.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DelayDiffEq/versions/1.7.0/requires
+++ b/DelayDiffEq/versions/1.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.24.0 2.30.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/DelayDiffEq/versions/1.8.0/requires
+++ b/DelayDiffEq/versions/1.8.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.31.0 2.35.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/DelayDiffEq/versions/1.8.1/requires
+++ b/DelayDiffEq/versions/1.8.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 OrdinaryDiffEq 2.31.0 2.35.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/DelayDiffEq/versions/1.9.0/requires
+++ b/DelayDiffEq/versions/1.9.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 OrdinaryDiffEq 2.31.0 2.36.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
@@ -8,4 +8,4 @@ MuladdMacro
 ForwardDiff
 NLsolve 0.1 0.14
 Roots
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/DiffEqBayes/versions/0.0.1/requires
+++ b/DiffEqBayes/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 1.7.0 3.0.0
+DiffEqBase 1.7.0
 Mamba
 Stan
 Distributions

--- a/DiffEqBiological/versions/0.0.1/requires
+++ b/DiffEqBiological/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
 DiffEqJump
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/DiffEqBiological/versions/0.2.0/requires
+++ b/DiffEqBiological/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 DiffEqJump
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1
 Compat 0.17.0

--- a/DiffEqBiological/versions/0.3.0/requires
+++ b/DiffEqBiological/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 DiffEqJump
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1
 Compat 0.17.0
 DataStructures 0.4.6

--- a/DiffEqCallbacks/versions/0.0.1/requires
+++ b/DiffEqCallbacks/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0
 ForwardDiff 0.0.0 0.6.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/DiffEqCallbacks/versions/0.0.2/requires
+++ b/DiffEqCallbacks/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0
 ForwardDiff 0.0.0 0.6.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/DiffEqCallbacks/versions/0.1.0/requires
+++ b/DiffEqCallbacks/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0
 NLsolve 0.1 0.14
 ForwardDiff 0.3.0 0.6.0
 DiffBase
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/DiffEqCallbacks/versions/0.1.1/requires
+++ b/DiffEqCallbacks/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0
 NLsolve 0.1 0.14
 ForwardDiff 0.3.0 0.6.0
 DiffBase
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/DiffEqCallbacks/versions/0.2.0/requires
+++ b/DiffEqCallbacks/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0-pre
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0
 NLsolve 0.1 0.14
 ForwardDiff 0.5.0 0.6.0
 DiffBase
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/DiffEqCallbacks/versions/0.2.1/requires
+++ b/DiffEqCallbacks/versions/0.2.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0-pre
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0
 NLsolve 0.1 0.14
 ForwardDiff 0.5.0 0.6.0
 DiffBase
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/DiffEqCallbacks/versions/0.3.0/requires
+++ b/DiffEqCallbacks/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0
 NLsolve 0.1 0.14
 ForwardDiff 0.5.0 0.6.0
 DiffBase
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/DiffEqCallbacks/versions/0.4.0/requires
+++ b/DiffEqCallbacks/versions/0.4.0/requires
@@ -1,9 +1,9 @@
 julia 0.6.0
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0
 NLsolve 0.1 0.14
 ForwardDiff 0.5 0.6-
 DiffBase
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 RecursiveArrayTools
 DataStructures
 RecipesBase

--- a/DiffEqCallbacks/versions/0.5.0/requires
+++ b/DiffEqCallbacks/versions/0.5.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
-DiffEqBase 0.6.0 3.0.0
-OrdinaryDiffEq 2.21.3 3.0.0
+DiffEqBase 0.6.0
+OrdinaryDiffEq 2.21.3
 RecursiveArrayTools
 DataStructures
 RecipesBase

--- a/DiffEqCallbacks/versions/0.6.0/requires
+++ b/DiffEqCallbacks/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
-DiffEqBase 0.6.0 3.0.0
-OrdinaryDiffEq 2.21.3 3.0.0
+DiffEqBase 0.6.0
+OrdinaryDiffEq 2.21.3
 RecursiveArrayTools
 DataStructures
 RecipesBase

--- a/DiffEqCallbacks/versions/0.6.1/requires
+++ b/DiffEqCallbacks/versions/0.6.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
-DiffEqBase 0.6.0 3.0.0
-OrdinaryDiffEq 2.21.3 3.0.0
+DiffEqBase 0.6.0
+OrdinaryDiffEq 2.21.3
 RecursiveArrayTools
 DataStructures
 RecipesBase

--- a/DiffEqCallbacks/versions/0.7.0/requires
+++ b/DiffEqCallbacks/versions/0.7.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
-DiffEqBase 2.10.0 3.0.0
-OrdinaryDiffEq 2.34.0 3.0.0
+DiffEqBase 2.10.0
+OrdinaryDiffEq 2.34.0
 RecursiveArrayTools
 DataStructures
 RecipesBase

--- a/DiffEqCallbacks/versions/0.7.1/requires
+++ b/DiffEqCallbacks/versions/0.7.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
-DiffEqBase 2.10.0 3.0.0
-OrdinaryDiffEq 2.34.0 3.0.0
+DiffEqBase 2.10.0
+OrdinaryDiffEq 2.34.0
 RecursiveArrayTools
 DataStructures
 RecipesBase

--- a/DiffEqCallbacks/versions/0.8.0/requires
+++ b/DiffEqCallbacks/versions/0.8.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
-DiffEqBase 2.10.0 3.0.0
-OrdinaryDiffEq 2.34.0 3.0.0
+DiffEqBase 2.10.0
+OrdinaryDiffEq 2.34.0
 RecursiveArrayTools
 DataStructures
 RecipesBase

--- a/DiffEqDevTools/versions/0.10.0/requires
+++ b/DiffEqDevTools/versions/0.10.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.10.1/requires
+++ b/DiffEqDevTools/versions/0.10.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.11.0/requires
+++ b/DiffEqDevTools/versions/0.11.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.11.1/requires
+++ b/DiffEqDevTools/versions/0.11.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.11.2/requires
+++ b/DiffEqDevTools/versions/0.11.2/requires
@@ -1,6 +1,6 @@
 julia 0.6
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.11.3/requires
+++ b/DiffEqDevTools/versions/0.11.3/requires
@@ -1,6 +1,6 @@
 julia 0.6
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.8.0/requires
+++ b/DiffEqDevTools/versions/0.8.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase

--- a/DiffEqDevTools/versions/0.8.1/requires
+++ b/DiffEqDevTools/versions/0.8.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecipesBase 0.1.0
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase

--- a/DiffEqDevTools/versions/0.9.0/requires
+++ b/DiffEqDevTools/versions/0.9.0/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.9.1/requires
+++ b/DiffEqDevTools/versions/0.9.1/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.9.2/requires
+++ b/DiffEqDevTools/versions/0.9.2/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.9.3/requires
+++ b/DiffEqDevTools/versions/0.9.3/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.9.4/requires
+++ b/DiffEqDevTools/versions/0.9.4/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqDevTools/versions/0.9.5/requires
+++ b/DiffEqDevTools/versions/0.9.5/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 RecipesBase 0.1.0
-DiffEqBase 1.12.0 3.0.0
+DiffEqBase 1.12.0
 RecursiveArrayTools 0.4.0
 DiffEqPDEBase
 DiffEqMonteCarlo

--- a/DiffEqFinancial/versions/0.1.0/requires
+++ b/DiffEqFinancial/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 StochasticDiffEq

--- a/DiffEqFinancial/versions/0.2.0/requires
+++ b/DiffEqFinancial/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 DiffEqNoiseProcess

--- a/DiffEqFinancial/versions/0.3.0/requires
+++ b/DiffEqFinancial/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DiffEqBase 1.14.0 3.0.0
+DiffEqBase 1.14.0
 DiffEqNoiseProcess 0.3.1
 RandomNumbers

--- a/DiffEqJump/versions/0.0.1/requires
+++ b/DiffEqJump/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.5
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/DiffEqJump/versions/0.1.0/requires
+++ b/DiffEqJump/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1
 RecursiveArrayTools

--- a/DiffEqJump/versions/0.2.0/requires
+++ b/DiffEqJump/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1
 RecursiveArrayTools

--- a/DiffEqJump/versions/0.3.0/requires
+++ b/DiffEqJump/versions/0.3.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 0.13.0 3.0.0
+DiffEqBase 0.13.0
 RecursiveArrayTools

--- a/DiffEqJump/versions/0.3.1/requires
+++ b/DiffEqJump/versions/0.3.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 0.13.0 3.0.0
+DiffEqBase 0.13.0
 RecursiveArrayTools
 Compat 0.19.0

--- a/DiffEqJump/versions/0.3.2/requires
+++ b/DiffEqJump/versions/0.3.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 0.13.0 3.0.0
+DiffEqBase 0.13.0
 RecursiveArrayTools
 Compat 0.19.0

--- a/DiffEqJump/versions/0.4.0/requires
+++ b/DiffEqJump/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.13.0 3.0.0
+DiffEqBase 0.13.0
 RecursiveArrayTools
 Compat 0.19.0
 Juno

--- a/DiffEqJump/versions/0.5.0/requires
+++ b/DiffEqJump/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 0.13.0 3.0.0
+DiffEqBase 0.13.0
 RecursiveArrayTools
 Compat 0.19.0
 Juno

--- a/DiffEqJump/versions/0.5.1/requires
+++ b/DiffEqJump/versions/0.5.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 0.13.0 3.0.0
+DiffEqBase 0.13.0
 RecursiveArrayTools
 Compat 0.19.0
 Juno

--- a/DiffEqJump/versions/0.6.0/requires
+++ b/DiffEqJump/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 0.13.0 3.0.0
+DiffEqBase 0.13.0
 RecursiveArrayTools
 Compat 0.19.0
 Juno

--- a/DiffEqJump/versions/0.7.0/requires
+++ b/DiffEqJump/versions/0.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 0.13.0 3.0.0
+DiffEqBase 0.13.0
 RecursiveArrayTools
 Compat 0.19.0
 Requires

--- a/DiffEqMonteCarlo/versions/0.9.0/requires
+++ b/DiffEqMonteCarlo/versions/0.9.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DiffEqBase 1.18.0 3.0.0
+DiffEqBase 1.18.0
 RecursiveArrayTools 0.6.0
 DistributedArrays

--- a/DiffEqMonteCarlo/versions/0.9.1/requires
+++ b/DiffEqMonteCarlo/versions/0.9.1/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DiffEqBase 1.18.0 3.0.0
+DiffEqBase 1.18.0
 RecursiveArrayTools 0.6.0
 DistributedArrays

--- a/DiffEqNoiseProcess/versions/0.1.0/requires
+++ b/DiffEqNoiseProcess/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 ResettableStacks
 DataStructures
-DiffEqBase 1.3.1 3.0.0
+DiffEqBase 1.3.1
 RecipesBase
 RecursiveArrayTools

--- a/DiffEqNoiseProcess/versions/0.1.1/requires
+++ b/DiffEqNoiseProcess/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.5
 ResettableStacks
 DataStructures
-DiffEqBase 1.3.1 3.0.0
+DiffEqBase 1.3.1
 RecipesBase
 RecursiveArrayTools

--- a/DiffEqNoiseProcess/versions/0.2.0/requires
+++ b/DiffEqNoiseProcess/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 ResettableStacks
 DataStructures
-DiffEqBase 1.3.1 3.0.0
+DiffEqBase 1.3.1
 RecipesBase
 RecursiveArrayTools

--- a/DiffEqNoiseProcess/versions/0.3.0/requires
+++ b/DiffEqNoiseProcess/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.3.1/requires
+++ b/DiffEqNoiseProcess/versions/0.3.1/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.3.2/requires
+++ b/DiffEqNoiseProcess/versions/0.3.2/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.4.0/requires
+++ b/DiffEqNoiseProcess/versions/0.4.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.5.0/requires
+++ b/DiffEqNoiseProcess/versions/0.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks 0.2.0
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.6.0/requires
+++ b/DiffEqNoiseProcess/versions/0.6.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks 0.2.0
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.7.0/requires
+++ b/DiffEqNoiseProcess/versions/0.7.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks 0.2.0
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.7.1/requires
+++ b/DiffEqNoiseProcess/versions/0.7.1/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks 0.2.0
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.7.2/requires
+++ b/DiffEqNoiseProcess/versions/0.7.2/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks 0.2.0
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.8.0/requires
+++ b/DiffEqNoiseProcess/versions/0.8.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks 0.2.0
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqNoiseProcess/versions/0.8.1/requires
+++ b/DiffEqNoiseProcess/versions/0.8.1/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ResettableStacks 0.2.0
 DataStructures
-DiffEqBase 1.13.0 3.0.0
+DiffEqBase 1.13.0
 RecipesBase
 RecursiveArrayTools
 RandomNumbers

--- a/DiffEqOperators/versions/0.0.1/requires
+++ b/DiffEqOperators/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.6
-DiffEqBase 1.19.0 3.0.0
+DiffEqBase 1.19.0
 LinearMaps

--- a/DiffEqPDEBase/versions/0.3.0/requires
+++ b/DiffEqPDEBase/versions/0.3.0/requires
@@ -2,5 +2,5 @@ julia 0.5
 RecipesBase
 VectorizedRoutines
 ChunkedArrays
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 Compat 0.17.0

--- a/DiffEqPDEBase/versions/0.3.1/requires
+++ b/DiffEqPDEBase/versions/0.3.1/requires
@@ -2,5 +2,5 @@ julia 0.5
 RecipesBase
 VectorizedRoutines
 ChunkedArrays
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 Compat 0.17.0

--- a/DiffEqPDEBase/versions/0.3.2/requires
+++ b/DiffEqPDEBase/versions/0.3.2/requires
@@ -2,5 +2,5 @@ julia 0.5
 RecipesBase
 VectorizedRoutines
 ChunkedArrays
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 Compat 0.17.0

--- a/DiffEqPDEBase/versions/0.3.3/requires
+++ b/DiffEqPDEBase/versions/0.3.3/requires
@@ -2,5 +2,5 @@ julia 0.5
 RecipesBase
 VectorizedRoutines
 ChunkedArrays
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 Compat 0.17.0

--- a/DiffEqPDEBase/versions/0.3.4/requires
+++ b/DiffEqPDEBase/versions/0.3.4/requires
@@ -2,5 +2,5 @@ julia 0.5
 RecipesBase
 VectorizedRoutines
 ChunkedArrays
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 Compat 0.17.0

--- a/DiffEqPDEBase/versions/0.3.5/requires
+++ b/DiffEqPDEBase/versions/0.3.5/requires
@@ -2,5 +2,5 @@ julia 0.5
 RecipesBase
 VectorizedRoutines
 ChunkedArrays
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 Compat 0.17.0

--- a/DiffEqParamEstim/versions/0.2.0/requires
+++ b/DiffEqParamEstim/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 LsqFit 0.0.2
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.0.2
 ForwardDiff

--- a/DiffEqParamEstim/versions/0.3.0/requires
+++ b/DiffEqParamEstim/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 LsqFit 0.0.2
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.0.2
 ForwardDiff

--- a/DiffEqParamEstim/versions/0.4.0/requires
+++ b/DiffEqParamEstim/versions/0.4.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 LsqFit 0.0.2
-DiffEqBase 1.7.0 3.0.0
+DiffEqBase 1.7.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.0.2
 ForwardDiff

--- a/DiffEqParamEstim/versions/0.5.0/requires
+++ b/DiffEqParamEstim/versions/0.5.0/requires
@@ -1,6 +1,6 @@
 julia 0.6-pre
 LsqFit 0.0.2
-DiffEqBase 1.7.0 3.0.0
+DiffEqBase 1.7.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.0.2
 ForwardDiff

--- a/DiffEqParamEstim/versions/0.6.0/requires
+++ b/DiffEqParamEstim/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LsqFit 0.0.2
-DiffEqBase 1.7.0 3.0.0
+DiffEqBase 1.7.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.10.0
 ForwardDiff

--- a/DiffEqParamEstim/versions/0.7.0/requires
+++ b/DiffEqParamEstim/versions/0.7.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LsqFit 0.0.2
-DiffEqBase 1.7.0 3.0.0
+DiffEqBase 1.7.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.10.0
 ForwardDiff

--- a/DiffEqParamEstim/versions/0.7.1/requires
+++ b/DiffEqParamEstim/versions/0.7.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LsqFit 0.0.2
-DiffEqBase 1.7.0 3.0.0
+DiffEqBase 1.7.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.10.0
 ForwardDiff

--- a/DiffEqParamEstim/versions/0.7.2/requires
+++ b/DiffEqParamEstim/versions/0.7.2/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LsqFit 0.0.2
-DiffEqBase 1.7.0 3.0.0
+DiffEqBase 1.7.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.10.0
 ForwardDiff

--- a/DiffEqParamEstim/versions/0.8.0/requires
+++ b/DiffEqParamEstim/versions/0.8.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 LsqFit 0.0.2
-DiffEqBase 1.7.0 3.0.0
+DiffEqBase 1.7.0
 LossFunctions 0.0.2
 RecursiveArrayTools 0.10.0
 ForwardDiff

--- a/DiffEqPhysics/versions/0.0.1/requires
+++ b/DiffEqPhysics/versions/0.0.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
-DiffEqBase 1.15.0 3.0.0
-OrdinaryDiffEq 2.11.0 3.0.0
+DiffEqBase 1.15.0
+OrdinaryDiffEq 2.11.0
 Reexport
 ForwardDiff 0.5.0
 StaticArrays

--- a/DiffEqPhysics/versions/0.1.0/requires
+++ b/DiffEqPhysics/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
-DiffEqBase 1.15.0 3.0.0
-OrdinaryDiffEq 2.11.0 3.0.0
+DiffEqBase 1.15.0
+OrdinaryDiffEq 2.11.0
 Reexport
 ForwardDiff 0.5.0
 StaticArrays

--- a/DiffEqPhysics/versions/0.2.0/requires
+++ b/DiffEqPhysics/versions/0.2.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
-DiffEqBase 1.15.0 3.0.0
-OrdinaryDiffEq 2.33.0 3.0.0
+DiffEqBase 1.15.0
+OrdinaryDiffEq 2.33.0
 Reexport
 ForwardDiff 0.5.0
 StaticArrays

--- a/DiffEqPhysics/versions/0.3.0/requires
+++ b/DiffEqPhysics/versions/0.3.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
-DiffEqBase 1.15.0 3.0.0
-OrdinaryDiffEq 2.33.0 3.0.0
+DiffEqBase 1.15.0
+OrdinaryDiffEq 2.33.0
 Reexport
 ForwardDiff 0.5.0
 StaticArrays

--- a/DiffEqProblemLibrary/versions/0.10.0/requires
+++ b/DiffEqProblemLibrary/versions/0.10.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 ParameterizedFunctions 2.0.0
-DiffEqBase 1.21.0 3.0.0
+DiffEqBase 1.21.0
 DiffEqPDEBase

--- a/DiffEqProblemLibrary/versions/0.11.0/requires
+++ b/DiffEqProblemLibrary/versions/0.11.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 ParameterizedFunctions 2.0.0
-DiffEqBase 1.21.0 3.0.0
+DiffEqBase 1.21.0
 DiffEqPDEBase

--- a/DiffEqProblemLibrary/versions/0.5.0/requires
+++ b/DiffEqProblemLibrary/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ParameterizedFunctions 0.5.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 JLD 0.6.5
 DiffEqPDEBase

--- a/DiffEqProblemLibrary/versions/0.5.1/requires
+++ b/DiffEqProblemLibrary/versions/0.5.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ParameterizedFunctions 0.5.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 JLD 0.6.5
 DiffEqPDEBase

--- a/DiffEqProblemLibrary/versions/0.6.0/requires
+++ b/DiffEqProblemLibrary/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ParameterizedFunctions 2.0.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 JLD 0.6.5
 DiffEqPDEBase

--- a/DiffEqProblemLibrary/versions/0.7.0/requires
+++ b/DiffEqProblemLibrary/versions/0.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ParameterizedFunctions 2.0.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 JLD 0.6.5
 DiffEqPDEBase

--- a/DiffEqProblemLibrary/versions/0.8.0/requires
+++ b/DiffEqProblemLibrary/versions/0.8.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ParameterizedFunctions 2.0.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 JLD 0.6.5
 DiffEqPDEBase

--- a/DiffEqProblemLibrary/versions/0.9.0/requires
+++ b/DiffEqProblemLibrary/versions/0.9.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 ParameterizedFunctions 2.0.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 DiffEqPDEBase

--- a/DiffEqProblemLibrary/versions/0.9.1/requires
+++ b/DiffEqProblemLibrary/versions/0.9.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 ParameterizedFunctions 2.0.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 DiffEqPDEBase

--- a/DiffEqSensitivity/versions/0.0.1/requires
+++ b/DiffEqSensitivity/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
 DiffEqBase 0.0.0 0.15.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.0.2/requires
+++ b/DiffEqSensitivity/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5
 DiffEqBase 0.1.2 0.15.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.0.3/requires
+++ b/DiffEqSensitivity/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.5
 DiffEqBase 0.2.0 0.15.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.0.4/requires
+++ b/DiffEqSensitivity/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.5
 DiffEqBase 0.2.0 0.15.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.1.0/requires
+++ b/DiffEqSensitivity/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
 DiffEqBase 0.15.0 1.0.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.2.1/requires
+++ b/DiffEqSensitivity/versions/0.2.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 0.15.0 3.0.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqBase 0.15.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.2.2/requires
+++ b/DiffEqSensitivity/versions/0.2.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Compat 0.17.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.3.0/requires
+++ b/DiffEqSensitivity/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Compat 0.17.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.4.0/requires
+++ b/DiffEqSensitivity/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Compat 0.17.0
 ForwardDiff
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/DiffEqSensitivity/versions/0.5.0/requires
+++ b/DiffEqSensitivity/versions/0.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Compat 0.17.0
 ForwardDiff
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1
 DiffEqCallbacks
 QuadGK

--- a/DiffEqSensitivity/versions/0.5.1/requires
+++ b/DiffEqSensitivity/versions/0.5.1/requires
@@ -1,7 +1,7 @@
 julia 0.6
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Compat 0.17.0
 ForwardDiff
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1
 DiffEqCallbacks
 QuadGK

--- a/DiffEqUncertainty/versions/0.0.1/requires
+++ b/DiffEqUncertainty/versions/0.0.1/requires
@@ -1,2 +1,2 @@
 julia 0.5
-DiffEqBase 0.6.0 3.0.0
+DiffEqBase 0.6.0

--- a/DifferentialEquations/versions/0.0.1/requires
+++ b/DifferentialEquations/versions/0.0.1/requires
@@ -5,5 +5,5 @@ IterativeSolvers
 PyPlot
 Atom
 NLsolve 0.1 0.14
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.0.2/requires
+++ b/DifferentialEquations/versions/0.0.2/requires
@@ -5,5 +5,5 @@ IterativeSolvers
 PyPlot
 NLsolve 0.1 0.14
 Parameters
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.0.3/requires
+++ b/DifferentialEquations/versions/0.0.3/requires
@@ -8,5 +8,5 @@ Plots
 JLD
 ForwardDiff
 IterativeSolvers
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.1.0/requires
+++ b/DifferentialEquations/versions/0.1.0/requires
@@ -5,5 +5,5 @@ ChunkedArrays
 EllipsisNotation
 IterativeSolvers
 Plots
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.1.1/requires
+++ b/DifferentialEquations/versions/0.1.1/requires
@@ -5,5 +5,5 @@ ChunkedArrays
 EllipsisNotation
 IterativeSolvers
 Plots
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.1.2/requires
+++ b/DifferentialEquations/versions/0.1.2/requires
@@ -6,5 +6,5 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.1.3/requires
+++ b/DifferentialEquations/versions/0.1.3/requires
@@ -6,5 +6,5 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.1.4/requires
+++ b/DifferentialEquations/versions/0.1.4/requires
@@ -7,5 +7,5 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.2.0/requires
+++ b/DifferentialEquations/versions/0.2.0/requires
@@ -7,5 +7,5 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.2.1/requires
+++ b/DifferentialEquations/versions/0.2.1/requires
@@ -7,5 +7,5 @@ EllipsisNotation
 IterativeSolvers
 GenericSVD
 Plots
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/0.3.0/requires
+++ b/DifferentialEquations/versions/0.3.0/requires
@@ -9,5 +9,5 @@ GenericSVD
 Compat
 Plots
 InplaceOps
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/DifferentialEquations/versions/1.10.0/requires
+++ b/DifferentialEquations/versions/1.10.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 StochasticDiffEq 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 1.2.0 3.0.0
+OrdinaryDiffEq 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.10.1/requires
+++ b/DifferentialEquations/versions/1.10.1/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 StochasticDiffEq 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 1.2.0 3.0.0
+OrdinaryDiffEq 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.7.0/requires
+++ b/DifferentialEquations/versions/1.7.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.8.0 0.15.0
 StochasticDiffEq 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 1.2.0 3.0.0
+OrdinaryDiffEq 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.8.0/requires
+++ b/DifferentialEquations/versions/1.8.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.8.0 0.15.0
 StochasticDiffEq 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 1.2.0 3.0.0
+OrdinaryDiffEq 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.9.0/requires
+++ b/DifferentialEquations/versions/1.9.0/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.8.0 0.15.0
 StochasticDiffEq 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 1.2.0 3.0.0
+OrdinaryDiffEq 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/1.9.1/requires
+++ b/DifferentialEquations/versions/1.9.1/requires
@@ -4,7 +4,7 @@ DiffEqBase 0.8.0 0.15.0
 StochasticDiffEq 1.0.0
 FiniteElementDiffEq 0.0.5
 DiffEqDevTools 0.2.0
-OrdinaryDiffEq 1.2.0 3.0.0
+OrdinaryDiffEq 1.2.0
 AlgebraicDiffEq 0.0.2
 StokesDiffEq 0.0.2
 DiffEqParamEstim 0.0.2

--- a/DifferentialEquations/versions/2.0.0/requires
+++ b/DifferentialEquations/versions/2.0.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.0.0
 FiniteElementDiffEq 0.3.0
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.0.0 3.0.0
+OrdinaryDiffEq 2.0.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DifferentialEquations/versions/2.1.0/requires
+++ b/DifferentialEquations/versions/2.1.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.0.0
 FiniteElementDiffEq 0.3.0
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.0.0 3.0.0
+OrdinaryDiffEq 2.0.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DifferentialEquations/versions/2.2.0/requires
+++ b/DifferentialEquations/versions/2.2.0/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.0.0
 FiniteElementDiffEq 0.3.0
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.0.0 3.0.0
+OrdinaryDiffEq 2.0.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DifferentialEquations/versions/2.2.1/requires
+++ b/DifferentialEquations/versions/2.2.1/requires
@@ -1,10 +1,10 @@
 julia 0.5
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.0.0
 FiniteElementDiffEq 0.3.0
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.0.0 3.0.0
+OrdinaryDiffEq 2.0.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DifferentialEquations/versions/2.3.0/requires
+++ b/DifferentialEquations/versions/2.3.0/requires
@@ -1,10 +1,10 @@
 julia 0.6
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.11.1
 FiniteElementDiffEq 0.3.0
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.11.0 3.0.0
+OrdinaryDiffEq 2.11.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DifferentialEquations/versions/3.0.0/requires
+++ b/DifferentialEquations/versions/3.0.0/requires
@@ -1,11 +1,11 @@
 julia 0.6
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.11.1
 FiniteElementDiffEq 0.3.0
 BoundaryValueDiffEq
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.11.0 3.0.0
+OrdinaryDiffEq 2.11.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DifferentialEquations/versions/3.0.1/requires
+++ b/DifferentialEquations/versions/3.0.1/requires
@@ -1,11 +1,11 @@
 julia 0.6
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.11.1
 FiniteElementDiffEq 0.3.0
 BoundaryValueDiffEq
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.11.0 3.0.0
+OrdinaryDiffEq 2.11.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DifferentialEquations/versions/3.0.2/requires
+++ b/DifferentialEquations/versions/3.0.2/requires
@@ -1,11 +1,11 @@
 julia 0.6
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.11.1
 FiniteElementDiffEq 0.3.0
 BoundaryValueDiffEq
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.11.0 3.0.0
+OrdinaryDiffEq 2.11.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DifferentialEquations/versions/3.1.0/requires
+++ b/DifferentialEquations/versions/3.1.0/requires
@@ -1,11 +1,11 @@
 julia 0.6
 Reexport 0.0.3
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 StochasticDiffEq 2.11.1
 FiniteElementDiffEq 0.3.0
 BoundaryValueDiffEq
 DiffEqDevTools 0.8.0
-OrdinaryDiffEq 2.11.0 3.0.0
+OrdinaryDiffEq 2.11.0
 AlgebraicDiffEq 0.1.0
 DiffEqParamEstim 0.3.0
 DiffEqSensitivity 0.2.1

--- a/DynamicalSystemsBase/versions/0.1.0/requires
+++ b/DynamicalSystemsBase/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 StaticArrays 0.5.0

--- a/DynamicalSystemsBase/versions/0.2.0/requires
+++ b/DynamicalSystemsBase/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 StaticArrays 0.5.0

--- a/DynamicalSystemsBase/versions/0.2.1/requires
+++ b/DynamicalSystemsBase/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 StaticArrays 0.5.0

--- a/DynamicalSystemsBase/versions/0.3.0/requires
+++ b/DynamicalSystemsBase/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 StaticArrays 0.5.0

--- a/DynamicalSystemsBase/versions/0.3.1/requires
+++ b/DynamicalSystemsBase/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 StaticArrays 0.5.0

--- a/DynamicalSystemsBase/versions/0.3.2/requires
+++ b/DynamicalSystemsBase/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 StaticArrays 0.5.0

--- a/DynamicalSystemsBase/versions/0.3.3/requires
+++ b/DynamicalSystemsBase/versions/0.3.3/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 StaticArrays 0.5.0

--- a/DynamicalSystemsBase/versions/0.4.0/requires
+++ b/DynamicalSystemsBase/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 DiffEqCallbacks
 ForwardDiff 0.5
 Requires 0.4.3

--- a/DynamicalSystemsBase/versions/0.4.1/requires
+++ b/DynamicalSystemsBase/versions/0.4.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-OrdinaryDiffEq 2.17.0 3.0.0
+OrdinaryDiffEq 2.17.0
 DiffEqCallbacks
 ForwardDiff 0.5
 Requires 0.4.3

--- a/FiniteElementDiffEq/versions/0.3.0/requires
+++ b/FiniteElementDiffEq/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 DiffEqPDEBase 0.0.1 0.4.0
 IterativeSolvers 0.2.2
 Parameters 0.5.0

--- a/FiniteElementDiffEq/versions/0.4.0/requires
+++ b/FiniteElementDiffEq/versions/0.4.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 DiffEqPDEBase 0.0.1 0.4.0
 IterativeSolvers 0.2.2
 Parameters 0.5.0

--- a/LSODA/versions/0.1.0/requires
+++ b/LSODA/versions/0.1.0/requires
@@ -2,4 +2,4 @@ julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
 Parameters 0.5.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/LSODA/versions/0.2.0/requires
+++ b/LSODA/versions/0.2.0/requires
@@ -2,4 +2,4 @@ julia 0.6
 BinDeps 0.4.3
 Compat 0.17.0
 Parameters 0.5.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1

--- a/LSODA/versions/0.2.1/requires
+++ b/LSODA/versions/0.2.1/requires
@@ -2,4 +2,4 @@ julia 0.6
 BinDeps 0.4.3
 Compat 0.17.0
 Parameters 0.5.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1

--- a/LTISystems/versions/0.1.0/requires
+++ b/LTISystems/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 Compat 0.18.0
-OrdinaryDiffEq 1.0.0 3.0.0
+OrdinaryDiffEq 1.0.0
 PolynomialMatrices 0.1.1
 RationalFunctions 0.1.1
 RecipesBase

--- a/Latexify/versions/0.0.1/requires
+++ b/Latexify/versions/0.0.1/requires
@@ -2,4 +2,4 @@ julia 0.6
 DifferentialEquations 3.0
 SymEngine 0.2.0
 DataFrames 0.10.0 0.11.0
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Latexify/versions/0.1.0/requires
+++ b/Latexify/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase v2.4.0 3.0.0
+DiffEqBase v2.4.0
 SymEngine 0.2.0
 Missings 0.2.2
 LaTeXStrings v0.3.0

--- a/Latexify/versions/0.1.1/requires
+++ b/Latexify/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqBase v2.4.0 3.0.0
+DiffEqBase v2.4.0
 SymEngine 0.2.0
 Missings 0.2.2
 LaTeXStrings v0.3.0

--- a/Mads/versions/0.1.0/requires
+++ b/Mads/versions/0.1.0/requires
@@ -23,4 +23,4 @@ JSON
 JLD
 Gadfly
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.1/requires
+++ b/Mads/versions/0.1.1/requires
@@ -23,4 +23,4 @@ JLD
 Gadfly
 DataFrames 0.0.0 0.11.0
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.10/requires
+++ b/Mads/versions/0.1.10/requires
@@ -24,4 +24,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.11/requires
+++ b/Mads/versions/0.1.11/requires
@@ -27,4 +27,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.12/requires
+++ b/Mads/versions/0.1.12/requires
@@ -24,4 +24,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.13/requires
+++ b/Mads/versions/0.1.13/requires
@@ -24,4 +24,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.14/requires
+++ b/Mads/versions/0.1.14/requires
@@ -24,4 +24,4 @@ Optim
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.15/requires
+++ b/Mads/versions/0.1.15/requires
@@ -21,4 +21,4 @@ Optim
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.16/requires
+++ b/Mads/versions/0.1.16/requires
@@ -21,4 +21,4 @@ Optim
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.17/requires
+++ b/Mads/versions/0.1.17/requires
@@ -21,4 +21,4 @@ Optim
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.18/requires
+++ b/Mads/versions/0.1.18/requires
@@ -22,4 +22,4 @@ Optim 0.5
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.2/requires
+++ b/Mads/versions/0.1.2/requires
@@ -24,4 +24,4 @@ JLD
 Gadfly
 DataFrames 0.0.0 0.11.0
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.3/requires
+++ b/Mads/versions/0.1.3/requires
@@ -24,4 +24,4 @@ JLD
 Gadfly
 DataFrames 0.0.0 0.11.0
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.4/requires
+++ b/Mads/versions/0.1.4/requires
@@ -24,4 +24,4 @@ JLD
 Gadfly
 DataFrames 0.0.0 0.11.0
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.5/requires
+++ b/Mads/versions/0.1.5/requires
@@ -24,4 +24,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.6/requires
+++ b/Mads/versions/0.1.6/requires
@@ -24,4 +24,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.7/requires
+++ b/Mads/versions/0.1.7/requires
@@ -24,4 +24,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.8/requires
+++ b/Mads/versions/0.1.8/requires
@@ -24,4 +24,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.1.9/requires
+++ b/Mads/versions/0.1.9/requires
@@ -24,4 +24,4 @@ Gadfly
 DataFrames 0.0.0 0.11.0
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.0/requires
+++ b/Mads/versions/0.2.0/requires
@@ -22,4 +22,4 @@ Optim 0.5
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.1/requires
+++ b/Mads/versions/0.2.1/requires
@@ -22,4 +22,4 @@ Optim 0.5
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.10/requires
+++ b/Mads/versions/0.2.10/requires
@@ -23,4 +23,4 @@ Optim 0.5
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.11/requires
+++ b/Mads/versions/0.2.11/requires
@@ -23,4 +23,4 @@ Optim 0.5
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.12/requires
+++ b/Mads/versions/0.2.12/requires
@@ -23,4 +23,4 @@ Optim 0.5
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.13/requires
+++ b/Mads/versions/0.2.13/requires
@@ -23,4 +23,4 @@ Optim 0.5
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.14/requires
+++ b/Mads/versions/0.2.14/requires
@@ -24,4 +24,4 @@ Optim 0.7
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.15/requires
+++ b/Mads/versions/0.2.15/requires
@@ -24,4 +24,4 @@ Optim 0.7
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.16/requires
+++ b/Mads/versions/0.2.16/requires
@@ -24,4 +24,4 @@ Optim 0.7
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.17/requires
+++ b/Mads/versions/0.2.17/requires
@@ -24,4 +24,4 @@ Optim 0.7
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.18/requires
+++ b/Mads/versions/0.2.18/requires
@@ -25,4 +25,4 @@ Optim 0.7
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.19/requires
+++ b/Mads/versions/0.2.19/requires
@@ -25,4 +25,4 @@ Optim 0.7
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.2/requires
+++ b/Mads/versions/0.2.2/requires
@@ -22,4 +22,4 @@ Optim 0.5
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.3/requires
+++ b/Mads/versions/0.2.3/requires
@@ -22,4 +22,4 @@ Optim 0.5
 BlackBoxOptim
 Docile
 Lexicon
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.4/requires
+++ b/Mads/versions/0.2.4/requires
@@ -21,4 +21,4 @@ Klara 0.6
 Optim 0.5
 BlackBoxOptim
 Documenter
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.5/requires
+++ b/Mads/versions/0.2.5/requires
@@ -22,4 +22,4 @@ Klara 0.6
 Optim 0.5
 BlackBoxOptim
 Documenter
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.6/requires
+++ b/Mads/versions/0.2.6/requires
@@ -22,4 +22,4 @@ Klara 0.6
 Optim 0.5
 BlackBoxOptim
 Documenter
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.7/requires
+++ b/Mads/versions/0.2.7/requires
@@ -23,4 +23,4 @@ Optim 0.5
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.8/requires
+++ b/Mads/versions/0.2.8/requires
@@ -23,4 +23,4 @@ Optim 0.5
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.2.9/requires
+++ b/Mads/versions/0.2.9/requires
@@ -23,4 +23,4 @@ Optim 0.5
 BlackBoxOptim
 Documenter
 Compat 0.7.15
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.0/requires
+++ b/Mads/versions/0.3.0/requires
@@ -25,4 +25,4 @@ Optim 0.7
 BlackBoxOptim
 Documenter 0.8.10
 Compat 0.12
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.1/requires
+++ b/Mads/versions/0.3.1/requires
@@ -25,4 +25,4 @@ Optim 0.7
 BlackBoxOptim
 Documenter 0.8.10
 Compat 0.8
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.10/requires
+++ b/Mads/versions/0.3.10/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.2/requires
+++ b/Mads/versions/0.3.2/requires
@@ -28,4 +28,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 Ipopt 0.2.6
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.3/requires
+++ b/Mads/versions/0.3.3/requires
@@ -30,4 +30,4 @@ JuMP 0.15
 MathProgBase 0.5.10
 Ipopt 0.2.6
 Colors
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.4/requires
+++ b/Mads/versions/0.3.4/requires
@@ -28,4 +28,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.5/requires
+++ b/Mads/versions/0.3.5/requires
@@ -28,4 +28,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.6/requires
+++ b/Mads/versions/0.3.6/requires
@@ -29,4 +29,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.7/requires
+++ b/Mads/versions/0.3.7/requires
@@ -29,4 +29,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.8/requires
+++ b/Mads/versions/0.3.8/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.3.9/requires
+++ b/Mads/versions/0.3.9/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.0/requires
+++ b/Mads/versions/0.4.0/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.1/requires
+++ b/Mads/versions/0.4.1/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.10/requires
+++ b/Mads/versions/0.4.10/requires
@@ -32,4 +32,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.11/requires
+++ b/Mads/versions/0.4.11/requires
@@ -32,4 +32,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.12/requires
+++ b/Mads/versions/0.4.12/requires
@@ -32,4 +32,4 @@ Optim 0.7
 StatsBase 0.15
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.13/requires
+++ b/Mads/versions/0.4.13/requires
@@ -32,4 +32,4 @@ Optim 0.7
 StatsBase 0.15
 JuMP 0.17
 MathProgBase 0.6.4
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.14/requires
+++ b/Mads/versions/0.4.14/requires
@@ -32,4 +32,4 @@ Optim 0.7
 StatsBase 0.15
 JuMP 0.17
 MathProgBase 0.6.4
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.15/requires
+++ b/Mads/versions/0.4.15/requires
@@ -32,4 +32,4 @@ Optim 0.7
 StatsBase 0.15
 JuMP 0.17
 MathProgBase 0.6.4
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.16/requires
+++ b/Mads/versions/0.4.16/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.17/requires
+++ b/Mads/versions/0.4.17/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.18/requires
+++ b/Mads/versions/0.4.18/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.19/requires
+++ b/Mads/versions/0.4.19/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.2/requires
+++ b/Mads/versions/0.4.2/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.20/requires
+++ b/Mads/versions/0.4.20/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.21/requires
+++ b/Mads/versions/0.4.21/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.22/requires
+++ b/Mads/versions/0.4.22/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.23/requires
+++ b/Mads/versions/0.4.23/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.24/requires
+++ b/Mads/versions/0.4.24/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.25/requires
+++ b/Mads/versions/0.4.25/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.26/requires
+++ b/Mads/versions/0.4.26/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.27/requires
+++ b/Mads/versions/0.4.27/requires
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.28/requires
+++ b/Mads/versions/0.4.28/requires
@@ -25,7 +25,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.29/requires
+++ b/Mads/versions/0.4.29/requires
@@ -25,7 +25,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.3/requires
+++ b/Mads/versions/0.4.3/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.30/requires
+++ b/Mads/versions/0.4.30/requires
@@ -25,7 +25,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.31/requires
+++ b/Mads/versions/0.4.31/requires
@@ -25,7 +25,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames 0.0.0 0.11.0
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.32/requires
+++ b/Mads/versions/0.4.32/requires
@@ -25,7 +25,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.33/requires
+++ b/Mads/versions/0.4.33/requires
@@ -25,7 +25,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/Mads/versions/0.4.4/requires
+++ b/Mads/versions/0.4.4/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.5/requires
+++ b/Mads/versions/0.4.5/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.6/requires
+++ b/Mads/versions/0.4.6/requires
@@ -30,4 +30,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.7/requires
+++ b/Mads/versions/0.4.7/requires
@@ -31,4 +31,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.8/requires
+++ b/Mads/versions/0.4.8/requires
@@ -31,4 +31,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/Mads/versions/0.4.9/requires
+++ b/Mads/versions/0.4.9/requires
@@ -31,4 +31,4 @@ BlackBoxOptim
 Documenter 0.8.10
 JuMP 0.15
 MathProgBase 0.5.10
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/MultiScaleArrays/versions/0.0.1/requires
+++ b/MultiScaleArrays/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 RecursiveArrayTools 0.0.2
 Iterators
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/MultiScaleArrays/versions/0.1.0/requires
+++ b/MultiScaleArrays/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 RecursiveArrayTools 0.0.2
 Iterators
-DiffEqBase 0.11.0 3.0.0
+DiffEqBase 0.11.0

--- a/MultiScaleArrays/versions/0.2.0/requires
+++ b/MultiScaleArrays/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 RecursiveArrayTools 0.0.2
 Iterators
-DiffEqBase 0.11.0 3.0.0
+DiffEqBase 0.11.0
 Compat 0.19.0

--- a/MultiScaleArrays/versions/0.3.0/requires
+++ b/MultiScaleArrays/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 RecursiveArrayTools 0.8.0
-DiffEqBase 0.11.0 3.0.0
+DiffEqBase 0.11.0
 Compat 0.19.0

--- a/MultiScaleArrays/versions/0.4.0/requires
+++ b/MultiScaleArrays/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 RecursiveArrayTools 0.8.0
-DiffEqBase 0.11.0 3.0.0
+DiffEqBase 0.11.0
 

--- a/MultiScaleArrays/versions/0.5.0/requires
+++ b/MultiScaleArrays/versions/0.5.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 RecursiveArrayTools 0.8.0
-DiffEqBase 0.11.0 3.0.0
+DiffEqBase 0.11.0
 

--- a/ODE/versions/0.0.0/requires
+++ b/ODE/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 Polynomial
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/ODE/versions/0.1.0/requires
+++ b/ODE/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.2
 Polynomial
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/ODE/versions/0.1.1/requires
+++ b/ODE/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.2
 Polynomial
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/ODE/versions/0.1.2/requires
+++ b/ODE/versions/0.1.2/requires
@@ -1,3 +1,3 @@
 julia 0.2
 Polynomials
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/ODE/versions/0.2.0/requires
+++ b/ODE/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.2
 Polynomials
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/ODE/versions/0.2.1/requires
+++ b/ODE/versions/0.2.1/requires
@@ -1,4 +1,4 @@
 julia 0.3
 Polynomials
 Compat 0.4.1
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/ODE/versions/0.4.0/requires
+++ b/ODE/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Polynomials
 Compat 0.9
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/ODE/versions/0.5.0/requires
+++ b/ODE/versions/0.5.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Polynomials
 Compat 0.9
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0

--- a/ODE/versions/0.6.0/requires
+++ b/ODE/versions/0.6.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 Polynomials
 Compat 0.17.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1

--- a/ODE/versions/0.7.0/requires
+++ b/ODE/versions/0.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 Polynomials
 Compat 0.17.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport

--- a/ODEInterfaceDiffEq/versions/0.2.0/requires
+++ b/ODEInterfaceDiffEq/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
 ODEInterface 0.0.11
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/ODEInterfaceDiffEq/versions/0.3.0/requires
+++ b/ODEInterfaceDiffEq/versions/0.3.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
 ODEInterface 0.0.11
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/ODEInterfaceDiffEq/versions/0.3.1/requires
+++ b/ODEInterfaceDiffEq/versions/0.3.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 ODEInterface 0.0.11
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Compat 0.17.0

--- a/ODEInterfaceDiffEq/versions/0.4.0/requires
+++ b/ODEInterfaceDiffEq/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 ODEInterface 0.0.11
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0
 Compat 0.17.0

--- a/ODEInterfaceDiffEq/versions/0.4.1/requires
+++ b/ODEInterfaceDiffEq/versions/0.4.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 ODEInterface 0.0.11
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Compat 0.17.0

--- a/ODEInterfaceDiffEq/versions/0.5.0/requires
+++ b/ODEInterfaceDiffEq/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ODEInterface 0.1.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Compat 0.17.0
 Reexport

--- a/ODEInterfaceDiffEq/versions/0.5.1/requires
+++ b/ODEInterfaceDiffEq/versions/0.5.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 ODEInterface 0.1.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Compat 0.17.0
 Reexport

--- a/ODEInterfaceDiffEq/versions/0.6.0/requires
+++ b/ODEInterfaceDiffEq/versions/0.6.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 ODEInterface 0.1.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Compat 0.17.0
 Reexport
 DataStructures

--- a/OrdinaryDiffEq/versions/2.21.0/requires
+++ b/OrdinaryDiffEq/versions/2.21.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.21.1/requires
+++ b/OrdinaryDiffEq/versions/2.21.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.21.2/requires
+++ b/OrdinaryDiffEq/versions/2.21.2/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.22.0/requires
+++ b/OrdinaryDiffEq/versions/2.22.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.23.0/requires
+++ b/OrdinaryDiffEq/versions/2.23.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.24.0/requires
+++ b/OrdinaryDiffEq/versions/2.24.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.24.1/requires
+++ b/OrdinaryDiffEq/versions/2.24.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.25.0/requires
+++ b/OrdinaryDiffEq/versions/2.25.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.25.1/requires
+++ b/OrdinaryDiffEq/versions/2.25.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.25.2/requires
+++ b/OrdinaryDiffEq/versions/2.25.2/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.26.0/requires
+++ b/OrdinaryDiffEq/versions/2.26.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.27.0/requires
+++ b/OrdinaryDiffEq/versions/2.27.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.28.0/requires
+++ b/OrdinaryDiffEq/versions/2.28.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2

--- a/OrdinaryDiffEq/versions/2.29.0/requires
+++ b/OrdinaryDiffEq/versions/2.29.0/requires
@@ -1,12 +1,12 @@
 julia 0.6.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.12.0 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.29.1/requires
+++ b/OrdinaryDiffEq/versions/2.29.1/requires
@@ -1,12 +1,12 @@
 julia 0.6.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.12.0 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.30.0/requires
+++ b/OrdinaryDiffEq/versions/2.30.0/requires
@@ -1,12 +1,12 @@
 julia 0.6.0
-DiffEqBase 2.6.0 3.0.0
+DiffEqBase 2.6.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.12.0 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.31.0/requires
+++ b/OrdinaryDiffEq/versions/2.31.0/requires
@@ -1,12 +1,12 @@
 julia 0.6.0
-DiffEqBase 2.6.0 3.0.0
+DiffEqBase 2.6.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.31.1/requires
+++ b/OrdinaryDiffEq/versions/2.31.1/requires
@@ -1,12 +1,12 @@
 julia 0.6.0
-DiffEqBase 2.6.0 3.0.0
+DiffEqBase 2.6.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.32.0/requires
+++ b/OrdinaryDiffEq/versions/2.32.0/requires
@@ -1,12 +1,12 @@
 julia 0.6.0
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.32.1/requires
+++ b/OrdinaryDiffEq/versions/2.32.1/requires
@@ -1,12 +1,12 @@
 julia 0.6.0
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.33.0/requires
+++ b/OrdinaryDiffEq/versions/2.33.0/requires
@@ -1,12 +1,12 @@
 julia 0.6
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.33.1/requires
+++ b/OrdinaryDiffEq/versions/2.33.1/requires
@@ -1,12 +1,12 @@
 julia 0.6
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.33.2/requires
+++ b/OrdinaryDiffEq/versions/2.33.2/requires
@@ -1,12 +1,12 @@
 julia 0.6
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.34.0/requires
+++ b/OrdinaryDiffEq/versions/2.34.0/requires
@@ -1,12 +1,12 @@
 julia 0.6
-DiffEqBase 2.10.0 3.0.0
+DiffEqBase 2.10.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.35.0/requires
+++ b/OrdinaryDiffEq/versions/2.35.0/requires
@@ -1,12 +1,12 @@
 julia 0.6
-DiffEqBase 2.10.0 3.0.0
+DiffEqBase 2.10.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.35.1/requires
+++ b/OrdinaryDiffEq/versions/2.35.1/requires
@@ -1,12 +1,12 @@
 julia 0.6
-DiffEqBase 2.10.0 3.0.0
+DiffEqBase 2.10.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.36.0/requires
+++ b/OrdinaryDiffEq/versions/2.36.0/requires
@@ -1,12 +1,12 @@
 julia 0.6
-DiffEqBase 2.10.0 3.0.0
+DiffEqBase 2.10.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/OrdinaryDiffEq/versions/2.37.0/requires
+++ b/OrdinaryDiffEq/versions/2.37.0/requires
@@ -1,12 +1,12 @@
 julia 0.6
-DiffEqBase 2.10.0 3.0.0
+DiffEqBase 2.10.0
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2
 NLsolve 0.12.1 0.14
 RecursiveArrayTools 0.13.0
 Juno 0.2.5
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0
 Roots 0.2.1
 DataStructures 0.4.6
 Compat 0.18.0

--- a/ParameterizedFunctions/versions/1.3.0/requires
+++ b/ParameterizedFunctions/versions/1.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.1.2
 DataStructures 0.4.6
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/2.0.0/requires
+++ b/ParameterizedFunctions/versions/2.0.0/requires
@@ -1,6 +1,6 @@
 julia 0.5
 SymEngine 0.2.0 # This is SymEngine.jl version, not SymEngine version!
 DataStructures 0.4.6
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 SimpleTraits 0.1.1
 Iterators

--- a/ParameterizedFunctions/versions/2.1.0/requires
+++ b/ParameterizedFunctions/versions/2.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.2.0
 DataStructures 0.4.6
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/2.1.1/requires
+++ b/ParameterizedFunctions/versions/2.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.2.0
 DataStructures 0.4.6
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/2.1.2/requires
+++ b/ParameterizedFunctions/versions/2.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.2.0
 DataStructures 0.4.6
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/2.2.0/requires
+++ b/ParameterizedFunctions/versions/2.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 SymEngine 0.2.0
 DataStructures 0.4.6
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/2.3.0/requires
+++ b/ParameterizedFunctions/versions/2.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 SymEngine 0.2.0
 DataStructures 0.4.6
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 SimpleTraits 0.1.1

--- a/ParameterizedFunctions/versions/2.3.1/requires
+++ b/ParameterizedFunctions/versions/2.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
 SymEngine 0.2.0
 DataStructures 0.4.6
-DiffEqBase 0.14.0 3.0.0
+DiffEqBase 0.14.0
 SimpleTraits 0.1.1

--- a/PyDSTool/versions/0.0.1/requires
+++ b/PyDSTool/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 PyCall
 DataStructures
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/PyDSTool/versions/0.0.2/requires
+++ b/PyDSTool/versions/0.0.2/requires
@@ -2,4 +2,4 @@ julia 0.5
 PyCall
 DataStructures
 Conda
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/PyDSTool/versions/0.1.0/requires
+++ b/PyDSTool/versions/0.1.0/requires
@@ -2,5 +2,5 @@ julia 0.5
 PyCall
 DataStructures
 Conda
-DiffEqBase 0.11.0 3.0.0
+DiffEqBase 0.11.0
 RecipesBase

--- a/PyDSTool/versions/0.1.1/requires
+++ b/PyDSTool/versions/0.1.1/requires
@@ -2,5 +2,5 @@ julia 0.5
 PyCall
 DataStructures
 Conda
-DiffEqBase 0.11.0 3.0.0
+DiffEqBase 0.11.0
 RecipesBase

--- a/PyDSTool/versions/0.1.2/requires
+++ b/PyDSTool/versions/0.1.2/requires
@@ -2,5 +2,5 @@ julia 0.5
 PyCall
 DataStructures
 Conda 0.2.0
-DiffEqBase 0.11.0 3.0.0
+DiffEqBase 0.11.0
 RecipesBase

--- a/RandomMatrices/versions/0.0.0/requires
+++ b/RandomMatrices/versions/0.0.0/requires
@@ -3,4 +3,4 @@ Distributions
 GSL
 julia 0.2.0-
 ODE
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/RandomMatrices/versions/0.0.1/requires
+++ b/RandomMatrices/versions/0.0.1/requires
@@ -2,4 +2,4 @@ julia 0.3-
 Catalan
 Distributions
 ODE
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/RandomMatrices/versions/0.0.2/requires
+++ b/RandomMatrices/versions/0.0.2/requires
@@ -2,4 +2,4 @@ julia 0.3-
 Catalan
 Distributions
 ODE
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/RandomMatrices/versions/0.1.0/requires
+++ b/RandomMatrices/versions/0.1.0/requires
@@ -2,4 +2,4 @@ julia 0.3
 Combinatorics
 Distributions
 ODE
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/RandomMatrices/versions/0.2.0/requires
+++ b/RandomMatrices/versions/0.2.0/requires
@@ -3,4 +3,4 @@ Combinatorics 0.2
 Docile
 Distributions
 ODE
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/RandomMatrices/versions/0.2.1/requires
+++ b/RandomMatrices/versions/0.2.1/requires
@@ -4,4 +4,4 @@ Distributions 0.8.10
 ODE 0.2.1
 GSL 0.3.1
 Compat 0.9.2
-OrdinaryDiffEq 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1

--- a/RandomMatrices/versions/0.3.0/requires
+++ b/RandomMatrices/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 Combinatorics 0.2
 Distributions 0.8.10
-OrdinaryDiffEq 2.19.1 3.0.0
+OrdinaryDiffEq 2.19.1
 GSL 0.3.1

--- a/SteadyStateDiffEq/versions/0.0.1/requires
+++ b/SteadyStateDiffEq/versions/0.0.1/requires
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 1.0.2 3.0.0
+DiffEqBase 1.0.2
 NLsolve 0.1 0.14

--- a/SteadyStateDiffEq/versions/0.1.0/requires
+++ b/SteadyStateDiffEq/versions/0.1.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 1.0.2 3.0.0
+DiffEqBase 1.0.2
 NLsolve 0.1 0.14
 Compat 0.17.0

--- a/StochasticDiffEq/versions/0.0.1/requires
+++ b/StochasticDiffEq/versions/0.0.1/requires
@@ -5,4 +5,4 @@ ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0
 ForwardDiff 0.0.0 0.5.0
 RecursiveArrayTools 0.0.0 0.13.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.0.2/requires
+++ b/StochasticDiffEq/versions/0.0.2/requires
@@ -5,4 +5,4 @@ ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0
 ForwardDiff 0.0.0 0.5.0
 RecursiveArrayTools 0.0.0 0.13.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.0.3/requires
+++ b/StochasticDiffEq/versions/0.0.3/requires
@@ -5,4 +5,4 @@ ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0
 ForwardDiff 0.0.0 0.5.0
 RecursiveArrayTools 0.0.0 0.13.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.0.4/requires
+++ b/StochasticDiffEq/versions/0.0.4/requires
@@ -5,4 +5,4 @@ ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0
 RecursiveArrayTools 0.0.0 0.13.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.0.5/requires
+++ b/StochasticDiffEq/versions/0.0.5/requires
@@ -4,4 +4,4 @@ ChunkedArrays 0.1.0
 DiffEqBase 0.0.0 0.8.0
 RecursiveArrayTools 0.0.0 0.13.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.1.0/requires
+++ b/StochasticDiffEq/versions/0.1.0/requires
@@ -4,4 +4,4 @@ ChunkedArrays 0.1.0
 DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2 0.13.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.1.1/requires
+++ b/StochasticDiffEq/versions/0.1.1/requires
@@ -4,4 +4,4 @@ ChunkedArrays 0.1.0
 DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2 0.13.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.2.0/requires
+++ b/StochasticDiffEq/versions/0.2.0/requires
@@ -4,4 +4,4 @@ ChunkedArrays 0.1.0
 DiffEqBase 0.2.0 0.8.0
 RecursiveArrayTools 0.0.2 0.13.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.3.0/requires
+++ b/StochasticDiffEq/versions/0.3.0/requires
@@ -7,4 +7,4 @@ DataStructures
 ResettableStacks
 Juno
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.4.0/requires
+++ b/StochasticDiffEq/versions/0.4.0/requires
@@ -7,4 +7,4 @@ DataStructures 0.4.6
 ResettableStacks 0.0.1
 Juno 0.2.5
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/0.5.0/requires
+++ b/StochasticDiffEq/versions/0.5.0/requires
@@ -7,4 +7,4 @@ DataStructures 0.4.6
 ResettableStacks 0.0.1
 Juno 0.2.5
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/1.0.0/requires
+++ b/StochasticDiffEq/versions/1.0.0/requires
@@ -8,4 +8,4 @@ Juno 0.2.5
 Roots
 Iterators
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/1.0.1/requires
+++ b/StochasticDiffEq/versions/1.0.1/requires
@@ -8,4 +8,4 @@ Juno 0.2.5
 Roots
 Iterators
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/1.0.2/requires
+++ b/StochasticDiffEq/versions/1.0.2/requires
@@ -8,4 +8,4 @@ Juno 0.2.5
 Roots
 Iterators
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/1.1.0/requires
+++ b/StochasticDiffEq/versions/1.1.0/requires
@@ -8,4 +8,4 @@ Juno 0.2.5
 Roots
 Iterators
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/1.2.0/requires
+++ b/StochasticDiffEq/versions/1.2.0/requires
@@ -9,4 +9,4 @@ Roots
 Iterators
 Compat 0.17.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/1.2.1/requires
+++ b/StochasticDiffEq/versions/1.2.1/requires
@@ -9,4 +9,4 @@ Roots
 Iterators
 Compat 0.17.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/1.3.0/requires
+++ b/StochasticDiffEq/versions/1.3.0/requires
@@ -9,4 +9,4 @@ Roots
 Iterators
 Compat 0.17.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/1.4.0/requires
+++ b/StochasticDiffEq/versions/1.4.0/requires
@@ -9,4 +9,4 @@ Roots
 Iterators
 Compat 0.17.0
 ForwardDiff 0.0.0 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.0.0/requires
+++ b/StochasticDiffEq/versions/2.0.0/requires
@@ -10,4 +10,4 @@ Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.0.1 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.0.1/requires
+++ b/StochasticDiffEq/versions/2.0.1/requires
@@ -10,4 +10,4 @@ Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.0.1 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.0.2/requires
+++ b/StochasticDiffEq/versions/2.0.2/requires
@@ -10,4 +10,4 @@ Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.0.1 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.0.3/requires
+++ b/StochasticDiffEq/versions/2.0.3/requires
@@ -10,4 +10,4 @@ Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.0.1 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.0.4/requires
+++ b/StochasticDiffEq/versions/2.0.4/requires
@@ -10,4 +10,4 @@ Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.0.1 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.1.0/requires
+++ b/StochasticDiffEq/versions/2.1.0/requires
@@ -10,4 +10,4 @@ Compat 0.17.0
 DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.0.1 0.5.0
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.10.0/requires
+++ b/StochasticDiffEq/versions/2.10.0/requires
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.11.0/requires
+++ b/StochasticDiffEq/versions/2.11.0/requires
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.11.1/requires
+++ b/StochasticDiffEq/versions/2.11.1/requires
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.12.0/requires
+++ b/StochasticDiffEq/versions/2.12.0/requires
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.12.1/requires
+++ b/StochasticDiffEq/versions/2.12.1/requires
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.13.0/requires
+++ b/StochasticDiffEq/versions/2.13.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.13.1/requires
+++ b/StochasticDiffEq/versions/2.13.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.14.0/requires
+++ b/StochasticDiffEq/versions/2.14.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.15.0/requires
+++ b/StochasticDiffEq/versions/2.15.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.15.1/requires
+++ b/StochasticDiffEq/versions/2.15.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.15.2/requires
+++ b/StochasticDiffEq/versions/2.15.2/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.0.0 3.0.0
+DiffEqBase 2.0.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.16.0/requires
+++ b/StochasticDiffEq/versions/2.16.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5

--- a/StochasticDiffEq/versions/2.17.0/requires
+++ b/StochasticDiffEq/versions/2.17.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5

--- a/StochasticDiffEq/versions/2.18.0/requires
+++ b/StochasticDiffEq/versions/2.18.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.18.1/requires
+++ b/StochasticDiffEq/versions/2.18.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.4.0 3.0.0
+DiffEqBase 2.4.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.19.0/requires
+++ b/StochasticDiffEq/versions/2.19.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.6.0 3.0.0
+DiffEqBase 2.6.0
 RecursiveArrayTools 0.8.0 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.2.0/requires
+++ b/StochasticDiffEq/versions/2.2.0/requires
@@ -11,4 +11,4 @@ DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.0.1 0.5.0
 StaticArrays
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.2.1/requires
+++ b/StochasticDiffEq/versions/2.2.1/requires
@@ -11,4 +11,4 @@ DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.0.1 0.5.0
 StaticArrays
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.20.0/requires
+++ b/StochasticDiffEq/versions/2.20.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.6.0 3.0.0
+DiffEqBase 2.6.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.20.1/requires
+++ b/StochasticDiffEq/versions/2.20.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.6.0 3.0.0
+DiffEqBase 2.6.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.21.0/requires
+++ b/StochasticDiffEq/versions/2.21.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.6.0 3.0.0
+DiffEqBase 2.6.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.22.0/requires
+++ b/StochasticDiffEq/versions/2.22.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.23.0/requires
+++ b/StochasticDiffEq/versions/2.23.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.23.1/requires
+++ b/StochasticDiffEq/versions/2.23.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.23.2/requires
+++ b/StochasticDiffEq/versions/2.23.2/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.23.3/requires
+++ b/StochasticDiffEq/versions/2.23.3/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.23.4/requires
+++ b/StochasticDiffEq/versions/2.23.4/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 Parameters 0.5.0
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 RecursiveArrayTools 0.13.0
 DataStructures 0.4.6
 Juno 0.2.5
@@ -13,4 +13,4 @@ StaticArrays
 Reexport
 RandomNumbers
 MuladdMacro
-DiffEqDiffTools 0.2.0 0.3.0
+DiffEqDiffTools 0.2.0

--- a/StochasticDiffEq/versions/2.3.0/requires
+++ b/StochasticDiffEq/versions/2.3.0/requires
@@ -10,4 +10,4 @@ DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.5.0 0.6.0
 StaticArrays
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.4.0/requires
+++ b/StochasticDiffEq/versions/2.4.0/requires
@@ -10,4 +10,4 @@ DiffEqNoiseProcess
 NLsolve 0.1 0.14
 ForwardDiff 0.5.0 0.6.0
 StaticArrays
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.5.0/requires
+++ b/StochasticDiffEq/versions/2.5.0/requires
@@ -11,4 +11,4 @@ NLsolve 0.1 0.14
 ForwardDiff 0.5.0 0.6.0
 StaticArrays
 Reexport
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.5.1/requires
+++ b/StochasticDiffEq/versions/2.5.1/requires
@@ -11,4 +11,4 @@ NLsolve 0.1 0.14
 ForwardDiff 0.5.0 0.6.0
 StaticArrays
 Reexport
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.6.0/requires
+++ b/StochasticDiffEq/versions/2.6.0/requires
@@ -11,4 +11,4 @@ NLsolve 0.1 0.14
 ForwardDiff 0.5.0 0.6.0
 StaticArrays
 Reexport
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.7.0/requires
+++ b/StochasticDiffEq/versions/2.7.0/requires
@@ -12,4 +12,4 @@ ForwardDiff 0.5.0 0.6.0
 StaticArrays
 Reexport
 RandomNumbers
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.7.1/requires
+++ b/StochasticDiffEq/versions/2.7.1/requires
@@ -12,4 +12,4 @@ ForwardDiff 0.5.0 0.6.0
 StaticArrays
 Reexport
 RandomNumbers
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.8.0/requires
+++ b/StochasticDiffEq/versions/2.8.0/requires
@@ -12,4 +12,4 @@ ForwardDiff 0.5.0 0.6.0
 StaticArrays
 Reexport
 RandomNumbers
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.9.0/requires
+++ b/StochasticDiffEq/versions/2.9.0/requires
@@ -12,4 +12,4 @@ ForwardDiff 0.5.0 0.6.0
 StaticArrays
 Reexport
 RandomNumbers
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StochasticDiffEq/versions/2.9.1/requires
+++ b/StochasticDiffEq/versions/2.9.1/requires
@@ -12,4 +12,4 @@ ForwardDiff 0.5.0 0.6.0
 StaticArrays
 Reexport
 RandomNumbers
-DiffEqDiffTools 0.0.1 0.3.0
+DiffEqDiffTools 0.0.1

--- a/StokesDiffEq/versions/0.2.0/requires
+++ b/StokesDiffEq/versions/0.2.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0
 VectorizedRoutines 0.0.2
 Parameters 0.5.0

--- a/Sundials/versions/0.0.0/requires
+++ b/Sundials/versions/0.0.0/requires
@@ -1,2 +1,2 @@
 julia 0.2-
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/0.1.0/requires
+++ b/Sundials/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 BinDeps
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/0.1.1/requires
+++ b/Sundials/versions/0.1.1/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 BinDeps
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/0.1.2/requires
+++ b/Sundials/versions/0.1.2/requires
@@ -1,3 +1,3 @@
 julia 0.2-
 BinDeps
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/0.1.3/requires
+++ b/Sundials/versions/0.1.3/requires
@@ -1,3 +1,3 @@
 julia 0.2
 BinDeps 0.3
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/0.10.0/requires
+++ b/Sundials/versions/0.10.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.9.0
-DiffEqBase 0.15.0 3.0.0
+DiffEqBase 0.15.0

--- a/Sundials/versions/0.11.0/requires
+++ b/Sundials/versions/0.11.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.9.0
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0

--- a/Sundials/versions/0.11.1/requires
+++ b/Sundials/versions/0.11.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0

--- a/Sundials/versions/0.12.0/requires
+++ b/Sundials/versions/0.12.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
-DiffEqBase 1.0.0 3.0.0
+DiffEqBase 1.0.0

--- a/Sundials/versions/0.13.0/requires
+++ b/Sundials/versions/0.13.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1

--- a/Sundials/versions/0.14.0/requires
+++ b/Sundials/versions/0.14.0/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1

--- a/Sundials/versions/0.14.1/requires
+++ b/Sundials/versions/0.14.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1

--- a/Sundials/versions/0.14.2/requires
+++ b/Sundials/versions/0.14.2/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1

--- a/Sundials/versions/0.14.3/requires
+++ b/Sundials/versions/0.14.3/requires
@@ -1,5 +1,5 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport

--- a/Sundials/versions/0.15.0/requires
+++ b/Sundials/versions/0.15.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 BinDeps 0.4.3
 Compat 0.17.0
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport

--- a/Sundials/versions/0.16.0/requires
+++ b/Sundials/versions/0.16.0/requires
@@ -1,4 +1,4 @@
 julia 0.6
 BinDeps 0.4.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport

--- a/Sundials/versions/0.17.0/requires
+++ b/Sundials/versions/0.17.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 BinDeps 0.4.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport
 DataStructures
 Roots

--- a/Sundials/versions/0.17.1/requires
+++ b/Sundials/versions/0.17.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 BinDeps 0.4.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport
 DataStructures
 Roots

--- a/Sundials/versions/0.18.0/requires
+++ b/Sundials/versions/0.18.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 BinDeps 0.4.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport
 DataStructures
 Roots

--- a/Sundials/versions/0.18.1/requires
+++ b/Sundials/versions/0.18.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 BinDeps 0.4.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport
 DataStructures
 Roots

--- a/Sundials/versions/0.18.2/requires
+++ b/Sundials/versions/0.18.2/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 BinDeps 0.4.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport
 DataStructures
 Roots

--- a/Sundials/versions/0.18.3/requires
+++ b/Sundials/versions/0.18.3/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 BinDeps 0.4.3
-DiffEqBase 1.5.1 3.0.0
+DiffEqBase 1.5.1
 Reexport
 DataStructures
 Roots

--- a/Sundials/versions/0.19.0/requires
+++ b/Sundials/versions/0.19.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 BinDeps 0.4.3
-DiffEqBase 2.8.0 3.0.0
+DiffEqBase 2.8.0
 Reexport
 DataStructures
 Roots

--- a/Sundials/versions/0.2.0/requires
+++ b/Sundials/versions/0.2.0/requires
@@ -1,3 +1,3 @@
 julia 0.4-
 BinDeps 0.3
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/0.2.1/requires
+++ b/Sundials/versions/0.2.1/requires
@@ -1,4 +1,4 @@
 julia 0.4
 BinDeps 0.3
 Compat
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/0.2.2/requires
+++ b/Sundials/versions/0.2.2/requires
@@ -1,4 +1,4 @@
 julia 0.4
 BinDeps 0.3
 Compat
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/0.3.0/requires
+++ b/Sundials/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.4
 BinDeps 0.4.3
 Compat 0.9.0
-DiffEqBase 0.0.1 3.0.0
+DiffEqBase 0.0.1

--- a/Sundials/versions/1.0.0/requires
+++ b/Sundials/versions/1.0.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 BinaryProvider
-DiffEqBase 2.10.0 3.0.0
+DiffEqBase 2.10.0
 Reexport
 DataStructures
 Roots

--- a/SwitchTimeOpt/versions/0.0.1/requires
+++ b/SwitchTimeOpt/versions/0.0.1/requires
@@ -2,5 +2,5 @@ julia 0.4
 MathProgBase
 ODE
 Ipopt
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/SwitchTimeOpt/versions/0.0.2/requires
+++ b/SwitchTimeOpt/versions/0.0.2/requires
@@ -2,5 +2,5 @@ julia 0.4
 MathProgBase
 ODE
 Ipopt
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/SwitchTimeOpt/versions/0.1.0/requires
+++ b/SwitchTimeOpt/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
 MathProgBase
 ODE
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1

--- a/SwitchTimeOpt/versions/0.2.0/requires
+++ b/SwitchTimeOpt/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 MathProgBase
-DiffEqBase 0.0.1 3.0.0
-OrdinaryDiffEq 0.0.1 3.0.0
+DiffEqBase 0.0.1
+OrdinaryDiffEq 0.0.1
 Ipopt

--- a/VehicleModels/versions/0.1.2/requires
+++ b/VehicleModels/versions/0.1.2/requires
@@ -3,6 +3,6 @@ NLOptControl
 Parameters
 JuMP
 Interpolations
-OrdinaryDiffEq 0.0.1 3.0.0
-DiffEqBase 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
+DiffEqBase 0.0.1
 Ranges

--- a/VehicleModels/versions/0.1.3/requires
+++ b/VehicleModels/versions/0.1.3/requires
@@ -3,6 +3,6 @@ NLOptControl 0.1.3
 Parameters
 JuMP
 Interpolations
-OrdinaryDiffEq 0.0.1 3.0.0
-DiffEqBase 0.0.1 3.0.0
+OrdinaryDiffEq 0.0.1
+DiffEqBase 0.0.1
 Ranges


### PR DESCRIPTION
Technically all of these upper bounds are correct. They were for the DiffEq 4.0 update, with the breaking changes described here:

http://juliadiffeq.org/2018/01/24/Parameters.html

It was undeprecatable and massively breaking, but now in the past. Any new installation gets all the latest versions just fine.

But this is still causing all sorts of resolver issues. Most are in chats and stuff, but here's a thread on Discourse:

https://discourse.julialang.org/t/cannot-add-differentialequations/8660

It's the root cause of the resolver issues with a much smaller change:

https://github.com/JuliaLang/METADATA.jl/pull/13381

This fix would probably break less uses than https://github.com/JuliaLang/METADATA.jl/pull/13381 simply because it's less recent.

Honestly, the resolver is doing so much more harm than good at this point that this fix is effectively "turning it off". Hopefully that will allow people to update their packages, and allow for METADATA to not break whenever the resolver has to think about this. It will just end up giving everyone the newest versions of the packages they can get, which in pretty much any case will work. It served a purpose to make sure people did get a "half upgrade" of DiffEq while it was still in development, but now all it does is make the resolver weep.

While this is a nasty way to fix the issue, I hope this is acceptable.

@andreasnoack @KristofferC 