### PR TITLE
Upper bound LineSearches in Optim v0.14.1

### DIFF
--- a/Optim/versions/0.14.1/requires
+++ b/Optim/versions/0.14.1/requires
@@ -1,7 +1,7 @@
 julia 0.6.0
 PositiveFactorizations
 Compat 0.18.0
-LineSearches 3.2.4
+LineSearches 3.2.4 4.0.0
 Calculus
 NLSolversBase 4.0.0
 ForwardDiff 0.5.0


### PR DESCRIPTION
The Optim v0.14.1 entry was not in my local metadata when I made th prevoius PR.