### PR TITLE
BioAlignments retag

### DIFF
--- a/BioAlignments/versions/0.1.0/requires
+++ b/BioAlignments/versions/0.1.0/requires
@@ -2,7 +2,7 @@ julia 0.5
 Automa
 BioCore 1.0
 BioSequences 0.5
-BioSymbols 1.0
+BioSymbols 1.0 2.0
 BufferedStreams
 BGZFStreams
 Compat 0.17

--- a/BioAlignments/versions/0.2.0/requires
+++ b/BioAlignments/versions/0.2.0/requires
@@ -3,7 +3,7 @@ Automa 0.1
 BGZFStreams 0.0.1
 BioCore 1.0
 BioSequences 0.6
-BioSymbols 1.0
+BioSymbols 1.0 2.0
 BufferedStreams 0.3
 GenomicFeatures 0.1
 IntervalTrees 0.1


### PR DESCRIPTION
The new release of BioSymbols v2.0, breaks current versions of BioAlignments, so I've altered their require lines to avoid any issues when installing. ref: #13812 