### PR TITLE
restore Currencies.jl

### DIFF
--- a/Currencies/url
+++ b/Currencies/url
@@ -1,1 +1,1 @@
-git://github.com/JuliaFinance/Currencies.jl.git
+https://github.com/KristofferC/Currencies.jl

--- a/Currencies/url
+++ b/Currencies/url
@@ -1,1 +1,1 @@
-https://github.com/KristofferC/Currencies.jl.git
+https://github.com/JuliaPackageMirrors/Currencies.jl.git

--- a/Currencies/url
+++ b/Currencies/url
@@ -1,1 +1,1 @@
-https://github.com/KristofferC/Currencies.jl
+https://github.com/KristofferC/Currencies.jl.git


### PR DESCRIPTION
The Currencies.jl package has been made nonfunctional (git history destroyed). This PR repoints the URL to a mirror with the last functioning copy (currently on my own account). We should find a better place to host it but for now, it will do.