### PR TITLE
Requesting exception for mPulseAPI 1.0.7 to support julia 0.4

### DIFF
--- a/.test/list_3582.jl
+++ b/.test/list_3582.jl
@@ -1521,5 +1521,5 @@ maxver_list_3582 = Dict([ # List of grandfathered packages
     ("ZipFile", v"0.5.0"),
     ("Zlib", v"0.1.12"),
     ("kNN", v"0.0.0"),
-    ("mPulseAPI", v"1.0.6"),
+    ("mPulseAPI", v"1.0.7"),
     ])


### PR DESCRIPTION
Requesting an exception for `mPulseAPI v1.0.7` to continue to support julia v0.4.  We have current paying customers using our code with julia 0.4 and have tested extensively that all parts continue to work with julia 0.4.

Ref: https://github.com/JuliaLang/METADATA.jl/pull/14733#issuecomment-390623046

Thanks.