### PR TITLE
Retroactively fix the min version of ColorTypes

### DIFF
--- a/Colors/versions/0.9.3/requires
+++ b/Colors/versions/0.9.3/requires
@@ -1,4 +1,4 @@
 julia 0.7
-ColorTypes 0.7.0
+ColorTypes 0.7.4
 FixedPointNumbers 0.5.0
 Reexport


### PR DESCRIPTION
I messed up and merged/tagged without considering the version bounds implications.