### PR TITLE
Retire GLPK version 0.5.2

### DIFF
--- a/GLPK/versions/0.5.2/requires
+++ b/GLPK/versions/0.5.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 1000
 BinDeps
 @osx Homebrew
 Compat 0.66


### PR DESCRIPTION
It had the wrong version, should have been 0.6.1, sorry. So this PR just makes it incompatible with any julia version, and should happen together with #15788, I guess.