### PR TITLE
uncap Kwonly

### DIFF
--- a/Kwonly/versions/0.1.0/requires
+++ b/Kwonly/versions/0.1.0/requires
@@ -1,1 +1,1 @@
-julia 0.6
+julia 0.6 2-


### PR DESCRIPTION
Reading https://discourse.julialang.org/t/package-compatibility-caps/15301/37?u=tkf I thought a new release would uncap the package but that's not the case?  Also, note that the tests against julia 0.6 to 1.0 all passed https://github.com/JuliaLang/METADATA.jl/pull/18398