### PR TITLE
update Clipper url to use the JuliaGeometry fork

### DIFF
--- a/Clipper/url
+++ b/Clipper/url
@@ -1,1 +1,1 @@
-git://github.com/Voxel8/Clipper.jl.git
+git://github.com/JuliaGeometry/Clipper.jl.git


### PR DESCRIPTION
as agreed with @maxvoxel8 in https://github.com/Voxel8/Clipper.jl/pull/29, we want to make JuliaGeometry/Clipper.jl the official repository.
Let me know if there is more to do than just changing the URL!