### PR TITLE
Updated AWSSQS URL from Sam OConnors -> JuliaCloud org

### DIFF
--- a/AWSSQS/url
+++ b/AWSSQS/url
@@ -1,1 +1,1 @@
-https://github.com/samoconnor/AWSSQS.jl.git
+https://github.com/JuliaCloud/AWSSQS.jl.git


### PR DESCRIPTION
I recently tagged a release for `AWSSQS.jl` and got an issue created that the `METADATA.jl` url no longer matches the Julia Registry.

> https://github.com/JuliaCloud/AWSSQS.jl/issues/14

The renaming of the repo URL in the general registry:

> https://github.com/JuliaRegistries/General/pull/6624

I believe this is the only change that needs to be made? But I'm not entirely sure so advise as necessary.