### PR TITLE
Place upperbound on Interpolations

### DIFF
--- a/DIVAnd/versions/2.0.0/requires
+++ b/DIVAnd/versions/2.0.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-Interpolations
+Interpolations 0.0.0- 0.9.0
 NCDatasets
 SpecialFunctions
 DataStructures

--- a/DIVAnd/versions/2.0.1/requires
+++ b/DIVAnd/versions/2.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-Interpolations
+Interpolations 0.0.0- 0.9.0
 NCDatasets
 SpecialFunctions
 DataStructures

--- a/DIVAnd/versions/2.0.2/requires
+++ b/DIVAnd/versions/2.0.2/requires
@@ -1,5 +1,5 @@
 julia 0.6
-Interpolations
+Interpolations 0.0.0- 0.9.0
 NCDatasets
 SpecialFunctions
 DataStructures

--- a/DIVAnd/versions/2.1.0/requires
+++ b/DIVAnd/versions/2.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
-Interpolations
+Interpolations 0.0.0 0.9.0
 NCDatasets
 SpecialFunctions
 DataStructures

--- a/FourierFlows/versions/0.0.2/requires
+++ b/FourierFlows/versions/0.0.2/requires
@@ -1,4 +1,4 @@
 julia 0.6
 JLD2 0.0.4
 SpecialFunctions 0.3.6
-Interpolations 0.7.3
+Interpolations 0.7.3 0.9.0

--- a/FourierFlows/versions/0.1.0/requires
+++ b/FourierFlows/versions/0.1.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JLD2 0.0.4
 SpecialFunctions 0.3.6
-Interpolations 0.7.3
+Interpolations 0.7.3 0.9.0
 Requires

--- a/FourierFlows/versions/0.1.1/requires
+++ b/FourierFlows/versions/0.1.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JLD2 0.0.4
 SpecialFunctions 0.3.6
-Interpolations 0.7.3
+Interpolations 0.7.3 0.9.0
 Requires

--- a/FourierFlows/versions/0.1.2/requires
+++ b/FourierFlows/versions/0.1.2/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JLD2 0.0.4
 SpecialFunctions 0.3.6
-Interpolations 0.7.3
+Interpolations 0.7.3 0.9.0
 Requires

--- a/FourierFlows/versions/0.1.3/requires
+++ b/FourierFlows/versions/0.1.3/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JLD2 0.0.4
 SpecialFunctions 0.3.6
-Interpolations 0.7.3
+Interpolations 0.7.3 0.9.0
 Requires

--- a/FourierFlows/versions/0.2.0/requires
+++ b/FourierFlows/versions/0.2.0/requires
@@ -2,6 +2,6 @@ julia 0.7
 FFTW 0.2.3
 JLD2 0.0.4
 SpecialFunctions 0.3.6
-Interpolations 0.8
+Interpolations 0.8 0.9
 Requires 0.5.2
 ComputationalResources 0.2.0

--- a/ImageTransformations/versions/0.0.1/requires
+++ b/ImageTransformations/versions/0.0.1/requires
@@ -1,7 +1,7 @@
 julia 0.5
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.3.7
+Interpolations 0.3.7 0.9.0
 OffsetArrays
 StaticArrays
 Colors 0.7.0

--- a/ImageTransformations/versions/0.1.0/requires
+++ b/ImageTransformations/versions/0.1.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.3.7
+Interpolations 0.3.7 0.9.0
 OffsetArrays
 StaticArrays
 Colors 0.7.0

--- a/ImageTransformations/versions/0.2.0/requires
+++ b/ImageTransformations/versions/0.2.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.2.1/requires
+++ b/ImageTransformations/versions/0.2.1/requires
@@ -1,7 +1,7 @@
 julia 0.5
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.2.2/requires
+++ b/ImageTransformations/versions/0.2.2/requires
@@ -1,7 +1,7 @@
 julia 0.5
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.3.0/requires
+++ b/ImageTransformations/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.5
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.3.1/requires
+++ b/ImageTransformations/versions/0.3.1/requires
@@ -1,7 +1,7 @@
 julia 0.5
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.4.0/requires
+++ b/ImageTransformations/versions/0.4.0/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.4.1/requires
+++ b/ImageTransformations/versions/0.4.1/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.4.2/requires
+++ b/ImageTransformations/versions/0.4.2/requires
@@ -1,7 +1,7 @@
 julia 0.6
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.5.0/requires
+++ b/ImageTransformations/versions/0.5.0/requires
@@ -1,7 +1,7 @@
 julia 0.7
 ImageCore 0.7
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.5.1/requires
+++ b/ImageTransformations/versions/0.5.1/requires
@@ -1,7 +1,7 @@
 julia 0.7
 ImageCore 0.7
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/ImageTransformations/versions/0.5.2/requires
+++ b/ImageTransformations/versions/0.5.2/requires
@@ -1,7 +1,7 @@
 julia 0.7
 ImageCore 0.7
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.4.0 0.9.0
 AxisAlgorithms
 OffsetArrays
 StaticArrays


### PR DESCRIPTION
If my local analysis is correct, these are three packages that work currently on Julia 1.0 but will break once https://github.com/JuliaMath/Interpolations.jl/pull/226 is merged and tagged. The remaining packages will pass (with some deprecation warnings).

@Evizero I already have a PR prepared locally for ImageTransformations, once the new Interpolations is merged and tagged.