### PR TITLE
Update Modia3D REQUIRE file for ModiaMath

### DIFF
--- a/Modia3D/versions/0.2.1/requires
+++ b/Modia3D/versions/0.2.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-ModiaMath
+ModiaMath 0.2.1 0.3.0
 StaticArrays
 DataFrames
 DataStructures


### PR DESCRIPTION
Since ModiaMath 0.3.0 is not backwards compatible to 0.2.x, the existing Modia3D release is changed so that ModiaMath upto 0.2.x can be used, but not 0.3.0.