### PR TITLE
Revert "Tag DataStructures.jl v0.8.0 [https://github.com/JuliaCollect…

### DIFF
--- a/DataStructures/versions/0.8.0/requires
+++ b/DataStructures/versions/0.8.0/requires
@@ -1,2 +1,0 @@
-julia 0.6
-Compat 0.61.0

--- a/DataStructures/versions/0.8.0/sha1
+++ b/DataStructures/versions/0.8.0/sha1
@@ -1,1 +1,0 @@
-a1e9df5538ca099f23e67af177ffa29cdf30c50e


### PR DESCRIPTION
…ions/DataStructures.jl/releases/tag/v0.8.0] (#14335)"

This reverts commit 9e8e6c66c899b28c0ab97595db323277bd6e8a26.

See https://github.com/JuliaCollections/DataStructures.jl/issues/377. This breaks JLD2 and probably other packages as well.

cc: @ararslan 