### PR TITLE
Update URL

### DIFF
--- a/DataFramesMeta/url
+++ b/DataFramesMeta/url
@@ -1,1 +1,1 @@
-git://github.com/JuliaStats/DataFramesMeta.jl.git
+git://github.com/JuliaData/DataFramesMeta.jl.git


### PR DESCRIPTION
DataFramesMeta.jl was moved to JuliaData.

Resolves https://github.com/JuliaData/DataFramesMeta.jl/issues/123.

Do we need to do something more or the PR to tag a new release of DataFramesMeta.jl will then get merged?