### PR TITLE
Add upper bounds on GLM in Lasso

### DIFF
--- a/Lasso/versions/0.0.1/requires
+++ b/Lasso/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.3.6-
 StatsBase
 Distributions
-GLM
+GLM 0.4.8 0.11
 Reexport

--- a/Lasso/versions/0.0.2/requires
+++ b/Lasso/versions/0.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.3.6-
 StatsBase 0.6.11+
 Distributions
-GLM
+GLM 0.4.8 0.11
 Reexport

--- a/Lasso/versions/0.0.3/requires
+++ b/Lasso/versions/0.0.3/requires
@@ -1,5 +1,5 @@
 julia 0.3.6-
 StatsBase 0.6.11+
 Distributions
-GLM
+GLM 0.4.8 0.11
 Reexport

--- a/Lasso/versions/0.0.4/requires
+++ b/Lasso/versions/0.0.4/requires
@@ -1,6 +1,6 @@
 julia 0.3.7
 StatsBase 0.6.12
 Distributions
-GLM 0.4.8
+GLM 0.4.8 0.11
 Reexport
 Compat


### PR DESCRIPTION
As the only package, `Lasso` calls `GLM.initialeta!` which now has the output argument first.