### PR TITLE
Update julia requirement for ChemometricsTools

### DIFF
--- a/ChemometricsTools/versions/0.2.3/requires
+++ b/ChemometricsTools/versions/0.2.3/requires
@@ -1,4 +1,4 @@
-julia 1.0.3
+julia 1
 CSV
 DSP
 Distributions


### PR DESCRIPTION
The METADATA -> General conversion does this incorrectly, and we end up with
https://github.com/JuliaRegistries/General/blob/63e2b9bce862e0e623960a93eaebed7388ec77c6/C/ChemometricsTools/Compat.toml#L10