### PR TITLE
update URL for new organization

### DIFF
--- a/MIDI/url
+++ b/MIDI/url
@@ -1,1 +1,1 @@
-git://github.com/JoelHobson/MIDI.jl.git
+git://github.com/JuliaMusic/MIDI.jl.git


### PR DESCRIPTION
Otherwise attobot cannot tag a release in metadata...