### PR TITLE
Remove Libdl from LevelDB 1.2.2 requires file

### DIFF
--- a/LevelDB/versions/1.2.2/requires
+++ b/LevelDB/versions/1.2.2/requires
@@ -1,3 +1,2 @@
 julia 1.1
 BinDeps
-Libdl


### PR DESCRIPTION
Stdlib packages should not be included in REQUIRE, only in Project.toml. This is causing Julia nightly METADATA checks to fail, but no one noticed because we allow failures on nightly.

@jerryzhenleicai, please remove it from REQUIRE in your package, and the corresponding file(s) in METADATA in any currently open PRs.