### PR TITLE
Update package URLs after move to JuliaRobotics organization.

### DIFF
--- a/AprilTags/url
+++ b/AprilTags/url
@@ -1,1 +1,1 @@
-https://github.com/Affie/AprilTags.jl.git
+https://github.com/JuliaRobotics/AprilTags.jl.git

--- a/MotionCaptureJointCalibration/url
+++ b/MotionCaptureJointCalibration/url
@@ -1,1 +1,1 @@
-https://github.com/tkoolen/MotionCaptureJointCalibration.jl.git
+https://github.com/JuliaRobotics/MotionCaptureJointCalibration.jl.git

--- a/RigidBodyDynamics/url
+++ b/RigidBodyDynamics/url
@@ -1,1 +1,1 @@
-https://github.com/tkoolen/RigidBodyDynamics.jl.git
+https://github.com/JuliaRobotics/RigidBodyDynamics.jl.git

--- a/RigidBodySim/url
+++ b/RigidBodySim/url
@@ -1,1 +1,1 @@
-https://github.com/tkoolen/RigidBodySim.jl.git
+https://github.com/JuliaRobotics/RigidBodySim.jl.git


### PR DESCRIPTION
@Affie (and @dehann), I took the liberty of changing the AprilTags.jl URL as well.