### PR TITLE
Remove upper bound on Interpolations in KernelDensity

### DIFF
--- a/KernelDensity/versions/0.5.1/requires
+++ b/KernelDensity/versions/0.5.1/requires
@@ -2,5 +2,5 @@ julia 0.7
 StatsBase
 Distributions
 Optim 0.16
-Interpolations 0.9 0.10-
+Interpolations 0.9
 FFTW


### PR DESCRIPTION
The upper bound isn't strictly necessary and has caused some issues for other packages.