### PR TITLE
Tag ODEInterface v0.4.2 [https://github.com/luchr/ODEInterface.jl]

### DIFF
--- a/ODEInterface/versions/0.4.2/requires
+++ b/ODEInterface/versions/0.4.2/requires
@@ -1,0 +1,1 @@
+julia 0.7-DEV

--- a/ODEInterface/versions/0.4.2/sha1
+++ b/ODEInterface/versions/0.4.2/sha1
@@ -1,0 +1,1 @@
+5cd6720cf091b62c9a11bf2046dcada6e1e8fc55


### PR DESCRIPTION
* Workaround for Issue https://github.com/JuliaLang/julia/issues/25281 to make ODEInterface-Package usable again in julia v0.7/trunk.

A lot of syntax/deprecation changes for julia v0.7/trunk:
* `STDERR -> stderr`
* use newline instead of `->` in doc syntax 
* `unsafe_warp`: own-arg
* Pkg moved from base to stdlib: Libdl, Markdown, LinearAlgebra, Test, Unicode
* `Void -> Cvoid`
* use "uninitialized" for `Matrix{}`, `Vector{}`: `Array{}(uninitialized, ...)`
* `cfunction` with `Tuple{...}`

At the moment: no errors or warnings in the current nightlies during build and test.
