### PR TITLE
- Constrain upper Julia versions.

### DIFF
--- a/WebSockets/versions/0.4.0/requires
+++ b/WebSockets/versions/0.4.0/requires
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7-
 Compat 0.28.0
 HttpCommon
 HttpServer

--- a/WebSockets/versions/0.5.0/requires
+++ b/WebSockets/versions/0.5.0/requires
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.6 0.7-
 MbedTLS
 Requires

--- a/WebSockets/versions/1.0.0/requires
+++ b/WebSockets/versions/1.0.0/requires
@@ -1,3 +1,3 @@
-julia 0.7
+julia 0.7 2.0-
 MbedTLS
-HTTP
+HTTP 0.6.14 0.6.15-

--- a/WebSockets/versions/1.0.1/requires
+++ b/WebSockets/versions/1.0.1/requires
@@ -1,4 +1,4 @@
-julia 0.7
+julia 0.7 2.0-
 MbedTLS
-HTTP 0.6.14 0.6.99
+HTTP 0.6.14 0.6.15-
 

--- a/WebSockets/versions/1.0.2/requires
+++ b/WebSockets/versions/1.0.2/requires
@@ -1,4 +1,4 @@
-julia 0.7
+julia 0.7 2.0-
 MbedTLS
-HTTP 0.6.14 0.6.15
+HTTP 0.6.14 0.6.15-
 

--- a/WebSockets/versions/1.0.3/requires
+++ b/WebSockets/versions/1.0.3/requires
@@ -1,4 +1,4 @@
-julia 0.7
+julia 0.7 2.0-
 MbedTLS
 HTTP 0.6.14 0.6.15
 


### PR DESCRIPTION
- Constrain upper HTTP also for older versions. The
package resolver in some cases pick an old version
which do not work with current HTTP version.
	modified:   WebSockets/versions/0.4.0/requires
	modified:   WebSockets/versions/0.5.0/requires
	modified:   WebSockets/versions/1.0.0/requires
	modified:   WebSockets/versions/1.0.1/requires
	modified:   WebSockets/versions/1.0.2/requires
	modified:   WebSockets/versions/1.0.3/requires

Also refer https://github.com/JuliaWeb/WebSockets.jl/issues/119