### PR TITLE
Tag version 3.0.0 vor CRC

### DIFF
--- a/CRC/versions/3.0.0/requires
+++ b/CRC/versions/3.0.0/requires
@@ -1,0 +1,2 @@
+julia 0.7.0
+ArgParse

--- a/CRC/versions/3.0.0/sha1
+++ b/CRC/versions/3.0.0/sha1
@@ -1,0 +1,1 @@
+8c5ce09d431fdbbbf34916e5df78cb7a56bd88c4


### PR DESCRIPTION
@andreasnoack 

Manual addition of CRC.jl update. I'm just a contributor and not the maintainer of the CRC.jl and can therefore not install attobot. 