### PR TITLE
Update url of package SOM.jl

### DIFF
--- a/SOM/url
+++ b/SOM/url
@@ -1,1 +1,1 @@
-https://github.com/andreasdominik/SOM.jl.git
+https://github.com/LiScI-Lab/SOM.jl.git


### PR DESCRIPTION
Dear Administrators.
The Github repo has a **new url:**

The **first releases** 
were published from my personal github account (andreasdominik) ...

In the **meanwhile** 
more and more projects in my team are migrated to Julia
and as a result we started to develop more Julia packages (and reduce our
activity with R). Different students and researchers are owners of
the projects. Therefore it make sense to have all packages in one
organisation structure at Github and not in different personal accounts.

I did the repo transfer with the splendid Github transfer tool, so that
all links to the original repo keep in place (cloning from the old
repo is still possible and reflects updates). However it make sense to change the repo path of the
package to the new location. 

Thank you very much for your help
Cordially
Andreas