### PR TITLE
Upper bound julia version for older ACME versions

### DIFF
--- a/ACME/versions/0.2.0/requires
+++ b/ACME/versions/0.2.0/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7.0-DEV.3220
 Compat 0.9.0
 ProgressMeter 0.2.1

--- a/ACME/versions/0.2.1/requires
+++ b/ACME/versions/0.2.1/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7.0-DEV.3220
 Compat 0.9.0
 ProgressMeter 0.2.1

--- a/ACME/versions/0.2.2/requires
+++ b/ACME/versions/0.2.2/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7.0-DEV.3220
 Compat 0.9.0
 ProgressMeter 0.2.1

--- a/ACME/versions/0.3.0/requires
+++ b/ACME/versions/0.3.0/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7.0-DEV.3220
 Compat 0.9.0
 ProgressMeter 0.2.1


### PR DESCRIPTION
These ACME versions fail during `using` on julia 0.7.0-DEV.3220 and later.