### PR TITLE
Add upper bounds to WebIO dependency in MeshCat

### DIFF
--- a/MeshCat/versions/0.1.0/requires
+++ b/MeshCat/versions/0.1.0/requires
@@ -13,6 +13,6 @@ DocStringExtensions 0.4
 
 # Communication
 MsgPack 0.1.1
-WebIO 0.1.8
+WebIO 0.1.8 0.6
 Mux 0.2.3
 JSExpr 0.1.0

--- a/MeshCat/versions/0.1.1/requires
+++ b/MeshCat/versions/0.1.1/requires
@@ -13,6 +13,6 @@ DocStringExtensions 0.4
 
 # Communication
 MsgPack 0.1.1
-WebIO 0.1.8
+WebIO 0.1.8 0.6
 Mux 0.2.3
 JSExpr 0.1.0

--- a/MeshCat/versions/0.1.2/requires
+++ b/MeshCat/versions/0.1.2/requires
@@ -13,6 +13,6 @@ DocStringExtensions 0.4
 
 # Communication
 MsgPack 0.1.1
-WebIO 0.1.8
+WebIO 0.1.8 0.6
 Mux 0.2.3
 JSExpr 0.1.0

--- a/MeshCat/versions/0.2.0/requires
+++ b/MeshCat/versions/0.2.0/requires
@@ -14,6 +14,6 @@ BinDeps 0.8.7
 
 # Communication
 MsgPack 0.1.1
-WebIO 0.1.8
+WebIO 0.1.8 0.6
 Mux 0.2.3
 JSExpr 0.1.0

--- a/MeshCat/versions/0.2.1/requires
+++ b/MeshCat/versions/0.2.1/requires
@@ -14,6 +14,6 @@ BinDeps 0.8.7
 
 # Communication
 MsgPack 0.1.1
-WebIO 0.1.8
+WebIO 0.1.8 0.6
 Mux 0.2.3
 JSExpr 0.1.0

--- a/MeshCat/versions/0.2.2/requires
+++ b/MeshCat/versions/0.2.2/requires
@@ -14,7 +14,7 @@ BinDeps 0.8.7
 
 # Communication
 MsgPack 0.1.1
-WebIO 0.2.0
+WebIO 0.2.0 0.6
 Mux 0.2.3
 JSExpr 0.1.0
 AssetRegistry 0.0.1

--- a/MeshCat/versions/0.2.3/requires
+++ b/MeshCat/versions/0.2.3/requires
@@ -14,7 +14,7 @@ BinDeps 0.8.7
 
 # Communication
 MsgPack 0.1.1
-WebIO 0.2.0
+WebIO 0.2.0 0.6
 Mux 0.2.3
 JSExpr 0.1.0
 AssetRegistry 0.0.1

--- a/MeshCat/versions/0.3.0/requires
+++ b/MeshCat/versions/0.3.0/requires
@@ -16,7 +16,7 @@ Requires
 
 # Communication
 MsgPack 0.1.1
-WebIO  # TODO: require v0.3.0 when we drop Julia v0.6
+WebIO  0.2 0.6
 Mux 0.2.3 # TODO: require v0.5.2 when we drop Julia v0.6
 JSExpr # TODO: require v0.3.0 when we drop Julia v0.6
 AssetRegistry 0.0.1


### PR DESCRIPTION
The next MeshCat release will have an upper bound on its WebIO dependency, so I wanted to add retroactive upper bounds to all past versions so that the resolver doesn't try to do anything silly. 