### PR TITLE
Add upper bounds in JuliaFEM at Julia 0.7

### DIFF
--- a/JuliaFEM/versions/0.0.1/requires
+++ b/JuliaFEM/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4- 0.7
 Logging
 LightXML
 Docile

--- a/JuliaFEM/versions/0.1.0/requires
+++ b/JuliaFEM/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.4 0.7
 ForwardDiff
 Logging
 LightXML

--- a/JuliaFEM/versions/0.2.1/requires
+++ b/JuliaFEM/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.5 
+julia 0.5 0.7
 ForwardDiff
 LightXML 0.4
 HDF5 0.7

--- a/JuliaFEM/versions/0.3.0/requires
+++ b/JuliaFEM/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 ForwardDiff
 LightXML 0.4
 HDF5 0.7

--- a/JuliaFEM/versions/0.3.1/requires
+++ b/JuliaFEM/versions/0.3.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 ForwardDiff
 LightXML 0.4
 HDF5 0.7

--- a/JuliaFEM/versions/0.3.2/requires
+++ b/JuliaFEM/versions/0.3.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 ForwardDiff
 LightXML 0.4
 HDF5 0.7

--- a/JuliaFEM/versions/0.3.3/requires
+++ b/JuliaFEM/versions/0.3.3/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 ForwardDiff
 LightXML 0.4
 HDF5 0.7

--- a/JuliaFEM/versions/0.3.4/requires
+++ b/JuliaFEM/versions/0.3.4/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 FEMBase
 ForwardDiff
 LightXML 0.4

--- a/JuliaFEM/versions/0.3.5/requires
+++ b/JuliaFEM/versions/0.3.5/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 FEMBase 0.0 0.1-
 ForwardDiff
 LightXML 0.4

--- a/JuliaFEM/versions/0.3.6/requires
+++ b/JuliaFEM/versions/0.3.6/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 FEMBase 0.1 0.2-
 ForwardDiff
 LightXML 0.4

--- a/JuliaFEM/versions/0.3.7/requires
+++ b/JuliaFEM/versions/0.3.7/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 FEMBase 0.1 0.2-
 ForwardDiff
 LightXML 0.4

--- a/JuliaFEM/versions/0.4.0/requires
+++ b/JuliaFEM/versions/0.4.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 FEMBase 0.1 0.2-
 ForwardDiff
 LightXML 0.4

--- a/JuliaFEM/versions/0.4.1/requires
+++ b/JuliaFEM/versions/0.4.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 FEMBase 0.1 0.2-
 ForwardDiff
 LightXML 0.4

--- a/JuliaFEM/versions/0.4.2/requires
+++ b/JuliaFEM/versions/0.4.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 FEMBase 0.1 0.2-
 ForwardDiff
 LightXML 0.4


### PR DESCRIPTION
This will avoid that the package is tested as a reverse dependency of the JuliaFEM family of packages and it will also help users to avoid installing the package on Julia 1.0 before it is ready.

cc: @ahojukka5