### PR TITLE
Upper bound julia at 0.7- in JuliaDB

### DIFF
--- a/JuliaDB/versions/0.1.0/requires
+++ b/JuliaDB/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6- 0.7-
 IndexedTables 0.1.4 0.3.0
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.1.1/requires
+++ b/JuliaDB/versions/0.1.1/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6- 0.7-
 IndexedTables 0.1.4 0.3.0
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.1.2/requires
+++ b/JuliaDB/versions/0.1.2/requires
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6- 0.7-
 IndexedTables 0.1.4 0.3.0
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.1.3/requires
+++ b/JuliaDB/versions/0.1.3/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.2.1 0.3.0
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.1.4/requires
+++ b/JuliaDB/versions/0.1.4/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.2.1 0.3.0
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.1.5/requires
+++ b/JuliaDB/versions/0.1.5/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.2.1 0.3.0
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.2.0/requires
+++ b/JuliaDB/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.2.1/requires
+++ b/JuliaDB/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.2.2/requires
+++ b/JuliaDB/versions/0.2.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.1.6 0.3.0

--- a/JuliaDB/versions/0.2.3/requires
+++ b/JuliaDB/versions/0.2.3/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.2.0 0.3.0

--- a/JuliaDB/versions/0.3.0/requires
+++ b/JuliaDB/versions/0.3.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.3.1/requires
+++ b/JuliaDB/versions/0.3.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.3.2/requires
+++ b/JuliaDB/versions/0.3.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.3.3/requires
+++ b/JuliaDB/versions/0.3.3/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.3.4/requires
+++ b/JuliaDB/versions/0.3.4/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.3.5/requires
+++ b/JuliaDB/versions/0.3.5/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.3.6/requires
+++ b/JuliaDB/versions/0.3.6/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.3 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.3.7/requires
+++ b/JuliaDB/versions/0.3.7/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.3.3 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.4.0/requires
+++ b/JuliaDB/versions/0.4.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.4.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.4.1/requires
+++ b/JuliaDB/versions/0.4.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.4.1 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.4.2/requires
+++ b/JuliaDB/versions/0.4.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.4.2 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.4.3/requires
+++ b/JuliaDB/versions/0.4.3/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.4.2 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.4.4/requires
+++ b/JuliaDB/versions/0.4.4/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.4.5 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.5.0/requires
+++ b/JuliaDB/versions/0.5.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.5.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.6.0/requires
+++ b/JuliaDB/versions/0.6.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.5.2 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.7.0/requires
+++ b/JuliaDB/versions/0.7.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.6.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.7.1/requires
+++ b/JuliaDB/versions/0.7.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.6.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.7.2/requires
+++ b/JuliaDB/versions/0.7.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.6.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.8.0/requires
+++ b/JuliaDB/versions/0.8.0/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.7.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.8.1/requires
+++ b/JuliaDB/versions/0.8.1/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.7.0 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.8.2/requires
+++ b/JuliaDB/versions/0.8.2/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.7.1
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.8.3/requires
+++ b/JuliaDB/versions/0.8.3/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.7.3
 NamedTuples 4.0.0
 TextParse 0.3.0

--- a/JuliaDB/versions/0.8.4/requires
+++ b/JuliaDB/versions/0.8.4/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 IndexedTables 0.7.3
 NamedTuples 4.0.0
 TextParse 0.3.0


### PR DESCRIPTION
This is necessary for https://github.com/JuliaLang/METADATA.jl/pull/18361. It should have any effects for users as these bounds are also introduced during the conversion to the registry.