### PR TITLE
Add StaticArrays v0.9 upper cap for Plots

### DIFF
--- a/Plots/versions/0.12.1/requires
+++ b/Plots/versions/0.12.1/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.12.2/requires
+++ b/Plots/versions/0.12.2/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.12.3/requires
+++ b/Plots/versions/0.12.3/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.12.4/requires
+++ b/Plots/versions/0.12.4/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.13.0/requires
+++ b/Plots/versions/0.13.0/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.13.1/requires
+++ b/Plots/versions/0.13.1/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.14.0/requires
+++ b/Plots/versions/0.14.0/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.14.1/requires
+++ b/Plots/versions/0.14.1/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.14.2/requires
+++ b/Plots/versions/0.14.2/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.15.0/requires
+++ b/Plots/versions/0.15.0/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.15.1/requires
+++ b/Plots/versions/0.15.1/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.16.0/requires
+++ b/Plots/versions/0.16.0/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.17.0/requires
+++ b/Plots/versions/0.17.0/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.17.1/requires
+++ b/Plots/versions/0.17.1/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.17.2/requires
+++ b/Plots/versions/0.17.2/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.17.3/requires
+++ b/Plots/versions/0.17.3/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.17.4/requires
+++ b/Plots/versions/0.17.4/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.18.0/requires
+++ b/Plots/versions/0.18.0/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.19.0/requires
+++ b/Plots/versions/0.19.0/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.19.1/requires
+++ b/Plots/versions/0.19.1/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.19.2/requires
+++ b/Plots/versions/0.19.2/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.19.3/requires
+++ b/Plots/versions/0.19.3/requires
@@ -4,7 +4,7 @@ RecipesBase 0.2.3
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.20.0/requires
+++ b/Plots/versions/0.20.0/requires
@@ -4,7 +4,7 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.20.1/requires
+++ b/Plots/versions/0.20.1/requires
@@ -4,7 +4,7 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.20.2/requires
+++ b/Plots/versions/0.20.2/requires
@@ -4,7 +4,7 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.20.3/requires
+++ b/Plots/versions/0.20.3/requires
@@ -4,7 +4,7 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.20.4/requires
+++ b/Plots/versions/0.20.4/requires
@@ -4,7 +4,7 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.20.5/requires
+++ b/Plots/versions/0.20.5/requires
@@ -4,7 +4,7 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/Plots/versions/0.20.6/requires
+++ b/Plots/versions/0.20.6/requires
@@ -4,7 +4,7 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+StaticArrays 0.5 0.9
 FixedPointNumbers 0.3
 Measures
 Showoff


### PR DESCRIPTION
See https://github.com/JuliaPlots/Plots.jl/issues/1802.
I don't understand why this wasn't catched by the CIBot in https://github.com/JuliaLang/METADATA.jl/pull/19043.
It [seems it didn't run the Plots tests](https://github.com/JuliaLang/METADATA.jl/pull/19043) while StaticArrays is in its dependencies.