### PR TITLE
Place upper bound on IntervalSets for GtkReactive

### DIFF
--- a/GtkReactive/versions/0.0.1/requires
+++ b/GtkReactive/versions/0.0.1/requires
@@ -6,5 +6,5 @@ Colors
 Reexport
 Reactive 0.3.0
 Graphics
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.0.2/requires
+++ b/GtkReactive/versions/0.0.2/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.3.0
 Graphics
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.0.3/requires
+++ b/GtkReactive/versions/0.0.3/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.3.0
 Graphics
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.0.4/requires
+++ b/GtkReactive/versions/0.0.4/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.3.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.0.5/requires
+++ b/GtkReactive/versions/0.0.5/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.3.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.0.6/requires
+++ b/GtkReactive/versions/0.0.6/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.3.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.1.0/requires
+++ b/GtkReactive/versions/0.1.0/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.3.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.1.1/requires
+++ b/GtkReactive/versions/0.1.1/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.3.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.1.2/requires
+++ b/GtkReactive/versions/0.1.2/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.2.0/requires
+++ b/GtkReactive/versions/0.2.0/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.2.1/requires
+++ b/GtkReactive/versions/0.2.1/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.2.2/requires
+++ b/GtkReactive/versions/0.2.2/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.2.3/requires
+++ b/GtkReactive/versions/0.2.3/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.3.0/requires
+++ b/GtkReactive/versions/0.3.0/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.4.0/requires
+++ b/GtkReactive/versions/0.4.0/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.4.1/requires
+++ b/GtkReactive/versions/0.4.1/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.4.2/requires
+++ b/GtkReactive/versions/0.4.2/requires
@@ -7,5 +7,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.5.0/requires
+++ b/GtkReactive/versions/0.5.0/requires
@@ -6,5 +6,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers

--- a/GtkReactive/versions/0.5.1/requires
+++ b/GtkReactive/versions/0.5.1/requires
@@ -6,5 +6,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.0.5 0.3.0
 RoundingIntegers


### PR DESCRIPTION
IntervalSets underwent a major overhaul recently. It's almost backwards-compatible, but not quite. Consequently I'm putting an upper bound on its versions for GtkReactive in preparation for tagging a new release.