### PR TITLE
Cap dependencies of HomotopyContinuation

### DIFF
--- a/HomotopyContinuation/versions/0.3.0/requires
+++ b/HomotopyContinuation/versions/0.3.0/requires
@@ -1,7 +1,7 @@
 julia 0.7
 FixedPolynomials 0.4.0
 ProgressMeter 0.6.0
-StaticPolynomials 0.3.0
+StaticPolynomials 0.3.0 0.4.0
 DynamicPolynomials 0.1.0
 MultivariatePolynomials 0.2.0
 TreeViews 0.3.0

--- a/HomotopyContinuation/versions/0.3.1/requires
+++ b/HomotopyContinuation/versions/0.3.1/requires
@@ -1,7 +1,7 @@
 julia 0.7
 FixedPolynomials 0.4.0
 ProgressMeter 0.6.0
-StaticPolynomials 0.3.0
+StaticPolynomials 0.3.0 0.4.0
 DynamicPolynomials 0.1.0
 MultivariatePolynomials 0.2.0
 TreeViews 0.3.0

--- a/HomotopyContinuation/versions/0.3.2/requires
+++ b/HomotopyContinuation/versions/0.3.2/requires
@@ -1,7 +1,7 @@
 julia 0.7
 FixedPolynomials 0.4.0
 ProgressMeter 0.6.0
-StaticPolynomials 0.3.0
+StaticPolynomials 0.3.0 0.4.0
 DynamicPolynomials 0.1.0
 MultivariatePolynomials 0.2.0
 TreeViews 0.3.0


### PR DESCRIPTION
This caps the dependencies of HomotopyContinuation for all versions which support 0.7 to address the CI failure in #18440.