### PR TITLE
cap statplots on forestbiometrics

### DIFF
--- a/ForestBiometrics/versions/0.1.1/requires
+++ b/ForestBiometrics/versions/0.1.1/requires
@@ -1,6 +1,6 @@
 julia 0.6.0
 DataFrames 0.10.1
 Plots 0.13.1
-StatPlots 0.5.0
+StatPlots 0.5.0 0.8.1
 OffsetArrays 0.4.2
 GR 0.25.0


### PR DESCRIPTION
I've added a cap to StatPlots in the ForestBiometrics package, to prevent breakage from https://github.com/JuliaLang/METADATA.jl/pull/19526