### PR TITLE
Update Modia REQUIRE file for ModiaMath

### DIFF
--- a/Modia/versions/0.2.2/requires
+++ b/Modia/versions/0.2.2/requires
@@ -1,6 +1,6 @@
 julia 0.6
 DataStructures
 JSON
-ModiaMath
+ModiaMath 0.2.1 0.3.0
 StaticArrays
 Unitful


### PR DESCRIPTION
Since ModiaMath 0.3.0 is not backwards compatible to 0.2.x, the existing Modia release is changed so that ModiaMath upto 0.2.x can be used, but not 0.3.0.