### PR TITLE
Move LCMCore.jl URL from rdeits to JuliaRobotics

### DIFF
--- a/LCMCore/url
+++ b/LCMCore/url
@@ -1,1 +1,1 @@
-https://github.com/rdeits/LCMCore.jl.git
+https://github.com/JuliaRobotics/LCMCore.jl.git


### PR DESCRIPTION
You can see the github redirect already in place: <https://github.com/rdeits/LCMCore.jl>