### PR TITLE
Upper-bound Unitful version for Psychro

### DIFF
--- a/Psychro/versions/0.1.0/requires
+++ b/Psychro/versions/0.1.0/requires
@@ -1,2 +1,2 @@
 julia 0.6
-Unitful
+Unitful 0.8 0.13-


### PR DESCRIPTION
This PR is prep work for a version of Unitful with breaking changes (#19557). I have made individual PRs for the [very few] packages that the breaking changes affect. This is the last package where Unitful 0.13 will cause a version of the package working with Unitful 0.12 to break.