### PR TITLE
Bump the lower bounds for two Revise releases

### DIFF
--- a/Revise/versions/2.0.5/requires
+++ b/Revise/versions/2.0.5/requires
@@ -2,4 +2,4 @@ julia 1.0
 OrderedCollections
 CodeTracking 0.4 0.6
 JuliaInterpreter 0.2 0.5
-LoweredCodeUtils 0.3 0.4
+LoweredCodeUtils 0.3.1 0.4

--- a/Revise/versions/2.0.6/requires
+++ b/Revise/versions/2.0.6/requires
@@ -2,4 +2,4 @@ julia 1.0
 OrderedCollections
 CodeTracking 0.4 0.6
 JuliaInterpreter 0.2 0.5
-LoweredCodeUtils 0.3 0.4
+LoweredCodeUtils 0.3.1 0.4


### PR DESCRIPTION
It turns out 2.0.5 contained a change that caused a regression on certain syntax. The problem was subsequently fixed in LoweredCodeUtils; better to require the fixed version.