### PR TITLE
Put an upper bound on HTTP version in Coverage <= v0.8.0

### DIFF
--- a/Coverage/versions/0.5.0/requires
+++ b/Coverage/versions/0.5.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JSON
-HTTP
+HTTP 0.4 0.8.0
 Git
 Compat 0.44.0

--- a/Coverage/versions/0.5.1/requires
+++ b/Coverage/versions/0.5.1/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JSON
-HTTP
+HTTP 0.4 0.8.0
 Git
 Compat 0.44.0

--- a/Coverage/versions/0.5.2/requires
+++ b/Coverage/versions/0.5.2/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JSON
-HTTP
+HTTP 0.4 0.8.0
 Git
 Compat 0.44.0

--- a/Coverage/versions/0.5.3/requires
+++ b/Coverage/versions/0.5.3/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JSON
-HTTP
+HTTP 0.4 0.8.0
 MbedTLS
 Compat 0.44.0

--- a/Coverage/versions/0.5.4/requires
+++ b/Coverage/versions/0.5.4/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JSON
-HTTP
+HTTP 0.4 0.8.0
 MbedTLS
 Compat 0.60.0

--- a/Coverage/versions/0.6.0/requires
+++ b/Coverage/versions/0.6.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JSON
-HTTP
+HTTP 0.4 0.8.0
 MbedTLS
 Compat 0.60.0

--- a/Coverage/versions/0.7.0/requires
+++ b/Coverage/versions/0.7.0/requires
@@ -1,5 +1,5 @@
 julia 0.6
 JSON
-HTTP
+HTTP 0.4 0.8.0
 MbedTLS
 Compat 0.60.0

--- a/Coverage/versions/0.8.0/requires
+++ b/Coverage/versions/0.8.0/requires
@@ -1,4 +1,4 @@
 julia 1.0
 JSON
-HTTP
+HTTP 0.6.10 0.8.0
 MbedTLS


### PR DESCRIPTION
A breaking API change in HTTP 0.8.0 was only respected in Coverage 0.8.1 (with https://github.com/JuliaCI/Coverage.jl/pull/197), so earlier Coverage versions have to be used together with earlier HTTP versions. As Coverage 0.8.1 requires Julia 1.0, but HTTP 0.8.0 is compatible with Julia 0.7, without this PR, coverage submission from CI is broken unless one takes extra measures to downgrade HTTP.

Ref https://github.com/JuliaCI/Coverage.jl/issues/202, cc @ararslan 

Unfortunately, I have no idea what reasonable lower bounds are. I choose the lowest ones claimed to be compatible with Julia 0.6 or 1.0, respectively. Should they rather be 0.0.0 to make it clear that they are not real, intentional lower bounds?