### PR TITLE
Fix old versions of HomotopyContinuation to 0.6 only

### DIFF
--- a/HomotopyContinuation/versions/0.1.0/requires
+++ b/HomotopyContinuation/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.1
+julia 0.6.1 0.7
 Homotopies
 Reexport 0.0.3
 Parameters 0.8.0

--- a/HomotopyContinuation/versions/0.2.0/requires
+++ b/HomotopyContinuation/versions/0.2.0/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 FixedPolynomials v0.3
 Juno
 ProgressMeter v0.5.5

--- a/HomotopyContinuation/versions/0.2.1/requires
+++ b/HomotopyContinuation/versions/0.2.1/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 FixedPolynomials v0.3
 Juno
 ProgressMeter v0.5.5

--- a/HomotopyContinuation/versions/0.2.2/requires
+++ b/HomotopyContinuation/versions/0.2.2/requires
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.6.0 0.7
 FixedPolynomials v0.3
 Juno
 ProgressMeter v0.5.5


### PR DESCRIPTION
It seems that I only need to add upper bounds of the Julia version to the old versions to get #18440 passing. Sorry for all the trouble here :/