### PR TITLE
Move wavexx repositories to gilab

### DIFF
--- a/Expect/url
+++ b/Expect/url
@@ -1,1 +1,1 @@
-git://github.com/wavexx/Expect.jl.git
+git://gitlab.com/wavexx/Expect.jl.git

--- a/Polyglot/url
+++ b/Polyglot/url
@@ -1,1 +1,1 @@
-git://github.com/wavexx/Polyglot.jl.git
+git://gitlab.com/wavexx/Polyglot.jl.git


### PR DESCRIPTION
I moved my personal repositories to gitlab, so this PR changes both.