### PR TITLE
Updated URL path for StatisticalRethinking

### DIFF
--- a/StatisticalRethinking/url
+++ b/StatisticalRethinking/url
@@ -1,1 +1,1 @@
-https://github.com/StanJulia/StatisticalRethinking.jl.git
+https://github.com/StatisticalRethinkingJulia/StatisticalRethinking.jl.git


### PR DESCRIPTION
I've moved StatisticalRethinking.jl from StanJulia Github org to a new org StatisticalRethinkingJulia.
The new Github org will also hold Turing, DynamicHMC and Mamba mcmc models in addition to Stan models.