### PR TITLE
Update Stan/url

### DIFF
--- a/Stan/url
+++ b/Stan/url
@@ -1,1 +1,1 @@
-git://github.com/goedman/Stan.jl.git
+git://github.com/StanJulia/Stan.jl.git


### PR DESCRIPTION
Attempting to tag a new release of Stan.jl. I have moved Stan.jl to the StanJulia github organization. This is a problem for attobot. Hopefully this will allow attobot the create the PR