### PR TITLE
Add upper bounds to SumOfSquares for MultivariateMoments

### DIFF
--- a/SumOfSquares/versions/0.1.0/requires
+++ b/SumOfSquares/versions/0.1.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 MultivariatePolynomials 0.1.1
 SemialgebraicSets 0.0.2
-MultivariateMoments
+MultivariateMoments 0.0.1 0.1.0
 JuMP
 PolyJuMP 0.1.0

--- a/SumOfSquares/versions/0.1.1/requires
+++ b/SumOfSquares/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.6
 MultivariatePolynomials 0.1.1
 SemialgebraicSets 0.0.2
-MultivariateMoments
+MultivariateMoments 0.0.1 0.1.0
 JuMP
 PolyJuMP 0.1.0


### PR DESCRIPTION
The release v0.1.0 of MultivariateMoments is going to break SumOfSquares but upper bounds can prevent this to harm anyone