### PR TITLE
Require BinaryProvider 0.5 in Arpack 0.3

### DIFF
--- a/Arpack/versions/0.3.0/requires
+++ b/Arpack/versions/0.3.0/requires
@@ -1,2 +1,2 @@
 julia 0.7-rc3
-BinaryProvider 0.3
+BinaryProvider 0.5


### PR DESCRIPTION
The version hadn't been bumped in the latest release which has caused some issues in JuliaPro