### PR TITLE
Bump MOI upper bound to v0.5 for CSDP

### DIFF
--- a/CSDP/versions/0.1.0/requires
+++ b/CSDP/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 BinDeps
 Glob
-MathOptInterface 0.3 0.4
-SemidefiniteOptInterface 0.0.1 0.1
+MathOptInterface 0.3 0.5
+SemidefiniteOptInterface 0.0.1 0.2
 MathProgBase 0.7 0.8
 SemidefiniteModels 0.0.3 0.1


### PR DESCRIPTION
No changes are needed for ECOS in order to work with MathOptInterface (MOI) v0.4. The needed changes will be in SemidefiniteOptInterface v0.1.
See https://github.com/JuliaOpt/CSDP.jl/pull/24