### PR TITLE
DataDeps requires HTTP 0.7

### DIFF
--- a/DataDeps/versions/0.6.0/requires
+++ b/DataDeps/versions/0.6.0/requires
@@ -1,3 +1,3 @@
 julia 0.7-beta
 Reexport
-HTTP 0.6
+HTTP 0.7

--- a/DataDeps/versions/0.6.1/requires
+++ b/DataDeps/versions/0.6.1/requires
@@ -1,3 +1,3 @@
 julia 0.7-beta
 Reexport
-HTTP 0.6
+HTTP 0.7


### PR DESCRIPTION
I updated the Project.toml without updating the REQUIRE

this is reconning
https://github.com/oxinabox/DataDeps.jl/pull/77