### PR TITLE
[AIControl] Changed url for ownership transfer

### DIFF
--- a/AIControl/url
+++ b/AIControl/url
@@ -1,1 +1,1 @@
-https://github.com/hiranumn/AIControl.jl.git
+https://github.com/suinleelab/AIControl.jl.git


### PR DESCRIPTION
I had to transfer the ownership of my repository from my personal account (hiranumn) to my organization (suinleelab). This pull request fixes the url address to comply with the ownership transfer. 