### PR TITLE
Add upper bound on Compat for StatsBase versions that don't

### DIFF
--- a/StatsBase/versions/0.18.0/requires
+++ b/StatsBase/versions/0.18.0/requires
@@ -1,3 +1,4 @@
 julia 0.6
 DataStructures 0.5.0
 SpecialFunctions 0.1.0
+Compat 0.0.0 0.55

--- a/StatsBase/versions/0.19.0/requires
+++ b/StatsBase/versions/0.19.0/requires
@@ -1,3 +1,4 @@
 julia 0.6
 DataStructures 0.5.0
 SpecialFunctions 0.1.0
+Compat 0.0.0 0.55


### PR DESCRIPTION
explicitly use Compat to avoid stderr conflict caused by other
packages using Compat