### PR TITLE
Make LazyQuery uninstallable because the repo has been deleted

### DIFF
--- a/LazyQuery/versions/0.0.1/requires
+++ b/LazyQuery/versions/0.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.5
 DataFrames 0.0.0 0.11.0
 DataArrays 0.0.0 0.7.0
 MacroTools

--- a/LazyQuery/versions/0.1.0/requires
+++ b/LazyQuery/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.6
 LazyContext 0.1.1
 DataFrames 0.0.0 0.11.0
 DataArrays 0.0.0 0.7.0

--- a/LazyQuery/versions/0.1.1/requires
+++ b/LazyQuery/versions/0.1.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.6
 LazyContext 0.1.2
 DataFrames 0.0.0 0.11.0
 MacroTools 0.3.2

--- a/LazyQuery/versions/0.1.2/requires
+++ b/LazyQuery/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.6
 LazyContext 0.1.2
 DataFrames 0.0.0 0.11.0
 MacroTools 0.3.2

--- a/LazyQuery/versions/0.1.3/requires
+++ b/LazyQuery/versions/0.1.3/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.6
 LazyContext 0.1.2
 DataFrames 0.0.0 0.11.0
 MacroTools 0.3.2


### PR DESCRIPTION
@bramtayl Please stop deleting repos you've registered in METADATA without first making them uninstallable. Just deleting them causes problems for our infrastructure.