### PR TITLE
WriteVTK works on 0.7 / 1.0

### DIFF
--- a/WriteVTK/versions/0.8.0/requires
+++ b/WriteVTK/versions/0.8.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 2-
 LightXML 0.4.0
 CodecZlib 0.4.2
 Compat 0.59.0  # undef: 0.59.0


### PR DESCRIPTION
This should make it not get capped anymore