### PR TITLE
Add upper bounds on Julia 0.6 for ExperimentalAnalysis since package

### DIFF
--- a/ExperimentalAnalysis/versions/0.0.1/requires
+++ b/ExperimentalAnalysis/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6
 DataFrames 0.0.0 0.11.0
 Plots 0.0 0.7
 PyPlot

--- a/ExperimentalAnalysis/versions/0.0.2/requires
+++ b/ExperimentalAnalysis/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.6
 DataFrames 0.0.0 0.11.0
 Plots 0.0 0.7
 PyPlot

--- a/ExperimentalAnalysis/versions/0.1.0/requires
+++ b/ExperimentalAnalysis/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.6
 DataFrames 0.0.0 0.11.0
 Plots
 GLM 0.0 0.11

--- a/ExperimentalAnalysis/versions/0.1.1/requires
+++ b/ExperimentalAnalysis/versions/0.1.1/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.6
 DataFrames 0.0.0 0.11.0
 Plots
 GLM 0.0 0.11


### PR DESCRIPTION
uses ~ parsed as macro which stopped working in Julia 0.6