### PR TITLE
Add upper bounds to some of MeshCatMechanisms.jl's dependencies

### DIFF
--- a/MeshCatMechanisms/versions/0.0.1/requires
+++ b/MeshCatMechanisms/versions/0.0.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
-MeshCat 0.0.1
+MeshCat 0.0.1 0.6
 
 ColorTypes 0.2.0
 CoordinateTransformations 0.4.1

--- a/MeshCatMechanisms/versions/0.0.2/requires
+++ b/MeshCatMechanisms/versions/0.0.2/requires
@@ -1,9 +1,9 @@
 julia 0.6
-MeshCat 0.0.1
+MeshCat 0.0.1 0.6
 ColorTypes 0.2.0
 CoordinateTransformations 0.4.1
 Interpolations 0.3.6
 LoopThrottle 0.0.1
-MechanismGeometries
+MechanismGeometries 0.0.1 0.2
 MeshCat 0.0.1
 RigidBodyDynamics 0.4

--- a/MeshCatMechanisms/versions/0.0.3/requires
+++ b/MeshCatMechanisms/versions/0.0.3/requires
@@ -1,9 +1,9 @@
 julia 0.6
-MeshCat 0.0.1
+MeshCat 0.0.1 0.6
 ColorTypes 0.2.0
 CoordinateTransformations 0.4.1
 Interpolations 0.3.6
 LoopThrottle 0.0.1
-MechanismGeometries 0.0.1
+MechanismGeometries 0.0.1 0.2
 MeshCat 0.0.2
 RigidBodyDynamics 0.4

--- a/MeshCatMechanisms/versions/0.0.4/requires
+++ b/MeshCatMechanisms/versions/0.0.4/requires
@@ -3,6 +3,6 @@ ColorTypes 0.2.0
 CoordinateTransformations 0.4.1
 Interpolations 0.3.6
 LoopThrottle 0.0.1
-MechanismGeometries 0.0.1
-MeshCat 0.0.2
+MechanismGeometries 0.0.1 0.2
+MeshCat 0.0.2 0.6
 RigidBodyDynamics 0.4

--- a/MeshCatMechanisms/versions/0.0.5/requires
+++ b/MeshCatMechanisms/versions/0.0.5/requires
@@ -3,6 +3,6 @@ ColorTypes 0.2.0
 CoordinateTransformations 0.4.1
 Interpolations 0.3.6
 LoopThrottle 0.0.1
-MechanismGeometries 0.0.1
-MeshCat 0.0.2
+MechanismGeometries 0.0.1 0.2
+MeshCat 0.0.2 0.6
 RigidBodyDynamics 0.4

--- a/MeshCatMechanisms/versions/0.0.6/requires
+++ b/MeshCatMechanisms/versions/0.0.6/requires
@@ -3,7 +3,7 @@ ColorTypes 0.2.0
 CoordinateTransformations 0.4.1
 Interpolations 0.3.6
 LoopThrottle 0.0.1
-MechanismGeometries 0.0.1
-MeshCat 0.0.2
+MechanismGeometries 0.0.1 0.2
+MeshCat 0.0.2 0.6
 RigidBodyDynamics 0.4
 GeometryTypes 0.4

--- a/MeshCatMechanisms/versions/0.1.0/requires
+++ b/MeshCatMechanisms/versions/0.1.0/requires
@@ -4,7 +4,7 @@ CoordinateTransformations 0.4.1
 Interpolations 0.3.6
 InteractBase 0.3.0
 LoopThrottle 0.0.1
-MechanismGeometries 0.0.1
-MeshCat 0.2.1
+MechanismGeometries 0.0.1 0.2
+MeshCat 0.2.1 0.6
 RigidBodyDynamics 0.4
 GeometryTypes 0.4

--- a/MeshCatMechanisms/versions/0.1.1/requires
+++ b/MeshCatMechanisms/versions/0.1.1/requires
@@ -7,6 +7,6 @@ GeometryTypes 0.4
 Interpolations 0.3.6
 InteractBase 0.5.0
 LoopThrottle 0.0.1
-MechanismGeometries 0.0.1
-MeshCat 0.2.1
+MechanismGeometries 0.0.1 0.2
+MeshCat 0.2.1 0.6
 RigidBodyDynamics 0.4

--- a/MeshCatMechanisms/versions/0.2.0/requires
+++ b/MeshCatMechanisms/versions/0.2.0/requires
@@ -6,6 +6,6 @@ GeometryTypes 0.4
 Interpolations 0.3.6
 InteractBase 0.8
 LoopThrottle 0.0.1
-MechanismGeometries 0.0.1
-MeshCat 0.2.1
+MechanismGeometries 0.0.1 0.2
+MeshCat 0.2.1 0.6
 RigidBodyDynamics 0.4

--- a/MeshCatMechanisms/versions/0.2.1/requires
+++ b/MeshCatMechanisms/versions/0.2.1/requires
@@ -6,6 +6,6 @@ GeometryTypes 0.4
 Interpolations 0.9
 InteractBase 0.8
 LoopThrottle 0.0.1
-MechanismGeometries 0.1.2
-MeshCat 0.2.1
+MechanismGeometries 0.1.2 0.2
+MeshCat 0.2.1 0.6
 RigidBodyDynamics 0.4


### PR DESCRIPTION
We have some minor but breaking and backwards-incompatible changes coming for those packages. 

cc @tkoolen 