### PR TITLE
Bound Julia at 0.7 in Query and IterableTables for unsupported versions.

### DIFF
--- a/IterableTables/versions/0.0.1/requires
+++ b/IterableTables/versions/0.0.1/requires
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 2.0.0 3.0.0
 Requires 0.3.0

--- a/IterableTables/versions/0.0.2/requires
+++ b/IterableTables/versions/0.0.2/requires
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 2.0.0 3.0.0
 Requires 0.3.0

--- a/IterableTables/versions/0.1.0/requires
+++ b/IterableTables/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6.0-rc1 0.7
 NamedTuples 3.0.2 4.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.2.0/requires
+++ b/IterableTables/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6.0-rc1 0.7
 NamedTuples 3.0.2 4.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.3.0/requires
+++ b/IterableTables/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6.0-rc1 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.4.0/requires
+++ b/IterableTables/versions/0.4.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6.0-rc1 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.4.1/requires
+++ b/IterableTables/versions/0.4.1/requires
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6.0-rc1 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.4.2/requires
+++ b/IterableTables/versions/0.4.2/requires
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6.0-rc1 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.5.0/requires
+++ b/IterableTables/versions/0.5.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.5.1/requires
+++ b/IterableTables/versions/0.5.1/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.5.2/requires
+++ b/IterableTables/versions/0.5.2/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.6.0/requires
+++ b/IterableTables/versions/0.6.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.6.1/requires
+++ b/IterableTables/versions/0.6.1/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.7.0/requires
+++ b/IterableTables/versions/0.7.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.7.1/requires
+++ b/IterableTables/versions/0.7.1/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.7.2/requires
+++ b/IterableTables/versions/0.7.2/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/IterableTables/versions/0.7.3/requires
+++ b/IterableTables/versions/0.7.3/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 NamedTuples 4.0.0 5.0.0
 Requires 0.4.3
 DataValues 0.0.3

--- a/Query/versions/0.0.1/requires
+++ b/Query/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5- 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.0.2/requires
+++ b/Query/versions/0.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5- 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.0.3/requires
+++ b/Query/versions/0.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5- 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.0.4/requires
+++ b/Query/versions/0.0.4/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.1.0/requires
+++ b/Query/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.2.0/requires
+++ b/Query/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.2.1/requires
+++ b/Query/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.3.0/requires
+++ b/Query/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.3.1/requires
+++ b/Query/versions/0.3.1/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.3.2/requires
+++ b/Query/versions/0.3.2/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 1.0.0 2.0.0
 FunctionWrappers 0.0.1
 DataStructures 0.4.5

--- a/Query/versions/0.4.0/requires
+++ b/Query/versions/0.4.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 2.0.0 3.0.0
 DataStructures 0.4.5
 Requires 0.3.0

--- a/Query/versions/0.4.1/requires
+++ b/Query/versions/0.4.1/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7
 NamedTuples 2.0.0 3.0.0
 DataStructures 0.4.5
 Requires 0.3.0

--- a/Query/versions/0.5.0/requires
+++ b/Query/versions/0.5.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6.0-rc1 0.7
 NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5
 Requires 0.4.3

--- a/Query/versions/0.6.0/requires
+++ b/Query/versions/0.6.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6.0-rc1 0.7
 NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5
 Requires 0.4.3

--- a/Query/versions/0.7.0/requires
+++ b/Query/versions/0.7.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 TableTraits 0.0.1
 NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5

--- a/Query/versions/0.7.1/requires
+++ b/Query/versions/0.7.1/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 TableTraits 0.0.1
 NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5

--- a/Query/versions/0.7.2/requires
+++ b/Query/versions/0.7.2/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 TableTraits 0.0.1
 NamedTuples 3.0.2 5.0.0
 DataStructures 0.4.5

--- a/Query/versions/0.8.0/requires
+++ b/Query/versions/0.8.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 TableTraits 0.0.1
 NamedTuples 3.0.2 5.0.0
 Requires 0.4.3

--- a/Query/versions/0.9.0/requires
+++ b/Query/versions/0.9.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 TableTraits 0.0.1
 NamedTuples 3.0.2 5.0.0
 Requires 0.4.3

--- a/Query/versions/0.9.1/requires
+++ b/Query/versions/0.9.1/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 TableTraits 0.0.1
 NamedTuples 3.0.2 5.0.0
 Requires 0.4.3

--- a/Query/versions/0.9.2/requires
+++ b/Query/versions/0.9.2/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 TableTraits 0.0.1
 NamedTuples 3.0.2 5.0.0
 Requires 0.4.3

--- a/Query/versions/0.9.3/requires
+++ b/Query/versions/0.9.3/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 TableTraits 0.0.1
 NamedTuples 3.0.2 5.0.0
 Requires 0.4.3


### PR DESCRIPTION
Necessary for https://github.com/JuliaLang/METADATA.jl/pull/17804 but shouldn't have any real implications as these versions were already not possible to install on Julia 0.7.

cc @davidanthoff 