### PR TITLE
Bump MOI upper bound to v0.5 for ECOS

### DIFF
--- a/ECOS/versions/0.9.0/requires
+++ b/ECOS/versions/0.9.0/requires
@@ -1,6 +1,6 @@
 julia 0.6
 BinDeps
 MathProgBase 0.5 0.8
-MathOptInterface 0.3 0.4
+MathOptInterface 0.3 0.5
 @osx Homebrew
 Compat 0.63


### PR DESCRIPTION
No changes are needed for ECOS in order to work with MathOptInterface (MOI) v0.4.
See https://github.com/JuliaOpt/ECOS.jl/pull/68