### PR TITLE
Add upper bounds at Julia 0.7 in GLVisualize

### DIFF
--- a/CDDLib/versions/0.0.1/requires
+++ b/CDDLib/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 BinDeps
 MathProgBase
 Polyhedra 0.0.1 0.1-

--- a/GLVisualize/versions/0.0.1/requires
+++ b/GLVisualize/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4- 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.10/requires
+++ b/GLVisualize/versions/0.0.10/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.2/requires
+++ b/GLVisualize/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4- 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.3/requires
+++ b/GLVisualize/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.4/requires
+++ b/GLVisualize/versions/0.0.4/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.5/requires
+++ b/GLVisualize/versions/0.0.5/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.6/requires
+++ b/GLVisualize/versions/0.0.6/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.7/requires
+++ b/GLVisualize/versions/0.0.7/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.8/requires
+++ b/GLVisualize/versions/0.0.8/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.0.9/requires
+++ b/GLVisualize/versions/0.0.9/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.1.0/requires
+++ b/GLVisualize/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 GLFW
 GLWindow
 GLAbstraction

--- a/GLVisualize/versions/0.1.1/requires
+++ b/GLVisualize/versions/0.1.1/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 GLFW
 GLWindow
 GLAbstraction

--- a/GLVisualize/versions/0.1.2/requires
+++ b/GLVisualize/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 GLFW
 GLWindow
 GLAbstraction

--- a/GLVisualize/versions/0.2.0/requires
+++ b/GLVisualize/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 
 GLFW
 GLWindow

--- a/GLVisualize/versions/0.2.1/requires
+++ b/GLVisualize/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 
 GLWindow 0.3
 GLAbstraction 0.3.1

--- a/GLVisualize/versions/0.2.2/requires
+++ b/GLVisualize/versions/0.2.2/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 
 GLWindow 0.3
 GLAbstraction 0.3.1

--- a/GLVisualize/versions/0.5.0/requires
+++ b/GLVisualize/versions/0.5.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 
 StaticArrays 0.6.0
 GeometryTypes 0.4.1

--- a/GLVisualize/versions/0.5.1/requires
+++ b/GLVisualize/versions/0.5.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 
 StaticArrays 0.6.0
 GeometryTypes 0.4.1

--- a/GLVisualize/versions/0.6.0/requires
+++ b/GLVisualize/versions/0.6.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 
 StaticArrays 0.6.0
 GeometryTypes 0.4.1

--- a/GLVisualize/versions/0.6.1/requires
+++ b/GLVisualize/versions/0.6.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 
 StaticArrays 0.6.0
 GeometryTypes 0.4.1

--- a/GLVisualize/versions/0.7.0/requires
+++ b/GLVisualize/versions/0.7.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 
 StaticArrays 0.6.0
 GeometryTypes 0.4.1


### PR DESCRIPTION
We are currently wasting resources on reverse dependency testing of GLVisualize so this PR adds upper bounds on all released versions of the package to avoid it being tested on 0.7 and 1.0.

cc: @SimonDanisch 