### PR TITLE
Add upper bound to NLsolve

### DIFF
--- a/NLsolve/versions/1.1.0/requires
+++ b/NLsolve/versions/1.1.0/requires
@@ -4,4 +4,4 @@ Distances
 ForwardDiff 0.7.0
 LineSearches 4.0.0
 DiffBase
-NLSolversBase 4.0.0
+NLSolversBase 4.0.0 5.0.0


### PR DESCRIPTION
This was a mistake. The upper bounds was only present in METADATA and not the repo as such. It should have been there all along.