### PR TITLE
Bound BinaryProvider versions on Ipopt

### DIFF
--- a/Ipopt/versions/0.3.0/requires
+++ b/Ipopt/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 MathProgBase 0.5 0.8
-BinaryProvider
+BinaryProvider 0.2.5 0.3
 BinDeps
 Compat 0.27


### PR DESCRIPTION
Recent changes appear to have broken the package (https://github.com/JuliaOpt/Ipopt.jl/issues/110). This should prevent further user-visible breakage until we can address the underlying issue. I picked 0.2.5 as the version of BinaryProvided that was released when we last tagged Ipopt.
@staticfloat 