### PR TITLE
Add upper bound to xtensor CXXWrap version

### DIFF
--- a/Xtensor/versions/0.0.1/requires
+++ b/Xtensor/versions/0.0.1/requires
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.2
 Compat 0.21
-CxxWrap 0.4
+CxxWrap 0.4 0.5

--- a/Xtensor/versions/0.0.10/requires
+++ b/Xtensor/versions/0.0.10/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6

--- a/Xtensor/versions/0.0.11/requires
+++ b/Xtensor/versions/0.0.11/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6

--- a/Xtensor/versions/0.0.2/requires
+++ b/Xtensor/versions/0.0.2/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.4.1
+CxxWrap 0.4.1 0.5

--- a/Xtensor/versions/0.0.3/requires
+++ b/Xtensor/versions/0.0.3/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.4.1
+CxxWrap 0.4.1 0.5

--- a/Xtensor/versions/0.0.4/requires
+++ b/Xtensor/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6

--- a/Xtensor/versions/0.0.5/requires
+++ b/Xtensor/versions/0.0.5/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6

--- a/Xtensor/versions/0.0.6/requires
+++ b/Xtensor/versions/0.0.6/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6

--- a/Xtensor/versions/0.0.7/requires
+++ b/Xtensor/versions/0.0.7/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6

--- a/Xtensor/versions/0.0.8/requires
+++ b/Xtensor/versions/0.0.8/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6

--- a/Xtensor/versions/0.0.9/requires
+++ b/Xtensor/versions/0.0.9/requires
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6

--- a/Xtensor/versions/0.1.0/requires
+++ b/Xtensor/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.6
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6-

--- a/Xtensor/versions/0.1.0/requires
+++ b/Xtensor/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.6
 BinDeps 0.4.2
-CxxWrap 0.5.0 0.6-
+CxxWrap 0.5.0 0.6


### PR DESCRIPTION
Is it ok to add this upper bound now, or do we have to release a new version of xtensor-julia?