### PR TITLE
Update URL to Twiddle

### DIFF
--- a/Twiddle/url
+++ b/Twiddle/url
@@ -1,1 +1,1 @@
-https://github.com/Ward9250/Twiddle.jl.git
+https://github.com/BenJWard/Twiddle.jl.git


### PR DESCRIPTION
Hi, this url needs to be changed before attobot will publish a tagged release of Twiddle for julia 0.7 / 1.0. The only reason the URL worked previously is GitHub is kind enough to redirect my old username to my new one.