### PR TITLE
Revert "Tag BedgraphFiles.jl v2.0.1"

### DIFF
--- a/BedgraphFiles/versions/2.0.1/requires
+++ b/BedgraphFiles/versions/2.0.1/requires
@@ -1,9 +1,0 @@
-julia 0.7
-Bedgraph 1.0.0
-DataFrames 0.9.0
-FileIO 1.0.1
-IterableTables 0.9.0
-IteratorInterfaceExtensions 0.1.1
-TableShowUtils 0.2.0
-TableTraits 0.4.0
-TableTraitsUtils 0.3.0

--- a/BedgraphFiles/versions/2.0.1/sha1
+++ b/BedgraphFiles/versions/2.0.1/sha1
@@ -1,1 +1,0 @@
-95f757dda2babc452b4fec3c401a7c70013f1eaa


### PR DESCRIPTION
Reverts JuliaLang/METADATA.jl#21009

This version refers to a commit that cannot be found when checking out the BedgraphFiles.jl repo, which breaks a lot of stuff. Usually when a commit is tagged it is visible in git. @CiaranOMara did you change the commit that the v2.0.1 tag referred to after registering it?