### PR TITLE
Upper bound IterableTables and Query at NamedTuples 5.0.0

### DIFF
--- a/IterableTables/versions/0.3.0/requires
+++ b/IterableTables/versions/0.3.0/requires
@@ -1,4 +1,4 @@
 julia 0.6.0-rc1
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.4.0/requires
+++ b/IterableTables/versions/0.4.0/requires
@@ -1,4 +1,4 @@
 julia 0.6.0-rc1
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.4.1/requires
+++ b/IterableTables/versions/0.4.1/requires
@@ -1,4 +1,4 @@
 julia 0.6.0-rc1
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.4.2/requires
+++ b/IterableTables/versions/0.4.2/requires
@@ -1,4 +1,4 @@
 julia 0.6.0-rc1
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.5.0/requires
+++ b/IterableTables/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/IterableTables/versions/0.5.1/requires
+++ b/IterableTables/versions/0.5.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/IterableTables/versions/0.5.2/requires
+++ b/IterableTables/versions/0.5.2/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/IterableTables/versions/0.6.0/requires
+++ b/IterableTables/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/IterableTables/versions/0.6.1/requires
+++ b/IterableTables/versions/0.6.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/IterableTables/versions/0.7.0/requires
+++ b/IterableTables/versions/0.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/IterableTables/versions/0.7.1/requires
+++ b/IterableTables/versions/0.7.1/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/IterableTables/versions/0.7.2/requires
+++ b/IterableTables/versions/0.7.2/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/IterableTables/versions/0.7.3/requires
+++ b/IterableTables/versions/0.7.3/requires
@@ -1,5 +1,5 @@
 julia 0.6.0
-NamedTuples 4.0.0
+NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3
 TableTraits 0.0.1

--- a/Query/versions/0.5.0/requires
+++ b/Query/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0

--- a/Query/versions/0.6.0/requires
+++ b/Query/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.6.0-rc1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0

--- a/Query/versions/0.7.0/requires
+++ b/Query/versions/0.7.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 TableTraits 0.0.1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0

--- a/Query/versions/0.7.1/requires
+++ b/Query/versions/0.7.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 TableTraits 0.0.1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0

--- a/Query/versions/0.7.2/requires
+++ b/Query/versions/0.7.2/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 TableTraits 0.0.1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5
 Requires 0.4.3
 Documenter 0.9.0

--- a/Query/versions/0.8.0/requires
+++ b/Query/versions/0.8.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 TableTraits 0.0.1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 Requires 0.4.3
 Documenter 0.9.0
 IterableTables 0.5.0

--- a/Query/versions/0.9.0/requires
+++ b/Query/versions/0.9.0/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 TableTraits 0.0.1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 Requires 0.4.3
 Documenter 0.9.0
 IterableTables 0.5.0

--- a/Query/versions/0.9.1/requires
+++ b/Query/versions/0.9.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 TableTraits 0.0.1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 Requires 0.4.3
 Documenter 0.9.0
 IterableTables 0.5.0

--- a/Query/versions/0.9.2/requires
+++ b/Query/versions/0.9.2/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 TableTraits 0.0.1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 Requires 0.4.3
 Documenter 0.9.0
 IterableTables 0.5.0

--- a/Query/versions/0.9.3/requires
+++ b/Query/versions/0.9.3/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 TableTraits 0.0.1
-NamedTuples 3.0.2
+NamedTuples 3.0.2 5.0.0
 Requires 0.4.3
 Documenter 0.9.0
 IterableTables 0.5.0


### PR DESCRIPTION
The versions of IterableTables and Query which depend on NamedTuples but do not already impose an upper bound on it now have an explicit upper bound at NamedTuples 5.0.0, which will be introduced in #17804.