### PR TITLE
Upper bound all past Convex versions at Julia 0.7-

### DIFF
--- a/Convex/versions/0.0.1/requires
+++ b/Convex/versions/0.0.1/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.7-
 MathProgBase 0.3.1 0.4
 ECOS

--- a/Convex/versions/0.0.2/requires
+++ b/Convex/versions/0.0.2/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.7-
 MathProgBase 0.3.8 0.4
 ECOS 0.4.1

--- a/Convex/versions/0.0.3/requires
+++ b/Convex/versions/0.0.3/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.7-
 MathProgBase 0.3.8 0.4

--- a/Convex/versions/0.0.4/requires
+++ b/Convex/versions/0.0.4/requires
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.3 0.7-
 MathProgBase 0.3.8 0.4

--- a/Convex/versions/0.0.5/requires
+++ b/Convex/versions/0.0.5/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.7-
 MathProgBase 0.3.8 0.4
 Compat 0.4.4

--- a/Convex/versions/0.0.6/requires
+++ b/Convex/versions/0.0.6/requires
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3 0.7-
 MathProgBase 0.3.8 0.4
 Compat 0.4.4

--- a/Convex/versions/0.1.0/requires
+++ b/Convex/versions/0.1.0/requires
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.7-
 MathProgBase 0.3.8 0.4
 Compat 0.4.4
 DataStructures

--- a/Convex/versions/0.2.0/requires
+++ b/Convex/versions/0.2.0/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 MathProgBase 0.4.0 0.5-
 DataStructures

--- a/Convex/versions/0.3.0/requires
+++ b/Convex/versions/0.3.0/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 MathProgBase 0.5 0.6
 DataStructures

--- a/Convex/versions/0.4.0/requires
+++ b/Convex/versions/0.4.0/requires
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.4 0.7-
 MathProgBase 0.5 0.7
 DataStructures

--- a/Convex/versions/0.5.0/requires
+++ b/Convex/versions/0.5.0/requires
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.5 0.7-
 MathProgBase 0.5 0.8
 DataStructures


### PR DESCRIPTION
Convex does not currently support Julia 0.7 or higher. In order to register another 0.6-compatible tag, we need JuliaCIBot to pass, but it won't pass if it tries to run on 0.7 or higher. See https://github.com/JuliaLang/METADATA.jl/pull/19091.