### PR TITLE
Tag BlockArrays v0.3.0 [https://github.com/KristofferC/BlockArrays.jl]

### DIFF
--- a/BlockArrays/versions/0.3.0/requires
+++ b/BlockArrays/versions/0.3.0/requires
@@ -1,0 +1,2 @@
+julia 0.6
+Compat 0.39

--- a/BlockArrays/versions/0.3.0/sha1
+++ b/BlockArrays/versions/0.3.0/sha1
@@ -1,0 +1,1 @@
+1b6f7edc2654eaca244cbf77d6a183a4093d8aa6


### PR DESCRIPTION
Diff vs v0.2.0: https://github.com/KristofferC/BlockArrays.jl/compare/4fd38a2a9b3097b16c3a9c049e63d319d5aa8289...1b6f7edc2654eaca244cbf77d6a183a4093d8aa6


1. Updated for Julia v0.7
2. New syntax `BlockArrays(uninitialized_blocks, ...)` a la Julia v0.7
3. Improved support for views