### PR TITLE
upper bound for ToeplitzMatrices 0.4

### DIFF
--- a/FastTransforms/versions/0.0.4/requires
+++ b/FastTransforms/versions/0.0.4/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ToeplitzMatrices 0.1
+ToeplitzMatrices 0.1 0.4
 Compat 0.8.4

--- a/FastTransforms/versions/0.0.5/requires
+++ b/FastTransforms/versions/0.0.5/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ToeplitzMatrices 0.1
+ToeplitzMatrices 0.1 0.4
 Compat 0.8.4

--- a/FastTransforms/versions/0.0.6/requires
+++ b/FastTransforms/versions/0.0.6/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ToeplitzMatrices 0.1
+ToeplitzMatrices 0.1 0.4
 Compat 0.8.4

--- a/FastTransforms/versions/0.0.7/requires
+++ b/FastTransforms/versions/0.0.7/requires
@@ -1,3 +1,3 @@
 julia 0.4
-ToeplitzMatrices 0.1
+ToeplitzMatrices 0.1 0.4
 Compat 0.8.4

--- a/FastTransforms/versions/0.1.0/requires
+++ b/FastTransforms/versions/0.1.0/requires
@@ -1,3 +1,3 @@
 julia 0.5
-ToeplitzMatrices 0.2
+ToeplitzMatrices 0.2 0.4
 Compat 0.17

--- a/FastTransforms/versions/0.2.0/requires
+++ b/FastTransforms/versions/0.2.0/requires
@@ -1,5 +1,5 @@
 julia 0.5
-ToeplitzMatrices 0.2
+ToeplitzMatrices 0.2 0.4
 HierarchicalMatrices 0.0.1 0.1.1
 LowRankApprox 0.0.2
 ProgressMeter 0.3.4

--- a/FastTransforms/versions/0.2.1/requires
+++ b/FastTransforms/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.5
-ToeplitzMatrices 0.2
+ToeplitzMatrices 0.2 0.4
 HierarchicalMatrices 0.0.2 0.1.1
 LowRankApprox 0.0.2
 ProgressMeter 0.3.4

--- a/FastTransforms/versions/0.2.2/requires
+++ b/FastTransforms/versions/0.2.2/requires
@@ -1,5 +1,5 @@
 julia 0.5
-ToeplitzMatrices 0.2
+ToeplitzMatrices 0.2 0.4
 HierarchicalMatrices 0.0.2 0.1.1
 LowRankApprox 0.0.2
 ProgressMeter 0.3.4

--- a/FastTransforms/versions/0.3.0/requires
+++ b/FastTransforms/versions/0.3.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-ToeplitzMatrices 0.2
+ToeplitzMatrices 0.2 0.4
 HierarchicalMatrices 0.1 0.1.1
 LowRankApprox 0.0.2
 ProgressMeter 0.3.4

--- a/FastTransforms/versions/0.3.1/requires
+++ b/FastTransforms/versions/0.3.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-ToeplitzMatrices 0.2
+ToeplitzMatrices 0.2 0.4
 HierarchicalMatrices 0.1 0.1.1
 LowRankApprox 0.1.1
 ProgressMeter 0.3.4

--- a/FastTransforms/versions/0.3.2/requires
+++ b/FastTransforms/versions/0.3.2/requires
@@ -1,5 +1,5 @@
 julia 0.6
-ToeplitzMatrices 0.2
+ToeplitzMatrices 0.2 0.4
 HierarchicalMatrices 0.1.1
 LowRankApprox 0.1.1
 ProgressMeter 0.3.4


### PR DESCRIPTION
Adds upper bounds in FastTransforms.jl for new ToeplitzMatrices.jl.