### PR TITLE
Move ReferenceFrameRotations.jl to SatelliteToolbox Org

### DIFF
--- a/ReferenceFrameRotations/url
+++ b/ReferenceFrameRotations/url
@@ -1,1 +1,1 @@
-https://github.com/ronisbr/ReferenceFrameRotations.jl.git
+https://github.com/SatelliteToolbox/ReferenceFrameRotations.jl.git


### PR DESCRIPTION
The package ReferenceFrameRotations.jl was transfered to the
Organization SatelliteToolbox and this commit updates the URL of
the package.