### PR TITLE
Cap AxisAlgorithms version in Interpolations requires

### DIFF
--- a/Interpolations/versions/0.1.1/requires
+++ b/Interpolations/versions/0.1.1/requires
@@ -2,4 +2,4 @@ julia 0.4-
 
 WoodburyMatrices 0.1
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3

--- a/Interpolations/versions/0.2.0/requires
+++ b/Interpolations/versions/0.2.0/requires
@@ -2,4 +2,4 @@ julia 0.4-
 
 WoodburyMatrices 0.1
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3

--- a/Interpolations/versions/0.3.0/requires
+++ b/Interpolations/versions/0.3.0/requires
@@ -2,4 +2,4 @@ julia 0.4-
 
 WoodburyMatrices 0.1
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3

--- a/Interpolations/versions/0.3.1/requires
+++ b/Interpolations/versions/0.3.1/requires
@@ -2,4 +2,4 @@ julia 0.4-
 
 WoodburyMatrices 0.1
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3

--- a/Interpolations/versions/0.3.2/requires
+++ b/Interpolations/versions/0.3.2/requires
@@ -2,4 +2,4 @@ julia 0.4-
 
 WoodburyMatrices 0.1
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3

--- a/Interpolations/versions/0.3.3/requires
+++ b/Interpolations/versions/0.3.3/requires
@@ -2,4 +2,4 @@ julia 0.4-
 
 WoodburyMatrices 0.1
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3

--- a/Interpolations/versions/0.3.4/requires
+++ b/Interpolations/versions/0.3.4/requires
@@ -2,4 +2,4 @@ julia 0.4
 
 WoodburyMatrices 0.1
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3

--- a/Interpolations/versions/0.3.5/requires
+++ b/Interpolations/versions/0.3.5/requires
@@ -2,4 +2,4 @@ julia 0.4
 
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3

--- a/Interpolations/versions/0.3.6/requires
+++ b/Interpolations/versions/0.3.6/requires
@@ -2,5 +2,5 @@ julia 0.4
 
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.8.0

--- a/Interpolations/versions/0.3.7/requires
+++ b/Interpolations/versions/0.3.7/requires
@@ -1,6 +1,6 @@
 julia 0.4
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.8.0
 DualNumbers

--- a/Interpolations/versions/0.3.8/requires
+++ b/Interpolations/versions/0.3.8/requires
@@ -1,6 +1,6 @@
 julia 0.4
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.4.0/requires
+++ b/Interpolations/versions/0.4.0/requires
@@ -2,6 +2,6 @@ julia 0.5
 
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.5.0/requires
+++ b/Interpolations/versions/0.5.0/requires
@@ -3,6 +3,6 @@ julia 0.5
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.6.0/requires
+++ b/Interpolations/versions/0.6.0/requires
@@ -3,6 +3,6 @@ julia 0.5
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.6.1/requires
+++ b/Interpolations/versions/0.6.1/requires
@@ -3,6 +3,6 @@ julia 0.5
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.6.2/requires
+++ b/Interpolations/versions/0.6.2/requires
@@ -3,6 +3,6 @@ julia 0.5
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.6.3/requires
+++ b/Interpolations/versions/0.6.3/requires
@@ -3,6 +3,6 @@ julia 0.5
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.7.0/requires
+++ b/Interpolations/versions/0.7.0/requires
@@ -3,6 +3,6 @@ julia 0.6
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.7.1/requires
+++ b/Interpolations/versions/0.7.1/requires
@@ -3,6 +3,6 @@ julia 0.6
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.7.2/requires
+++ b/Interpolations/versions/0.7.2/requires
@@ -3,6 +3,6 @@ julia 0.6
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers

--- a/Interpolations/versions/0.7.3/requires
+++ b/Interpolations/versions/0.7.3/requires
@@ -3,6 +3,6 @@ julia 0.6
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
-AxisAlgorithms
+AxisAlgorithms 0- 0.3
 Compat 0.19.0
 DualNumbers


### PR DESCRIPTION
The new version of AxisAlgorithms 0.3.0 breaks Interpolations (cf. https://github.com/timholy/AxisAlgorithms.jl/pull/11#issuecomment-409151080).
So I capped the requirements in all versions of Interpolations to <0.3.0.
A new version of Interpolations compatible with that version will be available when [this PR](https://github.com/JuliaMath/Interpolations.jl/pull/218) is merged and the changes released.
cc @timholy @zygmuntszpak @tlycken 