### PR TITLE
Add upper bounds on CategoricalArrays 0.3.8 to StatsModels

### DIFF
--- a/StatsModels/versions/0.1.0/requires
+++ b/StatsModels/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DataFrames 0.11
-CategoricalArrays 0.3.0
+CategoricalArrays 0.3.0 0.3.8
 Missings
 StatsBase 0.11.1
 Compat 0.9.2

--- a/StatsModels/versions/0.2.0/requires
+++ b/StatsModels/versions/0.2.0/requires
@@ -2,3 +2,4 @@ julia 0.6
 DataFrames 0.11
 StatsBase 0.19.2
 Compat 0.33.0
+CategoricalArrays 0.3.0 0.3.8

--- a/StatsModels/versions/0.2.1/requires
+++ b/StatsModels/versions/0.2.1/requires
@@ -2,3 +2,4 @@ julia 0.6
 DataFrames 0.11
 StatsBase 0.19.2
 Compat 0.33.0
+CategoricalArrays 0.3.0 0.3.8

--- a/StatsModels/versions/0.2.2/requires
+++ b/StatsModels/versions/0.2.2/requires
@@ -2,3 +2,4 @@ julia 0.6
 DataFrames 0.11
 StatsBase 0.19.2
 Compat 0.33.0
+CategoricalArrays 0.3.0 0.3.8


### PR DESCRIPTION
That version changed the behavior of unique, which breaks older StatsModels releases (https://github.com/JuliaStats/StatsModels.jl/pull/55).

Merge after the new StatsModels version is tagged (https://github.com/JuliaLang/METADATA.jl/pull/14303).