### PR TITLE
Update Clang.jl's URL

### DIFF
--- a/Clang/url
+++ b/Clang/url
@@ -1,1 +1,1 @@
-git://github.com/ihnorton/Clang.jl.git
+git://github.com/JuliaInterop/Clang.jl.git


### PR DESCRIPTION
Clang.jl has been transferred to JuliaInterop.